### PR TITLE
fix: Demo Dataset media tab query using Drizzle ORM UNION

### DIFF
--- a/src/main/db/schemas.js
+++ b/src/main/db/schemas.js
@@ -45,14 +45,8 @@ export const metadataSchema = z.object({
   importerName: z.string(),
   contributors: contributorsSchema,
   updatedAt: z.string().nullable(),
-  startDate: z
-    .string()
-    .regex(isoDatePattern, 'Must be ISO date format (YYYY-MM-DD)')
-    .nullable(),
-  endDate: z
-    .string()
-    .regex(isoDatePattern, 'Must be ISO date format (YYYY-MM-DD)')
-    .nullable()
+  startDate: z.string().regex(isoDatePattern, 'Must be ISO date format (YYYY-MM-DD)').nullable(),
+  endDate: z.string().regex(isoDatePattern, 'Must be ISO date format (YYYY-MM-DD)').nullable()
 })
 
 // Schema for updating metadata (all fields optional except what's being updated)

--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -8,7 +8,20 @@ import {
   executeRawQuery
 } from './db/index.js'
 import { union } from 'drizzle-orm/sqlite-core'
-import { eq, and, desc, count, sql, isNotNull, ne, inArray, gte, lte, isNull, or } from 'drizzle-orm'
+import {
+  eq,
+  and,
+  desc,
+  count,
+  sql,
+  isNotNull,
+  ne,
+  inArray,
+  gte,
+  lte,
+  isNull,
+  or
+} from 'drizzle-orm'
 import log from 'electron-log'
 import { DateTime } from 'luxon'
 
@@ -506,7 +519,13 @@ export async function getSpeciesHeatmapData(
  * @returns {Promise<Array>} - Media files matching the criteria
  */
 export async function getMedia(dbPath, options = {}) {
-  const { limit: queryLimit = 10, offset: queryOffset = 0, species = [], dateRange = {}, timeRange = {} } = options
+  const {
+    limit: queryLimit = 10,
+    offset: queryOffset = 0,
+    species = [],
+    dateRange = {},
+    timeRange = {}
+  } = options
 
   const startTime = Date.now()
   log.info(`Querying media files from: ${dbPath} with filtering options`)
@@ -532,7 +551,10 @@ export async function getMedia(dbPath, options = {}) {
     const db = await getDrizzleDb(studyId, dbPath)
 
     // Build dynamic filter conditions array for base query
-    const baseConditions = [isNotNull(observations.scientificName), ne(observations.scientificName, '')]
+    const baseConditions = [
+      isNotNull(observations.scientificName),
+      ne(observations.scientificName, '')
+    ]
 
     // Add species filter if provided
     if (species.length > 0) {
@@ -555,8 +577,12 @@ export async function getMedia(dbPath, options = {}) {
     if (timeRange.start !== undefined && timeRange.end !== undefined) {
       if (timeRange.start < timeRange.end) {
         // Simple range (e.g., 8:00 to 17:00)
-        baseConditions.push(sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`)
-        baseConditions.push(sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`)
+        baseConditions.push(
+          sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`
+        )
+        baseConditions.push(
+          sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
+        )
       } else if (timeRange.start > timeRange.end) {
         // Wrapping range (e.g., 22:00 to 6:00)
         baseConditions.push(

--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -291,10 +291,7 @@ export default function Overview({ data, studyId, studyName }) {
   const { importStatus } = useImportStatus(studyId)
 
   // Use useQuery for deployments data - automatically handles caching per studyId
-  const {
-    data: deploymentsData,
-    error: deploymentsError
-  } = useQuery({
+  const { data: deploymentsData, error: deploymentsError } = useQuery({
     queryKey: ['deployments', studyId],
     queryFn: async () => {
       const response = await window.api.getDeployments(studyId)
@@ -308,10 +305,7 @@ export default function Overview({ data, studyId, studyName }) {
   })
 
   // Use useQuery for species data - automatically handles caching per studyId
-  const {
-    data: speciesData,
-    error: speciesError
-  } = useQuery({
+  const { data: speciesData, error: speciesError } = useQuery({
     queryKey: ['species', studyId],
     queryFn: async () => {
       const response = await window.api.getSpeciesDistribution(studyId)
@@ -381,7 +375,6 @@ export default function Overview({ data, studyId, studyName }) {
       maxDeploymentDate: maxDate ? maxDate.toISOString().split('T')[0] : null
     }
   }, [deploymentsData])
-
 
   // Check scroll possibility
   useEffect(() => {

--- a/test/camtrap-import.test.js
+++ b/test/camtrap-import.test.js
@@ -559,11 +559,7 @@ media001,deploy001,${mediaUrl},image.jpg,2023-03-20T14:30:15Z`
       assert.equal(metadata.name, 'test-camtrap-dataset', 'name should match datapackage name')
 
       // Verify datapackage metadata is preserved
-      assert.equal(
-        metadata.title,
-        'Test CamTrap Dataset',
-        'Should preserve datapackage title'
-      )
+      assert.equal(metadata.title, 'Test CamTrap Dataset', 'Should preserve datapackage title')
 
       // Verify returned data matches
       assert(result.data, 'Should return data')

--- a/test/metadata-validation.test.js
+++ b/test/metadata-validation.test.js
@@ -286,9 +286,7 @@ describe('Metadata Zod Validation', () => {
 
     test('should accept contributors update', () => {
       const contributorsUpdate = {
-        contributors: [
-          { title: 'New Contributor', email: 'new@example.com', role: 'author' }
-        ]
+        contributors: [{ title: 'New Contributor', email: 'new@example.com', role: 'author' }]
       }
 
       const result = metadataUpdateSchema.safeParse(contributorsUpdate)

--- a/test/wildlife-import.test.js
+++ b/test/wildlife-import.test.js
@@ -332,11 +332,7 @@ describe('Wildlife Import Tests', () => {
       const contributors = JSON.parse(metadata.contributors)
       assert(Array.isArray(contributors), 'Contributors should be an array')
       assert.equal(contributors.length, 1, 'Should have one contributor')
-      assert.equal(
-        contributors[0].title,
-        'Rafa Benjumea',
-        'Should have correct contributor name'
-      )
+      assert.equal(contributors[0].title, 'Rafa Benjumea', 'Should have correct contributor name')
 
       // Verify returned data matches
       assert(result.data, 'Should return data')


### PR DESCRIPTION
## Summary

- Fix the Media tab not displaying any media for the Demo Dataset (CamTrap DP format)
- Rewrite `getMedia()` query using Drizzle ORM instead of raw SQL
- Use UNION to efficiently support both mediaID-based and timestamp-based observation links

## Problem

The Demo Dataset has observations with NULL `mediaID` - they link to media via timestamp matching (`media.timestamp = observations.eventStart`). After commit a0edae9 changed the JOIN to use `mediaID`, the Media tab showed no results.

Using OR in the JOIN condition caused full table scans (137K × 53K = 7.3 billion comparisons), freezing the UI.

## Solution

Use UNION to combine two efficient queries:
1. **Branch 1**: `JOIN ON media.mediaID = observations.mediaID` (for ML runs, Wildlife Insights, Deepfaune)
2. **Branch 2**: `JOIN ON media.timestamp = observations.eventStart WHERE observations.mediaID IS NULL` (for CamTrap DP datasets)

Each branch can use indexes independently, avoiding the performance issue.

## Test plan

- [x] Verify Media tab displays images for Demo Dataset
- [x] Verify filters (species, date range, time range) work correctly
- [x] Verify ML model run results still display in Media tab