### PR TITLE
Migrate raw SQL queries to Drizzle ORM

### DIFF
--- a/src/main/db/index.js
+++ b/src/main/db/index.js
@@ -3,7 +3,7 @@
  * Replaces the old db.js with type-safe database operations
  */
 
-import { eq } from 'drizzle-orm'
+import { eq, desc } from 'drizzle-orm'
 import { getStudyDatabase, closeStudyDatabase, closeAllDatabases } from './manager.js'
 import { deployments, media, observations, modelRuns, modelOutputs, metadata } from './schema.js'
 import {
@@ -188,23 +188,6 @@ export async function insertModelOutput(db, data) {
  * @returns {Promise<Object|null>} Latest model run or null
  */
 export async function getLatestModelRun(db) {
-  const result = await db.select().from(modelRuns).orderBy(modelRuns.startedAt).limit(1)
-  // Note: orderBy defaults to ASC, we need DESC for latest
-  // Using raw query for proper DESC ordering
-  return result[0] || null
-}
-
-/**
- * Get the latest model run using raw SQL (proper DESC ordering)
- * @param {string} studyId - Study identifier
- * @param {string} dbPath - Path to database file
- * @returns {Promise<Object|null>} Latest model run or null
- */
-export async function getLatestModelRunRaw(studyId, dbPath) {
-  const result = await executeRawQuery(
-    studyId,
-    dbPath,
-    'SELECT * FROM model_runs ORDER BY startedAt DESC LIMIT 1'
-  )
+  const result = await db.select().from(modelRuns).orderBy(desc(modelRuns.startedAt)).limit(1)
   return result[0] || null
 }


### PR DESCRIPTION
## Summary

Migrate raw SQL queries to Drizzle ORM for improved type safety and consistency, while keeping complex CTEs as raw SQL where appropriate.

## Changes

### `src/main/db/index.js`
- Fixed `getLatestModelRun()` to properly order by `startedAt DESC`
- Removed redundant `getLatestModelRunRaw()` function

### `src/main/queries.js`
Migrated 6 query functions from raw SQL to Drizzle ORM:

| Function | Migration Approach |
|----------|-------------------|
| `getDeployments()` | Drizzle subquery + selectDistinct + groupBy |
| `getDistinctSpecies()` | Drizzle select + groupBy + orderBy with count() |
| `getSpeciesHeatmapData()` | Drizzle innerJoin + sql template for strftime |
| `getSpeciesDailyActivity()` | Drizzle select with sql template for hour extraction |
| `getMediaBboxes()` | Drizzle leftJoin chain |
| `getMediaPredictions()` | Drizzle leftJoin + explicit column selection |

### `src/main/importer.js`
- Migrated bulk insert to use Drizzle's `insert().values([])` with transactions
- Removed direct `better-sqlite3` import (now uses Drizzle through db manager)

## Kept as Raw SQL
- `getSpeciesTimeseries()` - Complex recursive CTE with 5 CTEs for date generation
- Schema introspection queries in `manager.js` - Query `sqlite_master`

## Test Plan
- [x] Verify species distribution queries work correctly
- [x] Test heatmap and daily activity visualizations
- [x] Test media bbox and predictions queries
- [x] Test bulk image import performance