### PR TITLE
feat: generate multiple bboxes per image with confidence filtering

### DIFF
--- a/src/main/db/migrations/0006_add_detection_confidence.sql
+++ b/src/main/db/migrations/0006_add_detection_confidence.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `observations` ADD `detectionConfidence` real;

--- a/src/main/db/migrations/meta/0006_snapshot.json
+++ b/src/main/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,582 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "205a6a00-1427-4dde-9e7e-2918d70f3aa9",
+  "prevId": "9ab7f8fa-5ca4-4168-b5d2-5bd9cff142f7",
+  "tables": {
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationID": {
+          "name": "locationID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationName": {
+          "name": "locationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentStart": {
+          "name": "deploymentStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentEnd": {
+          "name": "deploymentEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importFolder": {
+          "name": "importFolder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folderName": {
+          "name": "folderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_deploymentID_deployments_deploymentID_fk": {
+          "name": "media_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "media",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata": {
+      "name": "metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "importerName": {
+          "name": "importerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributors": {
+          "name": "contributors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_outputs": {
+      "name": "model_outputs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runID": {
+          "name": "runID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawOutput": {
+          "name": "rawOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_outputs_mediaID_runID_unique": {
+          "name": "model_outputs_mediaID_runID_unique",
+          "columns": [
+            "mediaID",
+            "runID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_outputs_mediaID_media_mediaID_fk": {
+          "name": "model_outputs_mediaID_media_mediaID_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_outputs_runID_model_runs_id_fk": {
+          "name": "model_outputs_runID_model_runs_id_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "model_runs",
+          "columnsFrom": [
+            "runID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_runs": {
+      "name": "model_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelID": {
+          "name": "modelID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelVersion": {
+          "name": "modelVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "importPath": {
+          "name": "importPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observations": {
+      "name": "observations",
+      "columns": {
+        "observationID": {
+          "name": "observationID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventStart": {
+          "name": "eventStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventEnd": {
+          "name": "eventEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scientificName": {
+          "name": "scientificName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observationType": {
+          "name": "observationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commonName": {
+          "name": "commonName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifeStage": {
+          "name": "lifeStage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "behavior": {
+          "name": "behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxX": {
+          "name": "bboxX",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxY": {
+          "name": "bboxY",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxWidth": {
+          "name": "bboxWidth",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxHeight": {
+          "name": "bboxHeight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detectionConfidence": {
+          "name": "detectionConfidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modelOutputID": {
+          "name": "modelOutputID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationMethod": {
+          "name": "classificationMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classifiedBy": {
+          "name": "classifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationTimestamp": {
+          "name": "classificationTimestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observations_mediaID_media_mediaID_fk": {
+          "name": "observations_mediaID_media_mediaID_fk",
+          "tableFrom": "observations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_deploymentID_deployments_deploymentID_fk": {
+          "name": "observations_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "observations",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_modelOutputID_model_outputs_id_fk": {
+          "name": "observations_modelOutputID_model_outputs_id_fk",
+          "tableFrom": "observations",
+          "tableTo": "model_outputs",
+          "columnsFrom": [
+            "modelOutputID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/main/db/migrations/meta/_journal.json
+++ b/src/main/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1764928927800,
       "tag": "0005_add_metadata_and_model_options",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1765038114335,
+      "tag": "0006_add_detection_confidence",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.js
+++ b/src/main/db/schema.js
@@ -82,6 +82,8 @@ export const observations = sqliteTable('observations', {
   bboxY: real('bboxY'),
   bboxWidth: real('bboxWidth'),
   bboxHeight: real('bboxHeight'),
+  // Detection confidence (bbox confidence from model, separate from classification confidence)
+  detectionConfidence: real('detectionConfidence'),
   // Model output link (nullable - NULL if manual entry without model)
   modelOutputID: text('modelOutputID').references(() => modelOutputs.id),
   // Camtrap DP classification fields (all nullable)

--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -1050,6 +1050,7 @@ export async function getMediaBboxes(dbPath, mediaID) {
         o.observationID,
         o.scientificName,
         o.confidence,
+        o.detectionConfidence,
         o.bboxX,
         o.bboxY,
         o.bboxWidth,
@@ -1064,7 +1065,7 @@ export async function getMediaBboxes(dbPath, mediaID) {
       LEFT JOIN model_runs mr ON mo.runID = mr.id
       WHERE o.mediaID = ?
       AND o.bboxX IS NOT NULL
-      ORDER BY o.confidence DESC
+      ORDER BY o.detectionConfidence DESC
     `
 
     const rows = await executeRawQuery(studyId, dbPath, query, [mediaID])
@@ -1102,6 +1103,7 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
         observationID: observations.observationID,
         scientificName: observations.scientificName,
         confidence: observations.confidence,
+        detectionConfidence: observations.detectionConfidence,
         bboxX: observations.bboxX,
         bboxY: observations.bboxY,
         bboxWidth: observations.bboxWidth,
@@ -1112,7 +1114,7 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
       })
       .from(observations)
       .where(and(inArray(observations.mediaID, mediaIDs), isNotNull(observations.bboxX)))
-      .orderBy(observations.mediaID, desc(observations.confidence))
+      .orderBy(observations.mediaID, desc(observations.detectionConfidence))
 
     // Group results by mediaID
     const bboxesByMedia = {}

--- a/src/shared/mlmodels.js
+++ b/src/shared/mlmodels.js
@@ -139,7 +139,8 @@ export const modelZoo = [
     description:
       "Google's SpeciesNet is an open-source AI model launched in 2025, specifically designed for identifying animal species from images captured by camera traps. It boasts the capability to classify images into over 2,000 species labels, greatly enhancing the efficiency of wildlife data analysis for conservation initiatives.",
     website: 'https://github.com/google/cameratrapai',
-    logo: 'google'
+    logo: 'google',
+    detectionConfidenceThreshold: 0.5
   },
   {
     reference: { id: 'deepfaune', version: '1.3' },
@@ -152,7 +153,8 @@ export const modelZoo = [
     description:
       "Launched in 2022, CNRS' DeepFaune is an open-source AI model developed to identify animal species from images captured by camera traps, focusing specifically on European fauna.",
     website: 'https://www.deepfaune.cnrs.fr/en/',
-    logo: 'cnrs'
+    logo: 'cnrs',
+    detectionConfidenceThreshold: 0.5
   },
   {
     reference: { id: 'manas', version: '1.0' },
@@ -165,7 +167,8 @@ export const modelZoo = [
     description:
       'Manas is an AI model developed by OSI-Panthera and Hex Data for classifying wildlife species from camera trap images in Kirghizistan, focusing on snow leopard (panthera uncia) and other regional fauna including 11 species classes.',
     website: 'https://huggingface.co/Hex-Data/Panthera',
-    logo: 'osi-panthera'
+    logo: 'osi-panthera',
+    detectionConfidenceThreshold: 0.5
   }
 ]
 


### PR DESCRIPTION
## Summary

- Generate one observation per detected bounding box (instead of just the top one)
- Add `detectionConfidence` field to observations table to store bbox confidence separately from classification confidence
- Add per-model `detectionConfidenceThreshold` configuration (default 0.5)
- Best detection is always kept regardless of threshold; threshold only filters additional detections
- Queries now return `detectionConfidence` and order by it

## Changes

- **Schema**: Added `detectionConfidence` field to observations table
- **Migration**: `0006_add_detection_confidence.sql`
- **Model configs**: Added `detectionConfidenceThreshold` to SpeciesNet, DeepFaune, and Manas
- **Importer**: Creates multiple observations per image, one per valid detection
- **Queries**: Updated `getMediaBboxes` and `getMediaBboxesBatch` to include and order by `detectionConfidence`

## Behavior

| Scenario | Result |
|----------|--------|
| 1 detection (any conf) | 1 observation with bbox |
| 3 detections (0.9, 0.6, 0.3) | 2 observations: best (0.9) + one above threshold (0.6) |
| No detections | 1 observation with null bbox |

## Test plan

- [x] Run model on images with multiple animals
- [x] Verify multiple bboxes are created and displayed
- [x] Verify low-confidence additional detections are filtered
- [x] Verify best detection is always kept even if below threshold