### PR TITLE
feat: add click-to-place location marker for deployments

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -223,3 +223,25 @@ input::-webkit-inner-spin-button {
 .animate-bar-glow {
   animation: bar-glow 2s ease-in-out infinite;
 }
+
+/* Place mode styles for deployments map */
+.place-mode-active .leaflet-container {
+  cursor: crosshair !important;
+}
+
+.place-mode-active .leaflet-interactive {
+  cursor: crosshair !important;
+}
+
+.place-mode-active .leaflet-marker-icon {
+  cursor: crosshair !important;
+}
+
+/* Ghost marker styling - ensure it doesn't capture events */
+.ghost-camera-icon {
+  pointer-events: none !important;
+}
+
+.ghost-camera-marker {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15));
+}


### PR DESCRIPTION
## Summary
- Add ability to set deployment coordinates by clicking directly on the map
- Ghost marker preview follows cursor when placing
- Visual indicator shows which deployment is being placed

## Changes
- Added "place mode" toggle button next to lat/lng inputs in deployment list
- Ghost/preview marker follows cursor when in place mode
- Floating label shows active deployment name
- Exit via: map click (places marker), Escape key, or X button
- Crosshair cursor when hovering map in place mode

## Test plan
- [ ] Select a deployment from the list
- [ ] Click the pin icon next to coordinates
- [ ] Verify ghost marker follows cursor on map
- [ ] Click on map to place marker
- [ ] Verify coordinates update correctly
- [ ] Test Escape key cancels placement
- [ ] Test clicking existing marker exits place mode