### PR TITLE
feat: add species selection and blank inclusion to CamtrapDP export

### DIFF
--- a/src/renderer/src/export.jsx
+++ b/src/renderer/src/export.jsx
@@ -190,6 +190,7 @@ export default function Export({ studyId, importerName }) {
         isOpen={showCamtrapDPModal}
         onConfirm={handleCamtrapDPConfirm}
         onCancel={handleCamtrapDPCancel}
+        studyId={studyId}
       />
 
       <ImageDirectoriesExportModal


### PR DESCRIPTION
## Summary

- Add species multi-select with Select All/Deselect All controls to CamtrapDP export modal
- Add blank observations toggle to include/exclude images with no detections
- Filter observations and media in backend based on user selection
- Maintain referential integrity (only export media that has matching observations)

## Changes

- **CamtrapDPExportModal.jsx**: Add species selection UI, blank toggle, scrollable species list
- **export.jsx**: Pass `studyId` prop to modal
- **export.js**: Add filtering logic to `exportCamtrapDP()` function

## Test plan

- [ ] Open CamtrapDP export modal and verify species list loads
- [ ] Test Select All / Deselect All buttons
- [ ] Export with subset of species selected
- [ ] Export with blank observations enabled/disabled
- [ ] Verify exported CSV files only contain filtered data
- [ ] Verify media files are correctly filtered when includeMedia is enabled