### PR TITLE
feat: add ability to update model predictions

### DIFF
--- a/src/main/export.js
+++ b/src/main/export.js
@@ -85,7 +85,9 @@ export async function exportImageDirectories(studyId, options = {}) {
     }
 
     // Always exclude blanks from species query (handled separately)
-    conditions.push(or(isNull(observations.observationType), ne(observations.observationType, 'blank')))
+    conditions.push(
+      or(isNull(observations.observationType), ne(observations.observationType, 'blank'))
+    )
 
     // Query to get media files with their species using Drizzle
     const mediaFiles = await db

--- a/src/main/models.ts
+++ b/src/main/models.ts
@@ -545,7 +545,11 @@ async function downloadPythonEnvironment({ id, version, requestingModelId = null
   const extractPath = getMLModelEnvironmentLocalInstallPath({ id, version })
   const localTarPath = getMLModelEnvironmentLocalTarPath({ id, version })
   const manifestFilepath = getMLEnvironmentDownloadManifest()
-  const manifestOpts = { archivePath: localTarPath, installPath: extractPath, activeDownloadModelId: requestingModelId }
+  const manifestOpts = {
+    archivePath: localTarPath,
+    installPath: extractPath,
+    activeDownloadModelId: requestingModelId
+  }
 
   let previousDownloadProgress = 0
   const flushProgressDownloadIncrementThreshold = 1
@@ -1460,10 +1464,7 @@ async function startMLModelHTTPServer({ pythonEnvironment, modelReference, count
         localInstallPath,
         'best_model_Fri_Sep__1_18_50_55_2023.pt'
       )
-      const classesFilepath = join(
-        localInstallPath,
-        'classes_Fri_Sep__1_18_50_55_2023.pickle'
-      )
+      const classesFilepath = join(localInstallPath, 'classes_Fri_Sep__1_18_50_55_2023.pickle')
       const detectorWeightsFilepath = join(localInstallPath, 'MDV6-yolov10x.pt')
       const { process: pythonProcess, shutdownApiKey } = await startManasHTTPServer({
         port,

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -172,6 +172,19 @@ const api = {
   },
   exportCamtrapDP: async (studyId, options = {}) => {
     return await electronAPI.ipcRenderer.invoke('export:camtrap-dp', studyId, options)
+  },
+  // Observation classification update (CamTrap DP compliant)
+  updateObservationClassification: async (studyId, observationID, updates) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'observations:update-classification',
+      studyId,
+      observationID,
+      updates
+    )
+  },
+  // Get distinct species for dropdown
+  getDistinctSpecies: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('species:get-distinct', studyId)
   }
 }
 


### PR DESCRIPTION
## Summary
- Add the ability to update ML model predictions (species classifications) directly from the Media tab
- Users can click on bounding box labels or use the observation list panel to edit classifications
- Implements CamTrap DP compliant updates (classificationMethod, classifiedBy, classificationTimestamp)

## Changes
- **Backend**: Added `updateObservationClassification` and `getDistinctSpecies` query functions
- **IPC**: Added handlers for `observations:update-classification` and `species:get-distinct`
- **Frontend**: Enhanced ImageModal with:
  - Clickable bbox labels with smart positioning (avoids edge clipping)
  - Observation list panel (always visible, regardless of bbox position)
  - Species selector dropdown with search, custom species input, and "Mark as Blank" option
  - Visual distinction between human (green) and machine (lime) classifications

## Test plan
- [ ] Open an image with detections in the Media tab
- [ ] Click on a bbox label or item in the observation list
- [ ] Select a different species from the dropdown
- [ ] Verify the label updates and shows the human classification indicator
- [ ] Test "Mark as Blank" functionality
- [ ] Test adding a custom species name
- [ ] Verify species distribution updates after classification change