### PR TITLE
fix: pin Node.js version in build_preview.yml

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: latest
+          node-version: 24.x
 
       - name: Install Node.js dependencies
         run: |


### PR DESCRIPTION
## Summary
- Pin Node.js version to 24.x in build_preview.yml workflow
- Fixes CI failures caused by using `node-version: latest`
- Aligns with the same fix applied to build.yml

## Changes
- Updated `.github/workflows/build_preview.yml` to use `node-version: 24.x`