### PR TITLE
feat: implement Camtrap DP export

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -344,13 +344,21 @@ app.whenReady().then(async () => {
   })
 
   // Add dataset selection handler (supports both directories and zip files)
+  // Note: On Linux, GTK file chooser cannot handle ['openFile', 'openDirectory'] together,
+  // so we use directory-only mode on Linux
   ipcMain.handle('import:select-camtrap-dp', async () => {
+    const isLinux = process.platform === 'linux'
+
     const result = await dialog.showOpenDialog({
-      properties: ['openFile', 'openDirectory'],
-      filters: [
-        { name: 'Datasets', extensions: ['zip'] },
-        { name: 'All Files', extensions: ['*'] }
-      ]
+      title: 'Select CamTrap DP Dataset',
+      defaultPath: app.getPath('home'),
+      properties: isLinux ? ['openDirectory'] : ['openFile', 'openDirectory'],
+      filters: isLinux
+        ? undefined
+        : [
+            { name: 'Datasets', extensions: ['zip'] },
+            { name: 'All Files', extensions: ['*'] }
+          ]
     })
 
     if (!result || result.canceled || result.filePaths.length === 0) return null
@@ -362,13 +370,20 @@ app.whenReady().then(async () => {
   })
 
   // Add Wildlife Insights dataset selection handler
+  // Note: On Linux, GTK file chooser cannot handle ['openFile', 'openDirectory'] together
   ipcMain.handle('import:select-wildlife', async () => {
+    const isLinux = process.platform === 'linux'
+
     const result = await dialog.showOpenDialog({
-      properties: ['openFile', 'openDirectory'],
-      filters: [
-        { name: 'Wildlife Datasets', extensions: ['zip'] },
-        { name: 'All Files', extensions: ['*'] }
-      ]
+      title: 'Select Wildlife Insights Dataset',
+      defaultPath: app.getPath('home'),
+      properties: isLinux ? ['openDirectory'] : ['openFile', 'openDirectory'],
+      filters: isLinux
+        ? undefined
+        : [
+            { name: 'Wildlife Datasets', extensions: ['zip'] },
+            { name: 'All Files', extensions: ['*'] }
+          ]
     })
 
     if (!result || result.canceled || result.filePaths.length === 0) return null

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -166,6 +166,9 @@ const api = {
   },
   exportImageDirectories: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('export:image-directories', studyId)
+  },
+  exportCamtrapDP: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('export:camtrap-dp', studyId)
   }
 }
 

--- a/src/renderer/src/export.jsx
+++ b/src/renderer/src/export.jsx
@@ -60,9 +60,25 @@ export default function Export({ studyId, importerName }) {
   }
 
   const handleCamtrapDPExport = async () => {
-    // TODO: Implement Camtrap DP export
-    console.log('Exporting to Camtrap DP format...')
-    // This will call: await window.api.exportCamtrapDP(studyId)
+    setExportStatus(null)
+    const result = await window.api.exportCamtrapDP(studyId)
+
+    if (result.cancelled) {
+      return
+    }
+
+    if (result.success) {
+      setExportStatus({
+        type: 'success',
+        message: `Successfully exported Camtrap DP package to "${result.exportFolderName}" with ${result.deploymentsCount} deployments, ${result.mediaCount} media files, and ${result.observationsCount} observations.`,
+        exportPath: result.exportPath
+      })
+    } else {
+      setExportStatus({
+        type: 'error',
+        message: result.error || 'Camtrap DP export failed'
+      })
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Add Camtrap DP export functionality to the export tab
- Export creates a standardized Camera Trap Data Package with:
  - `datapackage.json` - metadata following Frictionless Data Package spec
  - `deployments.csv` - camera trap deployment information
  - `media.csv` - media files metadata with inferred MIME types
  - `observations.csv` - species observations with proper Camtrap DP vocabulary

## Features
- Reference-only export (keeps original file paths, no file copying)
- Automatic MIME type inference from file extensions
- Proper `observationType` mapping (species detections → `animal`, empty → `blank`)
- Placeholder metadata generation for contributors and description
- Success/error status display in UI

## Test plan
- [ ] Open a study with observations
- [ ] Go to Export tab
- [ ] Click "Export Camtrap DP" button
- [ ] Select destination folder
- [ ] Verify exported files contain correct data
- [ ] Validate with `frictionless validate datapackage.json`