### PR TITLE
feat: add editable observation dates in media tab

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -20,7 +20,8 @@ import {
   getSpeciesDistribution,
   getSpeciesHeatmapData,
   getSpeciesTimeseries,
-  getFilesData
+  getFilesData,
+  updateMediaTimestamp
 } from './queries'
 import { Importer } from './importer' //required to register handlers
 import studies from './studies'
@@ -1132,6 +1133,23 @@ ipcMain.handle('deployments:set-longitude', async (_, studyId, deploymentID, lon
     return { success: true }
   } catch (error) {
     log.error('Error updating deployment longitude:', error)
+    return { error: error.message }
+  }
+})
+
+ipcMain.handle('media:set-timestamp', async (_, studyId, mediaID, newTimestamp) => {
+  try {
+    const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+    if (!dbPath || !existsSync(dbPath)) {
+      log.warn(`Database not found for study ID: ${studyId}`)
+      return { error: 'Database not found for this study' }
+    }
+
+    const result = await updateMediaTimestamp(dbPath, mediaID, newTimestamp)
+    await closeStudyDatabase(studyId, dbPath)
+    return result
+  } catch (error) {
+    log.error('Error updating media timestamp:', error)
     return { error: error.message }
   }
 })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -161,6 +161,9 @@ const api = {
       longitude
     )
   },
+  setMediaTimestamp: async (studyId, mediaID, timestamp) => {
+    return await electronAPI.ipcRenderer.invoke('media:set-timestamp', studyId, mediaID, timestamp)
+  },
   getFilesData: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('files:get-data', studyId)
   },

