### PR TITLE
ui: improve tab styling for active/inactive states

### DIFF
--- a/src/renderer/src/settings.jsx
+++ b/src/renderer/src/settings.jsx
@@ -116,11 +116,11 @@ export default function SettingsPage() {
   }
   return (
     <div className="flex gap-4 flex-col h-full">
-      <header className="w-full flex border-b border-gray-200 divide-gray-200 divide-x sticky top-0 bg-white z-10 rounded-tl-md rounded-tr-md [&>a:last-child]:rounded-tr-md [&>a:first-child]:rounded-tl-md">
+      <header className="w-full flex border-b border-gray-200 divide-gray-200 divide-x sticky top-0 z-10 rounded-tl-md rounded-tr-md [&>a:last-child]:rounded-tr-md [&>a:first-child]:rounded-tl-md">
         <NavLink
           to={`/settings/info`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <Info color="black" size={20} className="pb-[2px]" />
@@ -129,7 +129,7 @@ export default function SettingsPage() {
         <NavLink
           to={`/settings/ml_zoo`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm border-r border-gray-200`
           }
         >
           <BrainCircuit color="black" size={20} className="pb-[2px]" />

--- a/src/renderer/src/study.jsx
+++ b/src/renderer/src/study.jsx
@@ -171,7 +171,7 @@ export default function Study() {
           to={`/study/${id}`}
           end
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <NotebookText color="black" size={20} className="pb-[2px]" />
@@ -180,7 +180,7 @@ export default function Study() {
         <NavLink
           to={`/study/${id}/activity`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <ChartBar color="black" size={20} className="pb-[2px]" />
@@ -189,7 +189,7 @@ export default function Study() {
         <NavLink
           to={`/study/${id}/media`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <Image color="black" size={20} className="pb-[2px]" />
@@ -198,7 +198,7 @@ export default function Study() {
         <NavLink
           to={`/study/${id}/deployments`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <Cctv color="black" size={20} className="pb-[2px]" />
@@ -208,7 +208,7 @@ export default function Study() {
           <NavLink
             to={`/study/${id}/files`}
             className={({ isActive }) =>
-              `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+              `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
             }
           >
             <FolderOpen color="black" size={20} className="pb-[2px]" />
@@ -218,7 +218,7 @@ export default function Study() {
         <NavLink
           to={`/study/${id}/export`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <Upload color="black" size={20} className="pb-[2px]" />
@@ -227,7 +227,7 @@ export default function Study() {
         <NavLink
           to={`/study/${id}/settings`}
           className={({ isActive }) =>
-            `${isActive ? 'bg-gray-100' : ''} cursor-pointer hover:bg-gray-100 transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
+            `${isActive ? 'bg-white' : 'bg-gray-100'} cursor-pointer hover:bg-white transition-colors flex justify-center flex-row gap-2 items-center px-4 h-10 text-sm`
           }
         >
           <Settings color="black" size={20} className="pb-[2px]" />


### PR DESCRIPTION
## Summary
- Fix tab styling so active tabs have white background and inactive tabs have gray background
- Previously the logic was inverted (active tabs were gray, inactive were white)
- Add right border to last tab in settings page for visual clarity

## Files changed
- `src/renderer/src/study.jsx` - Updated 7 tabs (Overview, Activity, Media, Deployments, Files, Export, Settings)
- `src/renderer/src/settings.jsx` - Updated 2 tabs (Info, AI Models) and fixed header styling

## Test plan
- [x] Navigate to a study and verify active tab is white, inactive tabs are gray
- [x] Hover over inactive tabs and verify they transition to white
- [x] Navigate to Settings page and verify same behavior
- [x] Verify right border appears after AI Models tab