### PR TITLE
feat: display model provenance for each folder

### DIFF
--- a/src/renderer/src/files.jsx
+++ b/src/renderer/src/files.jsx
@@ -98,6 +98,11 @@ export default function Files({ studyId }) {
                         <div className="text-sm font-medium text-gray-900 truncate">
                           {directory.folderName}
                         </div>
+                        {directory.lastModelUsed && (
+                          <div className="text-xs text-gray-500 truncate">
+                            Model: {directory.lastModelUsed}
+                          </div>
+                        )}
                       </div>
                     </div>
 


### PR DESCRIPTION
## Summary

<img width="1454" height="227" alt="image" src="https://github.com/user-attachments/assets/5c817ef9-d9cd-4149-ba25-55070fdcfa4d" />

- Display the most recent model (name + version) used to analyze each folder in the Files tab
- Uses `model_runs` table via `model_outputs` as the canonical source of model information
- Shows model info below folder name (e.g., "Model: speciesnet 4.0.1a")

## Changes
- `src/main/queries.js`: Added `lastModelUsed` field to `getFilesData()` query using a correlated subquery
- `src/renderer/src/files.jsx`: Display model info conditionally below each folder name

## Test plan
- [ ] Verify folder with no processed images shows no model
- [ ] Verify folder with processed images shows correct model
- [ ] Verify folder re-analyzed with different model shows the newer model