--- a/src/renderer/src/ui/DateTimePicker.jsx
+++ b/src/renderer/src/ui/DateTimePicker.jsx
@@ -1,0 +1,263 @@
+import { useState, useRef, useEffect } from 'react'
+import { ChevronLeft, ChevronRight, Clock } from 'lucide-react'
+
+/**
+ * DateTimePicker component for editing ISO 8601 timestamps
+ *
+ * @param {Object} props
+ * @param {string} props.value - ISO 8601 timestamp
+ * @param {(newValue: string) => void} props.onChange - Called with new ISO timestamp on save
+ * @param {() => void} props.onCancel - Called when picker is dismissed
+ * @param {string} [props.className] - Additional CSS classes
+ */
+export default function DateTimePicker({ value, onChange, onCancel, className = '' }) {
+  // Parse initial value
+  const initialDate = value ? new Date(value) : new Date()
+
+  const [year, setYear] = useState(initialDate.getFullYear())
+  const [month, setMonth] = useState(initialDate.getMonth())
+  const [day, setDay] = useState(initialDate.getDate())
+  const [hours, setHours] = useState(initialDate.getHours())
+  const [minutes, setMinutes] = useState(initialDate.getMinutes())
+  const [seconds, setSeconds] = useState(initialDate.getSeconds())
+
+  const containerRef = useRef(null)
+
+  // Handle click outside to cancel
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        onCancel()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [onCancel])
+
+  // Handle Escape key
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onCancel()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onCancel])
+
+  const [validationError, setValidationError] = useState(null)
+
+  const handleSave = () => {
+    // Validate year is within reasonable bounds
+    if (year < 1970 || year > 2100) {
+      setValidationError('Year must be between 1970 and 2100')
+      return
+    }
+
+    // Validate day is valid for the selected month
+    const daysInSelectedMonth = getDaysInMonth(year, month)
+    if (day < 1 || day > daysInSelectedMonth) {
+      setValidationError(`Invalid day for ${monthNames[month]} ${year}`)
+      return
+    }
+
+    const newDate = new Date(year, month, day, hours, minutes, seconds)
+
+    // Check if the date is valid
+    if (isNaN(newDate.getTime())) {
+      setValidationError('Invalid date/time combination')
+      return
+    }
+
+    setValidationError(null)
+    onChange(newDate.toISOString())
+  }
+
+  const getDaysInMonth = (y, m) => new Date(y, m + 1, 0).getDate()
+  const getFirstDayOfMonth = (y, m) => new Date(y, m, 1).getDay()
+
+  const prevMonth = () => {
+    if (month === 0) {
+      setMonth(11)
+      setYear(year - 1)
+    } else {
+      setMonth(month - 1)
+    }
+  }
+
+  const nextMonth = () => {
+    if (month === 11) {
+      setMonth(0)
+      setYear(year + 1)
+    } else {
+      setMonth(month + 1)
+    }
+  }
+
+  const monthNames = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December'
+  ]
+
+  const daysInMonth = getDaysInMonth(year, month)
+  const firstDay = getFirstDayOfMonth(year, month)
+
+  const handleTimeInputChange = (setter, min, max) => (e) => {
+    const val = e.target.value
+    // Allow empty string for typing
+    if (val === '') {
+      setter(0)
+      return
+    }
+    const num = parseInt(val, 10)
+    if (!isNaN(num)) {
+      setter(Math.min(max, Math.max(min, num)))
+    }
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`bg-white rounded-lg shadow-lg border border-gray-200 p-4 w-80 ${className}`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Calendar Header */}
+      <div className="flex items-center justify-between mb-3">
+        <button
+          onClick={prevMonth}
+          className="p-1.5 hover:bg-gray-100 rounded transition-colors"
+          type="button"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <div className="flex items-center gap-2">
+          <select
+            value={month}
+            onChange={(e) => setMonth(parseInt(e.target.value, 10))}
+            className="text-sm font-medium bg-transparent border-none cursor-pointer focus:outline-none"
+          >
+            {monthNames.map((name, i) => (
+              <option key={name} value={i}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            value={year}
+            onChange={(e) => setYear(parseInt(e.target.value, 10) || year)}
+            className="w-16 text-sm font-medium text-center border border-gray-200 rounded px-1 py-0.5"
+            min="1900"
+            max="2100"
+          />
+        </div>
+        <button
+          onClick={nextMonth}
+          className="p-1.5 hover:bg-gray-100 rounded transition-colors"
+          type="button"
+        >
+          <ChevronRight size={18} />
+        </button>
+      </div>
+
+      {/* Calendar Grid */}
+      <div className="grid grid-cols-7 gap-1 mb-4">
+        {['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'].map((d) => (
+          <div key={d} className="text-center text-xs text-gray-500 py-1 font-medium">
+            {d}
+          </div>
+        ))}
+        {Array(firstDay)
+          .fill(null)
+          .map((_, i) => (
+            <div key={`empty-${i}`} />
+          ))}
+        {Array(daysInMonth)
+          .fill(null)
+          .map((_, i) => (
+            <button
+              key={i + 1}
+              onClick={() => setDay(i + 1)}
+              type="button"
+              className={`text-center py-1.5 text-sm rounded transition-colors
+                ${
+                  day === i + 1
+                    ? 'bg-blue-600 text-white hover:bg-blue-700'
+                    : 'hover:bg-gray-100'
+                }`}
+            >
+              {i + 1}
+            </button>
+          ))}
+      </div>
+
+      {/* Time Inputs */}
+      <div className="flex items-center gap-2 mb-4 justify-center bg-gray-50 rounded-lg py-2">
+        <Clock size={16} className="text-gray-500" />
+        <input
+          type="number"
+          min="0"
+          max="23"
+          value={hours.toString().padStart(2, '0')}
+          onChange={handleTimeInputChange(setHours, 0, 23)}
+          className="w-12 text-center border border-gray-200 rounded px-1 py-1.5 text-sm font-mono"
+          title="Hours (0-23)"
+        />
+        <span className="text-gray-500 font-medium">:</span>
+        <input
+          type="number"
+          min="0"
+          max="59"
+          value={minutes.toString().padStart(2, '0')}
+          onChange={handleTimeInputChange(setMinutes, 0, 59)}
+          className="w-12 text-center border border-gray-200 rounded px-1 py-1.5 text-sm font-mono"
+          title="Minutes (0-59)"
+        />
+        <span className="text-gray-500 font-medium">:</span>
+        <input
+          type="number"
+          min="0"
+          max="59"
+          value={seconds.toString().padStart(2, '0')}
+          onChange={handleTimeInputChange(setSeconds, 0, 59)}
+          className="w-12 text-center border border-gray-200 rounded px-1 py-1.5 text-sm font-mono"
+          title="Seconds (0-59)"
+        />
+      </div>
+
+      {/* Validation Error */}
+      {validationError && (
+        <p className="text-xs text-red-500 mb-2 text-center">{validationError}</p>
+      )}
+
+      {/* Action Buttons */}
+      <div className="flex gap-2">
+        <button
+          onClick={onCancel}
+          type="button"
+          className="flex-1 px-3 py-2 text-sm font-medium border border-gray-200 rounded-md hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleSave}
+          type="button"
+          className="flex-1 px-3 py-2 text-sm font-medium bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

<img width="428" height="490" alt="image" src="https://github.com/user-attachments/assets/e1c34256-75a9-446f-985f-d11c2e145241" />


- Add ability to edit observation timestamps directly from the media tab when viewing an image
- Support both inline text editing and a calendar/time picker popup
- Automatically sync related observations (eventStart/eventEnd) with the same time offset, preserving duration
- Preserve original timestamp format when updating (with/without milliseconds, timezone)
- Add validation for invalid timestamps (year bounds 1970-2100, format validation)

## Changes

- **Backend**: Add `updateMediaTimestamp()` function with offset-preserving logic
- **Backend**: Add `media:set-timestamp` IPC handler  
- **Frontend**: New `DateTimePicker` component with calendar and time inputs
- **Frontend**: Update `ImageModal` with editable timestamp UI (inline + popup modes)
- **Frontend**: Add optimistic updates with rollback on error

## Test plan

- [ ] Click on timestamp text to edit inline, press Enter to save
- [ ] Press Escape to cancel inline edit
- [ ] Click calendar icon to open date/time picker
- [ ] Verify timestamp updates in database and UI
- [ ] Verify related observations are updated with same offset
- [ ] Test invalid date validation (shows error message)
- [ ] Verify keyboard navigation (arrows) still works when not editing