### PR TITLE
feat: span the entire time range by default

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -345,9 +345,8 @@ export default function Activity({ studyData, studyId }) {
       dateRange[0] === null &&
       dateRange[1] === null
     ) {
-      const totalPeriods = timeseriesData.length
-      const startIndex = Math.max(totalPeriods - Math.max(Math.ceil(totalPeriods * 0.3), 2), 0)
-      const endIndex = totalPeriods - 1
+      const startIndex = 0
+      const endIndex = timeseriesData.length - 1
 
       setDateRange([
         new Date(timeseriesData[startIndex].date),

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1039,18 +1039,11 @@ export default function Activity({ studyData, studyId }) {
       dateRange[0] === null &&
       dateRange[1] === null
     ) {
-      const totalPeriods = timeseriesData.length
-      const startIndex = Math.max(totalPeriods - Math.max(Math.ceil(totalPeriods * 0.3), 2), 0)
-      const endIndex = totalPeriods - 1
+      const startIndex = 0
+      const endIndex = timeseriesData.length - 1
 
       let startDate = new Date(timeseriesData[startIndex].date)
       let endDate = new Date(timeseriesData[endIndex].date)
-
-      // Ensure a minimum range of 1 day if dates are the same
-      // if (startDate.getTime() === endDate.getTime()) {
-      //   endDate = new Date(startDate)
-      //   endDate.setDate(endDate.getDate() + 1) // Add one day to end date
-      // }
 
       setDateRange([startDate, endDate])
     }


### PR DESCRIPTION
## Summary
- Changed temporal selector on Activity and Media tabs to span the entire available date range by default instead of the last 30%

## Test plan
- [x] Open Activity tab and verify the timeline selector covers the full date range
- [x] Open Media tab and verify the timeline selector covers the full date range
- [x] Verify map shows all data points when loaded
- [x] Verify gallery displays media from the entire date range initially