### PR TITLE
feat: add loading state when model is initializing

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -558,6 +558,13 @@ export default function Overview({ data, studyId, studyName }) {
 
       {error ? (
         <div className="text-red-500 py-4">Error: {error}</div>
+      ) : importStatus?.isRunning && importStatus?.done === 0 ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-gray-500">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600"></div>
+            <span>Loading model...</span>
+          </div>
+        </div>
       ) : (
         <>
           <div className="flex flex-row gap-4 flex-1 min-h-0 mt-2">


### PR DESCRIPTION
## Summary
- Add a centered loading spinner on the study overview page while the AI model is initializing
- Shows "Loading model..." with a spinner when import is running but no predictions have been processed yet
- Replaces the confusing "No data available" message during the loading phase

## Test plan
- [ ] Import a new images directory and verify spinner appears while model starts
- [ ] Once first batch processes, verify normal view with progress bar appears
- [ ] Verify non-local imports (GBIF, CamtrapDP) work normally