### PR TITLE
feat: add media grid view controls (bboxes toggle & grid density)

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -16,6 +16,7 @@ import {
   getDeploymentsActivity,
   getMedia,
   getMediaBboxes,
+  getMediaBboxesBatch,
   getSpeciesDailyActivity,
   getSpeciesDistribution,
   getSpeciesHeatmapData,
@@ -725,6 +726,23 @@ app.whenReady().then(async () => {
       return { data: bboxes }
     } catch (error) {
       log.error('Error getting media bboxes:', error)
+      return { error: error.message }
+    }
+  })
+
+  // Get bounding boxes for multiple media files in a single batch
+  ipcMain.handle('media:get-bboxes-batch', async (_, studyId, mediaIDs) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const bboxesByMedia = await getMediaBboxesBatch(dbPath, mediaIDs)
+      return { data: bboxesByMedia }
+    } catch (error) {
+      log.error('Error getting media bboxes batch:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -59,6 +59,9 @@ const api = {
   getMediaBboxes: async (studyId, mediaID) => {
     return await electronAPI.ipcRenderer.invoke('media:get-bboxes', studyId, mediaID)
   },
+  getMediaBboxesBatch: async (studyId, mediaIDs) => {
+    return await electronAPI.ipcRenderer.invoke('media:get-bboxes-batch', studyId, mediaIDs)
+  },
   getSpeciesDailyActivity: async (studyId, species, startDate, endDate) => {
     return await electronAPI.ipcRenderer.invoke(
       'activity:get-daily',

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -131,58 +131,69 @@ function SpeciesDistribution({ data, taxonomicData, selectedSpecies, onSpeciesCh
   }
 
   return (
-    <div className="w-full h-full bg-white rounded border border-gray-200 p-3 overflow-y-auto myscroll">
-      <div className="space-y-4">
-        {data.map((species, index) => {
-          // Try to get the common name from the taxonomic data first, then from the cache
-          const commonName =
-            scientificToCommonMap[species.scientificName] ||
-            commonNamesCache[species.scientificName]
+    <div className="w-full h-full bg-white rounded border border-gray-200 flex flex-col overflow-hidden">
+      {/* Header - matches GalleryControls height/style */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 flex-shrink-0">
+        <span className="text-sm font-medium text-gray-700">Species</span>
+        <span className="text-xs text-gray-400">({data.length})</span>
+      </div>
 
-          const isSelected = selectedSpecies.some(
-            (s) => s.scientificName === species.scientificName
-          )
-          const colorIndex = selectedSpecies.findIndex(
-            (s) => s.scientificName === species.scientificName
-          )
-          const color = colorIndex >= 0 ? palette[colorIndex % palette.length] : '#ccc'
+      {/* Scrollable content */}
+      <div className="flex-1 overflow-y-auto p-3 myscroll">
+        <div className="space-y-4">
+          {data.map((species, index) => {
+            // Try to get the common name from the taxonomic data first, then from the cache
+            const commonName =
+              scientificToCommonMap[species.scientificName] ||
+              commonNamesCache[species.scientificName]
 
-          return (
-            <div
-              key={index}
-              className="cursor-pointer group"
-              onClick={() => handleSpeciesToggle(species)}
-            >
-              <div className="flex justify-between mb-1 items-center cursor-pointer">
-                <div className="flex items-center cursor-pointer">
+            const isSelected = selectedSpecies.some(
+              (s) => s.scientificName === species.scientificName
+            )
+            const colorIndex = selectedSpecies.findIndex(
+              (s) => s.scientificName === species.scientificName
+            )
+            const color = colorIndex >= 0 ? palette[colorIndex % palette.length] : '#ccc'
+
+            return (
+              <div
+                key={index}
+                className="cursor-pointer group"
+                onClick={() => handleSpeciesToggle(species)}
+              >
+                <div className="flex justify-between mb-1 items-center cursor-pointer">
+                  <div className="flex items-center cursor-pointer">
+                    <div
+                      className={`w-2 h-2 rounded-full mr-2 border cursor-pointer ${isSelected ? `border-transparent bg-[${color}]` : 'border-gray-300'} group-hover:bg-gray-800 `}
+                      style={{
+                        backgroundColor: isSelected ? color : null
+                      }}
+                    ></div>
+
+                    <span className="capitalize text-sm">
+                      {commonName || species.scientificName}
+                    </span>
+                    {species.scientificName && commonName !== undefined && (
+                      <span className="text-gray-500 text-sm italic ml-2">
+                        {species.scientificName}
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs text-gray-500">{species.count}</span>
+                </div>
+                <div className="w-full bg-gray-200 rounded-full h-2">
                   <div
-                    className={`w-2 h-2 rounded-full mr-2 border cursor-pointer ${isSelected ? `border-transparent bg-[${color}]` : 'border-gray-300'} group-hover:bg-gray-800 `}
+                    className="h-2 rounded-full"
                     style={{
-                      backgroundColor: isSelected ? color : null
+                      width: `${(species.count / totalCount) * 100}%`,
+                      backgroundColor: isSelected ? color : '#ccc'
                     }}
                   ></div>
-
-                  <span className="capitalize text-sm">{commonName || species.scientificName}</span>
-                  {species.scientificName && commonName !== undefined && (
-                    <span className="text-gray-500 text-sm italic ml-2">
-                      {species.scientificName}
-                    </span>
-                  )}
                 </div>
-                <span className="text-xs text-gray-500">{species.count}</span>
               </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div
-                  className="h-2 rounded-full"
-                  style={{
-                    width: `${(species.count / totalCount) * 100}%`,
-                    backgroundColor: isSelected ? color : '#ccc'
-                  }}
-                ></div>
-              </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Add control buttons to the media tab Gallery for better user experience
- **Boxes toggle**: Show/hide bounding boxes on thumbnail images
- **Grid density**: Cycle through 3/4/5 columns per row for different viewing densities

## Changes
- Add `GalleryControls` component with Boxes and Grid buttons
- Implement batch bbox fetching to optimize performance (single query instead of N queries per page)
- Add `getMediaBboxesBatch` API endpoint using Drizzle ORM
- Add header to SpeciesDistribution component for visual alignment
- Consistent border styling between Gallery and Species columns

## Test plan
- [x] Toggle Boxes button and verify bboxes appear/disappear on thumbnails
- [x] Click Grid button and verify columns cycle 3→4→5→3
- [x] Verify bbox overlays align correctly with images
- [x] Check console logs show single batch query instead of multiple individual queries