### PR TITLE
feat: editable bounding boxes in media tab

### DIFF
--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -188,6 +188,19 @@ const api = {
       updates
     )
   },
+  // Observation bbox update
+  updateObservationBbox: async (studyId, observationID, bboxUpdates) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'observations:update-bbox',
+      studyId,
+      observationID,
+      bboxUpdates
+    )
+  },
+  // Delete observation
+  deleteObservation: async (studyId, observationID) => {
+    return await electronAPI.ipcRenderer.invoke('observations:delete', studyId, observationID)
+  },
   // Get distinct species for dropdown
   getDistinctSpecies: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('species:get-distinct', studyId)

--- a/src/renderer/src/ui/EditableBbox.jsx
+++ b/src/renderer/src/ui/EditableBbox.jsx
@@ -1,0 +1,316 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  getImageBounds,
+  screenToNormalized,
+  clampBbox,
+  getCursorForHandle,
+  resizeBboxFromHandle,
+  moveBbox,
+  pixelToNormalizedDelta
+} from '../utils/bboxCoordinates'
+
+const CORNER_HANDLE_SIZE = 8 // pixels
+const EDGE_HANDLE_SIZE = 6 // pixels
+const MIN_BBOX_SIZE = 0.05 // 5% of image dimension
+const NUDGE_PIXELS = 1 // pixels to move with arrow keys
+
+/**
+ * Editable bounding box with move and resize capabilities.
+ * Supports 8 handles (4 corners + 4 edge midpoints).
+ */
+export default function EditableBbox({
+  bbox,
+  isSelected,
+  onSelect,
+  onUpdate,
+  imageRef,
+  containerRef,
+  color = '#84cc16'
+}) {
+  const [localBbox, setLocalBbox] = useState(null)
+  const localBboxRef = useRef(null) // Mirror of localBbox for closure-safe access
+
+  // Refs for drag state (no re-renders during drag, and avoids closure issues)
+  const isDraggingRef = useRef(false)
+  const isResizingRef = useRef(null) // null or handle name
+  const dragStartRef = useRef(null) // { x, y } normalized
+  const initialBboxRef = useRef(null)
+  const rafRef = useRef(null)
+  const imageBoundsRef = useRef(null) // Store bounds in ref to avoid closure issues
+
+  // Helper function to get current image bounds
+  const getCurrentBounds = useCallback(() => {
+    if (imageRef?.current && containerRef?.current) {
+      return getImageBounds(imageRef.current, containerRef.current)
+    }
+    return null
+  }, [imageRef, containerRef])
+
+  // Update bounds ref on mount, resize, and image load
+  useEffect(() => {
+    const updateBounds = () => {
+      imageBoundsRef.current = getCurrentBounds()
+    }
+
+    updateBounds()
+    window.addEventListener('resize', updateBounds)
+
+    // Also update when image loads
+    const img = imageRef?.current
+    if (img) {
+      img.addEventListener('load', updateBounds)
+      // If image is already loaded, update bounds
+      if (img.complete && img.naturalWidth > 0) {
+        updateBounds()
+      }
+    }
+
+    return () => {
+      window.removeEventListener('resize', updateBounds)
+      if (img) {
+        img.removeEventListener('load', updateBounds)
+      }
+    }
+  }, [imageRef, containerRef, getCurrentBounds])
+
+  // Cleanup function for removing event listeners
+  const cleanupDrag = useCallback(() => {
+    isDraggingRef.current = false
+    isResizingRef.current = null
+    dragStartRef.current = null
+    initialBboxRef.current = null
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+  }, [])
+
+  // Handle mouse move during drag - uses refs to avoid closure issues
+  const handleMouseMove = useCallback((e) => {
+    if (!isDraggingRef.current && !isResizingRef.current) return
+
+    const bounds = imageBoundsRef.current
+    if (!bounds || !dragStartRef.current || !initialBboxRef.current) return
+
+    // Use RAF for performance
+    if (rafRef.current) return
+    rafRef.current = requestAnimationFrame(() => {
+      const current = screenToNormalized(e.clientX, e.clientY, bounds)
+      if (!current) {
+        rafRef.current = null
+        return
+      }
+
+      const deltaX = current.x - dragStartRef.current.x
+      const deltaY = current.y - dragStartRef.current.y
+      const initial = initialBboxRef.current
+
+      let newBbox
+
+      if (isDraggingRef.current) {
+        // Move entire bbox
+        newBbox = moveBbox(initial, deltaX, deltaY)
+      } else if (isResizingRef.current) {
+        // Resize from handle
+        newBbox = resizeBboxFromHandle(initial, isResizingRef.current, deltaX, deltaY)
+      }
+
+      if (newBbox) {
+        const clamped = clampBbox(newBbox, MIN_BBOX_SIZE)
+        localBboxRef.current = clamped
+        setLocalBbox(clamped)
+      }
+
+      rafRef.current = null
+    })
+  }, [])
+
+  // Handle mouse up - commit changes
+  const handleMouseUp = useCallback(() => {
+    document.removeEventListener('mousemove', handleMouseMove)
+    document.removeEventListener('mouseup', handleMouseUp)
+
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
+    }
+
+    // Commit changes if bbox moved - use ref to get current value
+    const currentLocalBbox = localBboxRef.current
+    if (currentLocalBbox && onUpdate && initialBboxRef.current) {
+      const initial = initialBboxRef.current
+      const hasChanged =
+        Math.abs(currentLocalBbox.bboxX - initial.bboxX) > 0.001 ||
+        Math.abs(currentLocalBbox.bboxY - initial.bboxY) > 0.001 ||
+        Math.abs(currentLocalBbox.bboxWidth - initial.bboxWidth) > 0.001 ||
+        Math.abs(currentLocalBbox.bboxHeight - initial.bboxHeight) > 0.001
+
+      if (hasChanged) {
+        onUpdate(currentLocalBbox)
+      }
+    }
+
+    cleanupDrag()
+    localBboxRef.current = null
+    setLocalBbox(null)
+  }, [onUpdate, cleanupDrag, handleMouseMove])
+
+  // Handle keyboard events for nudge and escape
+  useEffect(() => {
+    if (!isSelected) return
+
+    const handleKeyDown = (e) => {
+      // Escape to cancel drag
+      if (e.key === 'Escape') {
+        if (isDraggingRef.current || isResizingRef.current) {
+          // Cancel drag and restore initial bbox
+          document.removeEventListener('mousemove', handleMouseMove)
+          document.removeEventListener('mouseup', handleMouseUp)
+          cleanupDrag()
+          localBboxRef.current = null
+          setLocalBbox(null)
+        }
+        return
+      }
+
+      // Arrow keys to nudge
+      if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+        e.preventDefault()
+        const bounds = imageBoundsRef.current || getCurrentBounds()
+        if (!bounds || !onUpdate) return
+
+        let deltaX = 0
+        let deltaY = 0
+
+        switch (e.key) {
+          case 'ArrowUp':
+            deltaY = -pixelToNormalizedDelta(NUDGE_PIXELS, bounds, 'y')
+            break
+          case 'ArrowDown':
+            deltaY = pixelToNormalizedDelta(NUDGE_PIXELS, bounds, 'y')
+            break
+          case 'ArrowLeft':
+            deltaX = -pixelToNormalizedDelta(NUDGE_PIXELS, bounds, 'x')
+            break
+          case 'ArrowRight':
+            deltaX = pixelToNormalizedDelta(NUDGE_PIXELS, bounds, 'x')
+            break
+        }
+
+        const newBbox = moveBbox(bbox, deltaX, deltaY)
+        const clamped = clampBbox(newBbox, MIN_BBOX_SIZE)
+        onUpdate(clamped)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isSelected, bbox, onUpdate, getCurrentBounds, handleMouseMove, handleMouseUp, cleanupDrag])
+
+  const handleMouseDown = useCallback(
+    (e, handle = null) => {
+      e.stopPropagation()
+
+      // If not selected, just select it
+      if (!isSelected) {
+        onSelect()
+        return
+      }
+
+      e.preventDefault()
+
+      // Calculate bounds and store in ref
+      const bounds = getCurrentBounds()
+      if (!bounds) return
+
+      imageBoundsRef.current = bounds
+
+      const normalized = screenToNormalized(e.clientX, e.clientY, bounds)
+      if (!normalized) return
+
+      dragStartRef.current = normalized
+      initialBboxRef.current = { ...bbox }
+
+      if (handle) {
+        isResizingRef.current = handle
+      } else {
+        isDraggingRef.current = true
+      }
+
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+    },
+    [isSelected, bbox, onSelect, getCurrentBounds, handleMouseMove, handleMouseUp]
+  )
+
+  // Determine which bbox to render (local during drag, actual otherwise)
+  const displayBbox = localBbox || bbox
+  const { bboxX, bboxY, bboxWidth, bboxHeight } = displayBbox
+
+  // Convert to percentage strings for SVG
+  const x = `${bboxX * 100}%`
+  const y = `${bboxY * 100}%`
+  const width = `${bboxWidth * 100}%`
+  const height = `${bboxHeight * 100}%`
+
+  const selectedColor = '#22c55e'
+  const strokeColor = isSelected ? selectedColor : color
+  const strokeWidth = isSelected ? 4 : 3
+
+  // Handle definitions with normalized positions
+  const handles = [
+    // Corners
+    { name: 'nw', normX: bboxX, normY: bboxY, size: CORNER_HANDLE_SIZE },
+    { name: 'ne', normX: bboxX + bboxWidth, normY: bboxY, size: CORNER_HANDLE_SIZE },
+    { name: 'sw', normX: bboxX, normY: bboxY + bboxHeight, size: CORNER_HANDLE_SIZE },
+    { name: 'se', normX: bboxX + bboxWidth, normY: bboxY + bboxHeight, size: CORNER_HANDLE_SIZE },
+    // Edges
+    { name: 'n', normX: bboxX + bboxWidth / 2, normY: bboxY, size: EDGE_HANDLE_SIZE },
+    { name: 's', normX: bboxX + bboxWidth / 2, normY: bboxY + bboxHeight, size: EDGE_HANDLE_SIZE },
+    { name: 'w', normX: bboxX, normY: bboxY + bboxHeight / 2, size: EDGE_HANDLE_SIZE },
+    { name: 'e', normX: bboxX + bboxWidth, normY: bboxY + bboxHeight / 2, size: EDGE_HANDLE_SIZE }
+  ]
+
+  return (
+    <g>
+      {/* Main bbox rectangle - clickable for selection and move */}
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        stroke={strokeColor}
+        strokeWidth={strokeWidth}
+        fill={isSelected ? 'rgba(34, 197, 94, 0.1)' : 'transparent'}
+        style={{
+          pointerEvents: 'all',
+          cursor: isSelected ? 'move' : 'pointer'
+        }}
+        onMouseDown={(e) => handleMouseDown(e)}
+        onClick={(e) => e.stopPropagation()}
+      />
+
+      {/* Resize handles - only show when selected */}
+      {isSelected &&
+        handles.map((handle) => (
+          <rect
+            key={handle.name}
+            x={`${handle.normX * 100}%`}
+            y={`${handle.normY * 100}%`}
+            width={handle.size}
+            height={handle.size}
+            fill={selectedColor}
+            stroke="white"
+            strokeWidth={1}
+            style={{
+              cursor: getCursorForHandle(handle.name),
+              pointerEvents: 'all'
+            }}
+            transform={`translate(-${handle.size / 2}, -${handle.size / 2})`}
+            onMouseDown={(e) => handleMouseDown(e, handle.name)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ))}
+    </g>
+  )
+}

--- a/src/renderer/src/utils/bboxCoordinates.js
+++ b/src/renderer/src/utils/bboxCoordinates.js
@@ -1,0 +1,288 @@
+/**
+ * Coordinate transformation utilities for bounding box editing.
+ * Handles object-contain image scaling and letterboxing.
+ */
+
+/**
+ * Calculate the actual rendered image bounds within a container using object-contain.
+ * When an image uses object-contain, it may have letterboxing (black bars) on
+ * top/bottom or left/right. This function calculates the actual image position.
+ *
+ * @param {HTMLImageElement} imgElement - The image element
+ * @param {HTMLElement} containerElement - The container element
+ * @returns {Object|null} - { offsetX, offsetY, renderedWidth, renderedHeight, containerRect } or null if invalid
+ */
+export function getImageBounds(imgElement, containerElement) {
+  if (!imgElement || !containerElement) return null
+
+  const containerRect = containerElement.getBoundingClientRect()
+  const imgNaturalWidth = imgElement.naturalWidth
+  const imgNaturalHeight = imgElement.naturalHeight
+
+  if (!imgNaturalWidth || !imgNaturalHeight) return null
+
+  const containerAspect = containerRect.width / containerRect.height
+  const imageAspect = imgNaturalWidth / imgNaturalHeight
+
+  let renderedWidth, renderedHeight, offsetX, offsetY
+
+  if (imageAspect > containerAspect) {
+    // Image is wider than container - letterbox on top/bottom
+    renderedWidth = containerRect.width
+    renderedHeight = containerRect.width / imageAspect
+    offsetX = 0
+    offsetY = (containerRect.height - renderedHeight) / 2
+  } else {
+    // Image is taller than container - letterbox on left/right
+    renderedHeight = containerRect.height
+    renderedWidth = containerRect.height * imageAspect
+    offsetX = (containerRect.width - renderedWidth) / 2
+    offsetY = 0
+  }
+
+  return { offsetX, offsetY, renderedWidth, renderedHeight, containerRect }
+}
+
+/**
+ * Convert screen coordinates (clientX/clientY) to normalized (0-1) coordinates
+ * relative to the actual image bounds.
+ *
+ * @param {number} clientX - Mouse clientX
+ * @param {number} clientY - Mouse clientY
+ * @param {Object} imageBounds - Result from getImageBounds()
+ * @returns {Object|null} - { x, y } in normalized 0-1 coordinates, or null if invalid
+ */
+export function screenToNormalized(clientX, clientY, imageBounds) {
+  if (!imageBounds) return null
+
+  const { offsetX, offsetY, renderedWidth, renderedHeight, containerRect } = imageBounds
+
+  const relativeX = clientX - containerRect.left - offsetX
+  const relativeY = clientY - containerRect.top - offsetY
+
+  return {
+    x: relativeX / renderedWidth,
+    y: relativeY / renderedHeight
+  }
+}
+
+/**
+ * Convert normalized (0-1) coordinates to screen pixels.
+ *
+ * @param {number} normX - Normalized x coordinate (0-1)
+ * @param {number} normY - Normalized y coordinate (0-1)
+ * @param {Object} imageBounds - Result from getImageBounds()
+ * @returns {Object|null} - { x, y } in screen pixels, or null if invalid
+ */
+export function normalizedToScreen(normX, normY, imageBounds) {
+  if (!imageBounds) return null
+
+  const { offsetX, offsetY, renderedWidth, renderedHeight, containerRect } = imageBounds
+
+  return {
+    x: containerRect.left + offsetX + normX * renderedWidth,
+    y: containerRect.top + offsetY + normY * renderedHeight
+  }
+}
+
+/**
+ * Clamp bbox to stay within image bounds (0-1) and meet minimum size requirements.
+ *
+ * @param {Object} bbox - { bboxX, bboxY, bboxWidth, bboxHeight }
+ * @param {number} minSize - Minimum size as fraction of image (default 0.05 = 5%)
+ * @returns {Object} - Clamped { bboxX, bboxY, bboxWidth, bboxHeight }
+ */
+export function clampBbox(bbox, minSize = 0.05) {
+  let { bboxX, bboxY, bboxWidth, bboxHeight } = bbox
+
+  // Ensure minimum size
+  bboxWidth = Math.max(bboxWidth, minSize)
+  bboxHeight = Math.max(bboxHeight, minSize)
+
+  // Clamp to image bounds (0-1)
+  bboxX = Math.max(0, Math.min(bboxX, 1 - bboxWidth))
+  bboxY = Math.max(0, Math.min(bboxY, 1 - bboxHeight))
+
+  // Ensure width and height don't exceed bounds
+  bboxWidth = Math.min(bboxWidth, 1 - bboxX)
+  bboxHeight = Math.min(bboxHeight, 1 - bboxY)
+
+  return { bboxX, bboxY, bboxWidth, bboxHeight }
+}
+
+/**
+ * Determine which resize handle (corner or edge) is under the cursor.
+ *
+ * @param {number} normalizedX - Cursor x in normalized coordinates
+ * @param {number} normalizedY - Cursor y in normalized coordinates
+ * @param {Object} bbox - { bboxX, bboxY, bboxWidth, bboxHeight }
+ * @param {number} handleSize - Handle hit area size in normalized coordinates (default 0.02)
+ * @returns {string|null} - 'nw' | 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | null
+ */
+export function getHandleAtPoint(normalizedX, normalizedY, bbox, handleSize = 0.02) {
+  const { bboxX, bboxY, bboxWidth, bboxHeight } = bbox
+
+  // Define handle positions
+  const handles = {
+    // Corners
+    nw: { x: bboxX, y: bboxY },
+    ne: { x: bboxX + bboxWidth, y: bboxY },
+    sw: { x: bboxX, y: bboxY + bboxHeight },
+    se: { x: bboxX + bboxWidth, y: bboxY + bboxHeight },
+    // Edge midpoints
+    n: { x: bboxX + bboxWidth / 2, y: bboxY },
+    s: { x: bboxX + bboxWidth / 2, y: bboxY + bboxHeight },
+    w: { x: bboxX, y: bboxY + bboxHeight / 2 },
+    e: { x: bboxX + bboxWidth, y: bboxY + bboxHeight / 2 }
+  }
+
+  // Check corners first (higher priority)
+  for (const name of ['nw', 'ne', 'sw', 'se']) {
+    const handle = handles[name]
+    if (
+      Math.abs(normalizedX - handle.x) < handleSize &&
+      Math.abs(normalizedY - handle.y) < handleSize
+    ) {
+      return name
+    }
+  }
+
+  // Then check edge midpoints
+  for (const name of ['n', 's', 'w', 'e']) {
+    const handle = handles[name]
+    if (
+      Math.abs(normalizedX - handle.x) < handleSize &&
+      Math.abs(normalizedY - handle.y) < handleSize
+    ) {
+      return name
+    }
+  }
+
+  return null
+}
+
+/**
+ * Check if a point is inside the bbox (for move operation).
+ *
+ * @param {number} normalizedX - Point x in normalized coordinates
+ * @param {number} normalizedY - Point y in normalized coordinates
+ * @param {Object} bbox - { bboxX, bboxY, bboxWidth, bboxHeight }
+ * @returns {boolean} - True if point is inside bbox
+ */
+export function isInsideBbox(normalizedX, normalizedY, bbox) {
+  const { bboxX, bboxY, bboxWidth, bboxHeight } = bbox
+  return (
+    normalizedX >= bboxX &&
+    normalizedX <= bboxX + bboxWidth &&
+    normalizedY >= bboxY &&
+    normalizedY <= bboxY + bboxHeight
+  )
+}
+
+/**
+ * Get the appropriate cursor for a handle or move operation.
+ *
+ * @param {string|null} handle - Handle name or null for move
+ * @returns {string} - CSS cursor value
+ */
+export function getCursorForHandle(handle) {
+  const cursorMap = {
+    nw: 'nwse-resize',
+    se: 'nwse-resize',
+    ne: 'nesw-resize',
+    sw: 'nesw-resize',
+    n: 'ns-resize',
+    s: 'ns-resize',
+    e: 'ew-resize',
+    w: 'ew-resize'
+  }
+  return cursorMap[handle] || 'move'
+}
+
+/**
+ * Calculate new bbox dimensions based on handle being dragged and delta movement.
+ *
+ * @param {Object} initialBbox - Original bbox before drag started
+ * @param {string} handle - Which handle is being dragged
+ * @param {number} deltaX - Change in x (normalized coordinates)
+ * @param {number} deltaY - Change in y (normalized coordinates)
+ * @returns {Object} - New { bboxX, bboxY, bboxWidth, bboxHeight }
+ */
+export function resizeBboxFromHandle(initialBbox, handle, deltaX, deltaY) {
+  const { bboxX, bboxY, bboxWidth, bboxHeight } = initialBbox
+  let newBbox = { bboxX, bboxY, bboxWidth, bboxHeight }
+
+  switch (handle) {
+    case 'nw':
+      newBbox.bboxX = bboxX + deltaX
+      newBbox.bboxY = bboxY + deltaY
+      newBbox.bboxWidth = bboxWidth - deltaX
+      newBbox.bboxHeight = bboxHeight - deltaY
+      break
+    case 'ne':
+      newBbox.bboxY = bboxY + deltaY
+      newBbox.bboxWidth = bboxWidth + deltaX
+      newBbox.bboxHeight = bboxHeight - deltaY
+      break
+    case 'sw':
+      newBbox.bboxX = bboxX + deltaX
+      newBbox.bboxWidth = bboxWidth - deltaX
+      newBbox.bboxHeight = bboxHeight + deltaY
+      break
+    case 'se':
+      newBbox.bboxWidth = bboxWidth + deltaX
+      newBbox.bboxHeight = bboxHeight + deltaY
+      break
+    case 'n':
+      newBbox.bboxY = bboxY + deltaY
+      newBbox.bboxHeight = bboxHeight - deltaY
+      break
+    case 's':
+      newBbox.bboxHeight = bboxHeight + deltaY
+      break
+    case 'w':
+      newBbox.bboxX = bboxX + deltaX
+      newBbox.bboxWidth = bboxWidth - deltaX
+      break
+    case 'e':
+      newBbox.bboxWidth = bboxWidth + deltaX
+      break
+  }
+
+  return newBbox
+}
+
+/**
+ * Move bbox by delta, keeping size constant.
+ *
+ * @param {Object} initialBbox - Original bbox before drag started
+ * @param {number} deltaX - Change in x (normalized coordinates)
+ * @param {number} deltaY - Change in y (normalized coordinates)
+ * @returns {Object} - New { bboxX, bboxY, bboxWidth, bboxHeight }
+ */
+export function moveBbox(initialBbox, deltaX, deltaY) {
+  return {
+    bboxX: initialBbox.bboxX + deltaX,
+    bboxY: initialBbox.bboxY + deltaY,
+    bboxWidth: initialBbox.bboxWidth,
+    bboxHeight: initialBbox.bboxHeight
+  }
+}
+
+/**
+ * Convert a pixel nudge to normalized coordinates.
+ *
+ * @param {number} pixelDelta - Pixels to nudge
+ * @param {Object} imageBounds - Result from getImageBounds()
+ * @param {string} direction - 'x' or 'y'
+ * @returns {number} - Normalized delta
+ */
+export function pixelToNormalizedDelta(pixelDelta, imageBounds, direction) {
+  if (!imageBounds) return 0
+
+  if (direction === 'x') {
+    return pixelDelta / imageBounds.renderedWidth
+  } else {
+    return pixelDelta / imageBounds.renderedHeight
+  }
+}


### PR DESCRIPTION
## Summary

- Add ability to move and resize bounding boxes by dragging
- 8 resize handles (4 corners + 4 edge midpoints)
- Arrow keys to nudge selected bbox by 1px
- Escape to cancel drag operation
- Auto-save on mouse release
- Add delete observation functionality (trash icon on selected bbox and in list)
- Click outside bbox to deselect

## Changes

- **New files:**
  - `src/renderer/src/ui/EditableBbox.jsx` - Interactive bbox component with drag/resize
  - `src/renderer/src/utils/bboxCoordinates.js` - Coordinate transformation utilities

- **Backend:**
  - `src/main/queries.js` - Added `updateObservationBbox()` and `deleteObservation()`
  - `src/main/index.js` - Added IPC handlers for bbox update and delete
  - `src/preload/index.js` - Exposed new APIs to renderer

- **Frontend:**
  - `src/renderer/src/media.jsx` - Integrated EditableBbox, added mutations, delete UI

## Test plan

- [x] Select a bbox by clicking on it
- [x] Move bbox by dragging inside it
- [x] Resize bbox using corner and edge handles
- [x] Nudge bbox with arrow keys
- [x] Cancel drag with Escape key
- [x] Click outside bbox to deselect
- [x] Delete bbox using trash icon (on label or in list)
- [x] Verify changes persist after reload