### PR TITLE
feat: add geographic deployment filtering on media tab

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -52,7 +52,7 @@ const { data, error } = await window.api.getMedia(studyId, { limit: 100 })
 
 | Method | Channel | Parameters | Returns |
 |--------|---------|------------|---------|
-| `getSpeciesDistribution(studyId)` | `species:get-distribution` | studyId | `{ data: Distribution[] }` |
+| `getSpeciesDistribution(studyId, deployments?)` | `species:get-distribution` | studyId, deployments? | `{ data: Distribution[] }` |
 | `getDistinctSpecies(studyId)` | `species:get-distinct` | studyId | `{ data: string[] }` |
 
 ### Deployments
@@ -74,18 +74,29 @@ const { data, error } = await window.api.getMedia(studyId, { limit: 100 })
 
 | Method | Channel | Parameters | Returns |
 |--------|---------|------------|---------|
-| `getSpeciesTimeseries(studyId, species)` | `activity:get-timeseries` | studyId, species | `{ data: TimeseriesPoint[] }` |
-| `getSpeciesDailyActivity(studyId, species, startDate, endDate)` | `activity:get-daily` | studyId, species, startDate?, endDate? | `{ data: DailyActivity[] }` |
+| `getSpeciesTimeseries(studyId, species, deployments?)` | `activity:get-timeseries` | studyId, species, deployments? | `{ data: TimeseriesPoint[] }` |
+| `getSpeciesDailyActivity(studyId, species, startDate, endDate, deployments?)` | `activity:get-daily` | studyId, species, startDate?, endDate?, deployments? | `{ data: DailyActivity[] }` |
 | `getSpeciesHeatmapData(studyId, species, startDate, endDate, startTime, endTime)` | `activity:get-heatmap-data` | studyId, species, filters... | `{ data: HeatmapData }` |
 
 ### Media
 
 | Method | Channel | Parameters | Returns |
 |--------|---------|------------|---------|
-| `getMedia(studyId, options)` | `media:get` | studyId, { limit?, offset?, filters? } | `{ data: Media[] }` |
+| `getMedia(studyId, options)` | `media:get` | studyId, { limit?, offset?, species?, dateRange?, timeRange?, deployments? } | `{ data: Media[] }` |
 | `getMediaBboxes(studyId, mediaID)` | `media:get-bboxes` | studyId, mediaID | `{ data: Bbox[] }` |
 | `getMediaBboxesBatch(studyId, mediaIDs)` | `media:get-bboxes-batch` | studyId, mediaID[] | `{ data: Map<mediaID, Bbox[]> }` |
 | `setMediaTimestamp(studyId, mediaID, timestamp)` | `media:set-timestamp` | studyId, mediaID, timestamp | `{ success: boolean }` |
+
+#### getMedia Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `limit` | `number` | Maximum number of results (default: 10) |
+| `offset` | `number` | Number of results to skip for pagination (default: 0) |
+| `species` | `string[]` | Filter by scientific names |
+| `dateRange` | `{ start: Date\|string, end: Date\|string }` | Filter by timestamp range |
+| `timeRange` | `{ start: number, end: number }` | Filter by hour of day (0-23) |
+| `deployments` | `string[]` | Filter by deployment IDs (geographic filter) |
 
 ### Files
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -548,16 +548,16 @@ app.whenReady().then(async () => {
   })
 
   // Add species distribution handler
-  ipcMain.handle('species:get-distribution', async (_, studyId) => {
+  ipcMain.handle('species:get-distribution', async (_, studyId, deployments) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
-      log.info('Dd path for study:', dbPath)
+      log.info('Db path for study:', dbPath)
       if (!dbPath || !existsSync(dbPath)) {
         log.warn(`Database not found for study ID: ${studyId}`)
         return { error: 'Database not found for this study' }
       }
 
-      const distribution = await getSpeciesDistribution(dbPath)
+      const distribution = await getSpeciesDistribution(dbPath, deployments)
       return { data: distribution }
     } catch (error) {
       log.error('Error getting species distribution:', error)
@@ -582,7 +582,7 @@ app.whenReady().then(async () => {
     }
   })
 
-  ipcMain.handle('activity:get-timeseries', async (_, studyId, species) => {
+  ipcMain.handle('activity:get-timeseries', async (_, studyId, species, deployments) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
       if (!dbPath || !existsSync(dbPath)) {
@@ -590,7 +590,7 @@ app.whenReady().then(async () => {
         return { error: 'Database not found for this study' }
       }
 
-      const timeseriesData = await getSpeciesTimeseries(dbPath, species)
+      const timeseriesData = await getSpeciesTimeseries(dbPath, species, deployments)
       return { data: timeseriesData }
     } catch (error) {
       log.error('Error getting species timeseries:', error)
@@ -656,21 +656,30 @@ app.whenReady().then(async () => {
     }
   })
 
-  ipcMain.handle('activity:get-daily', async (_, studyId, species, startDate, endDate) => {
-    try {
-      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
-      if (!dbPath || !existsSync(dbPath)) {
-        log.warn(`Database not found for study ID: ${studyId}`)
-        return { error: 'Database not found for this study' }
-      }
+  ipcMain.handle(
+    'activity:get-daily',
+    async (_, studyId, species, startDate, endDate, deployments) => {
+      try {
+        const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+        if (!dbPath || !existsSync(dbPath)) {
+          log.warn(`Database not found for study ID: ${studyId}`)
+          return { error: 'Database not found for this study' }
+        }
 
-      const dailyActivity = await getSpeciesDailyActivity(dbPath, species, startDate, endDate)
-      return { data: dailyActivity }
-    } catch (error) {
-      log.error('Error getting species daily activity data:', error)
-      return { error: error.message }
+        const dailyActivity = await getSpeciesDailyActivity(
+          dbPath,
+          species,
+          startDate,
+          endDate,
+          deployments
+        )
+        return { data: dailyActivity }
+      } catch (error) {
+        log.error('Error getting species daily activity data:', error)
+        return { error: error.message }
+      }
     }
-  })
+  )
 
   // Add handler for deleting study
   ipcMain.handle('study:delete-database', async (event, studyId) => {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -24,8 +24,8 @@ const api = {
   importGbifDataset: async (datasetKey) => {
     return await electronAPI.ipcRenderer.invoke('import:gbif-dataset', datasetKey)
   },
-  getSpeciesDistribution: async (studyId) => {
-    return await electronAPI.ipcRenderer.invoke('species:get-distribution', studyId)
+  getSpeciesDistribution: async (studyId, deployments) => {
+    return await electronAPI.ipcRenderer.invoke('species:get-distribution', studyId, deployments)
   },
   getDeployments: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('deployments:get', studyId)
@@ -33,8 +33,13 @@ const api = {
   deleteStudyDatabase: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('study:delete-database', studyId)
   },
-  getSpeciesTimeseries: async (studyId, species) => {
-    return await electronAPI.ipcRenderer.invoke('activity:get-timeseries', studyId, species)
+  getSpeciesTimeseries: async (studyId, species, deployments) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'activity:get-timeseries',
+      studyId,
+      species,
+      deployments
+    )
   },
   getSpeciesHeatmapData: async (studyId, species, startDate, endDate, startTime, endTime) => {
     return await electronAPI.ipcRenderer.invoke(
@@ -62,13 +67,14 @@ const api = {
   getMediaBboxesBatch: async (studyId, mediaIDs) => {
     return await electronAPI.ipcRenderer.invoke('media:get-bboxes-batch', studyId, mediaIDs)
   },
-  getSpeciesDailyActivity: async (studyId, species, startDate, endDate) => {
+  getSpeciesDailyActivity: async (studyId, species, startDate, endDate, deployments) => {
     return await electronAPI.ipcRenderer.invoke(
       'activity:get-daily',
       studyId,
       species,
       startDate,
-      endDate
+      endDate,
+      deployments
     )
   },
   // ML Model Management

--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -178,11 +178,9 @@ function AppContent() {
         </header> */}
         <ul className="flex w-full min-w-0 flex-col gap-4 p-2">
           <li>
-            <div className="flex w-full items-center justify-between h-8 text-sm font-medium rounded-md p-2 cursor-default">
-              <div className="flex items-center gap-2">
-                <FolderOpen className="text-gray-500" size={16} />
-                <span>Studies</span>
-              </div>
+            <div className="flex w-full items-center h-8 text-sm font-medium rounded-md p-2 cursor-default gap-2">
+              <FolderOpen className="text-gray-500" size={16} />
+              <span className="flex-1">Studies</span>
               <NavLink
                 to="/import"
                 className="flex items-center justify-center w-5 h-5 rounded hover:bg-gray-200 transition-colors"
@@ -207,7 +205,7 @@ function AppContent() {
             </ul>
           </li>
         </ul>
-        <footer className="absolute left-0 bottom-8 w-full p-2">
+        <footer className="absolute left-0 bottom-0 w-full p-2">
           <NavLink
             to="/settings/ml_zoo"
             className={({ isActive }) =>

--- a/src/renderer/src/ui/DeploymentMapFilter.jsx
+++ b/src/renderer/src/ui/DeploymentMapFilter.jsx
@@ -1,0 +1,302 @@
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import { Camera, Expand } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet'
+import { useQuery } from '@tanstack/react-query'
+import ReactDOMServer from 'react-dom/server'
+
+// Debounce utility
+function useDebounce(callback, delay) {
+  const timeoutRef = useRef(null)
+
+  const debouncedCallback = useCallback(
+    (...args) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+      timeoutRef.current = setTimeout(() => {
+        callback(...args)
+      }, delay)
+    },
+    [callback, delay]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  return debouncedCallback
+}
+
+// Filter deployments by viewport bounds
+export function filterDeploymentsByBounds(deployments, bounds) {
+  if (!bounds || !deployments) return []
+
+  return deployments.filter((d) => {
+    if (!d.latitude || !d.longitude) return false
+    return bounds.contains([d.latitude, d.longitude])
+  })
+}
+
+// Create camera icon
+function createCameraIcon(size = 16) {
+  const cameraIcon = ReactDOMServer.renderToString(
+    <div className="deployment-filter-marker">
+      <Camera color="#1E40AF" fill="#93C5FD" size={size} />
+    </div>
+  )
+
+  return L.divIcon({
+    html: cameraIcon,
+    className: 'custom-camera-icon-small',
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2]
+  })
+}
+
+// Internal component to track viewport changes and emit view (zoom + center)
+function ViewportTracker({ deployments, onViewChange, isSyncingRef }) {
+  const map = useMap()
+  const initializedRef = useRef(false)
+  const pendingEmitRef = useRef(false)
+
+  const emitViewChange = useCallback(() => {
+    if (!pendingEmitRef.current) return
+    pendingEmitRef.current = false
+
+    const bounds = map.getBounds()
+    const center = map.getCenter()
+    const zoom = map.getZoom()
+
+    // Emit view (zoom + center) for synchronization, plus bounds for filtering
+    onViewChange({
+      zoom,
+      center: [center.lat, center.lng],
+      bounds
+    })
+  }, [map, onViewChange])
+
+  const debouncedEmit = useDebounce(emitViewChange, 300)
+
+  // Check sync flag IMMEDIATELY when event fires, before debouncing
+  const onMapMove = useCallback(() => {
+    // Skip if we're syncing from external source (modal)
+    if (isSyncingRef?.current) {
+      pendingEmitRef.current = false
+      return
+    }
+    pendingEmitRef.current = true
+    debouncedEmit()
+  }, [isSyncingRef, debouncedEmit])
+
+  useMapEvents({
+    moveend: onMapMove,
+    zoomend: onMapMove
+  })
+
+  // Initial view calculation on mount
+  useEffect(() => {
+    if (!initializedRef.current && deployments.length > 0) {
+      initializedRef.current = true
+      // Small delay to ensure map is ready
+      setTimeout(() => {
+        pendingEmitRef.current = true
+        emitViewChange()
+      }, 100)
+    }
+  }, [deployments, emitViewChange])
+
+  return null
+}
+
+// Component to set view on initial load or when external view changes
+function ViewSetter({ deployments, externalView, isSyncingRef }) {
+  const map = useMap()
+  const fittedRef = useRef(false)
+  const lastViewRef = useRef(null)
+
+  // Fit to all deployments on initial load
+  useEffect(() => {
+    if (!fittedRef.current && deployments.length > 0 && !externalView) {
+      const positions = deployments.map((d) => [d.latitude, d.longitude])
+      const bounds = L.latLngBounds(positions)
+      map.fitBounds(bounds, { padding: [10, 10] })
+      fittedRef.current = true
+    }
+  }, [deployments, map, externalView])
+
+  // Sync to external view (zoom + center) when it changes (from modal)
+  useEffect(() => {
+    if (externalView) {
+      // Mark as fitted on first external view (allows sync to work even if
+      // externalView was present before the initial fit useEffect ran)
+      if (!fittedRef.current) {
+        fittedRef.current = true
+      }
+
+      // Check if view actually changed to avoid infinite loops
+      const viewKey = `${externalView.zoom},${externalView.center[0]},${externalView.center[1]}`
+      if (lastViewRef.current !== viewKey) {
+        lastViewRef.current = viewKey
+
+        // Set flag BEFORE setView to suppress ViewportTracker emission
+        if (isSyncingRef) {
+          isSyncingRef.current = true
+        }
+
+        // Use setView with exact zoom and center
+        map.setView(externalView.center, externalView.zoom, { animate: false })
+
+        // Reset after map events have fired
+        if (isSyncingRef) {
+          requestAnimationFrame(() => {
+            isSyncingRef.current = false
+          })
+        }
+      }
+    }
+  }, [externalView, map, isSyncingRef])
+
+  return null
+}
+
+export default function DeploymentMapFilter({
+  studyId,
+  onChange,
+  onOpenModal,
+  externalView,
+  onViewChange
+}) {
+  const [visibleCount, setVisibleCount] = useState(0)
+  const isSyncingRef = useRef(false) // Track when syncing from external source
+
+  // Fetch deployments with coordinates
+  const { data: activityData, isLoading } = useQuery({
+    queryKey: ['deploymentsActivity', studyId],
+    queryFn: async () => {
+      const response = await window.api.getDeploymentsActivity(studyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!studyId
+  })
+
+  // Filter to deployments with valid coordinates
+  const deploymentsWithCoords = useMemo(() => {
+    if (!activityData?.deployments) return []
+    return activityData.deployments.filter((d) => d.latitude && d.longitude)
+  }, [activityData])
+
+  // Calculate initial bounds
+  const initialBounds = useMemo(() => {
+    if (deploymentsWithCoords.length === 0) return null
+    if (deploymentsWithCoords.length === 1) {
+      // For single deployment, create bounds around it with some padding
+      const d = deploymentsWithCoords[0]
+      return L.latLngBounds(
+        [d.latitude - 0.01, d.longitude - 0.01],
+        [d.latitude + 0.01, d.longitude + 0.01]
+      )
+    }
+    const positions = deploymentsWithCoords.map((d) => [d.latitude, d.longitude])
+    return L.latLngBounds(positions)
+  }, [deploymentsWithCoords])
+
+  // Handle view change from viewport tracker
+  const handleViewChange = useCallback(
+    (view) => {
+      const visibleDeployments = filterDeploymentsByBounds(deploymentsWithCoords, view.bounds)
+      const deploymentIDs = visibleDeployments.map((d) => d.deploymentID)
+      setVisibleCount(deploymentIDs.length)
+      onChange(deploymentIDs)
+      if (onViewChange) {
+        onViewChange(view)
+      }
+    },
+    [deploymentsWithCoords, onChange, onViewChange]
+  )
+
+  // Update visibleCount when receiving external view (from modal)
+  useEffect(() => {
+    if (externalView?.bounds) {
+      const visibleDeployments = filterDeploymentsByBounds(
+        deploymentsWithCoords,
+        externalView.bounds
+      )
+      setVisibleCount(visibleDeployments.length)
+    }
+  }, [externalView, deploymentsWithCoords])
+
+  // Create the camera icon
+  const cameraIcon = useMemo(() => createCameraIcon(16), [])
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-gray-100">
+        <div className="animate-pulse text-gray-400 text-xs">Loading...</div>
+      </div>
+    )
+  }
+
+  // Render placeholder if no coordinates
+  if (deploymentsWithCoords.length === 0) {
+    return (
+      <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-400 text-xs text-center p-2">
+        <span>No deployment coordinates</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative w-full h-full">
+      <MapContainer
+        bounds={initialBounds}
+        boundsOptions={{ padding: [10, 10] }}
+        style={{ height: '100%', width: '100%' }}
+        zoomControl={false}
+        attributionControl={false}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+
+        <ViewSetter
+          deployments={deploymentsWithCoords}
+          externalView={externalView}
+          isSyncingRef={isSyncingRef}
+        />
+        <ViewportTracker
+          deployments={deploymentsWithCoords}
+          onViewChange={handleViewChange}
+          isSyncingRef={isSyncingRef}
+        />
+
+        {deploymentsWithCoords.map((deployment) => (
+          <Marker
+            key={deployment.deploymentID}
+            position={[deployment.latitude, deployment.longitude]}
+            icon={cameraIcon}
+          />
+        ))}
+      </MapContainer>
+
+      {/* Expand button */}
+      <button
+        onClick={onOpenModal}
+        className="absolute top-1 right-1 z-[1000] p-1 bg-white rounded shadow hover:bg-gray-100 transition-colors"
+        title="Expand map for precise selection"
+      >
+        <Expand size={14} />
+      </button>
+
+      {/* Deployment count indicator */}
+      <div className="absolute bottom-1 left-1 z-[1000] bg-white/90 px-1.5 py-0.5 rounded text-xs font-medium shadow">
+        {visibleCount}/{deploymentsWithCoords.length}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/ui/DeploymentMapModal.jsx
+++ b/src/renderer/src/ui/DeploymentMapModal.jsx
@@ -1,0 +1,288 @@
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import { Camera, X } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { LayersControl, MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet'
+import { useQuery } from '@tanstack/react-query'
+import ReactDOMServer from 'react-dom/server'
+import { filterDeploymentsByBounds } from './DeploymentMapFilter'
+
+// Debounce utility
+function useDebounce(callback, delay) {
+  const timeoutRef = useRef(null)
+
+  const debouncedCallback = useCallback(
+    (...args) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+      timeoutRef.current = setTimeout(() => {
+        callback(...args)
+      }, delay)
+    },
+    [callback, delay]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  return debouncedCallback
+}
+
+// Create camera icon
+function createCameraIcon(size = 24) {
+  const cameraIcon = ReactDOMServer.renderToString(
+    <div className="deployment-modal-marker">
+      <Camera color="#1E40AF" fill="#93C5FD" size={size} />
+    </div>
+  )
+
+  return L.divIcon({
+    html: cameraIcon,
+    className: 'custom-camera-icon-modal',
+    iconSize: [size, size],
+    iconAnchor: [size / 2, size / 2]
+  })
+}
+
+// Internal component to track viewport changes and emit view (zoom + center)
+function ViewportTracker({ deployments, onChange, onViewChange }) {
+  const map = useMap()
+  const initializedRef = useRef(false)
+  const userHasInteractedRef = useRef(false)
+
+  // Update deployment selection (always runs)
+  const updateDeploymentSelection = useCallback(() => {
+    const bounds = map.getBounds()
+    const visibleDeployments = filterDeploymentsByBounds(deployments, bounds)
+    const deploymentIDs = visibleDeployments.map((d) => d.deploymentID)
+    onChange(deploymentIDs)
+  }, [map, deployments, onChange])
+
+  // Handle view change from user interaction (pan/zoom)
+  const handleUserInteraction = useCallback(() => {
+    userHasInteractedRef.current = true
+    const bounds = map.getBounds()
+    const center = map.getCenter()
+    const zoom = map.getZoom()
+
+    const visibleDeployments = filterDeploymentsByBounds(deployments, bounds)
+    const deploymentIDs = visibleDeployments.map((d) => d.deploymentID)
+    onChange(deploymentIDs)
+
+    // Emit view (zoom + center) for sync - only when user actually interacts
+    onViewChange({
+      zoom,
+      center: [center.lat, center.lng],
+      bounds
+    })
+  }, [map, deployments, onChange, onViewChange])
+
+  const debouncedHandleUserInteraction = useDebounce(handleUserInteraction, 300)
+
+  useMapEvents({
+    moveend: debouncedHandleUserInteraction,
+    zoomend: debouncedHandleUserInteraction
+  })
+
+  // Initial deployment selection on mount (but don't propagate view)
+  useEffect(() => {
+    if (!initializedRef.current && deployments.length > 0) {
+      initializedRef.current = true
+      setTimeout(() => {
+        // Only update deployment selection, don't propagate view back to mini-map
+        updateDeploymentSelection()
+      }, 100)
+    }
+  }, [deployments, updateDeploymentSelection])
+
+  return null
+}
+
+// Component to set initial view (zoom + center from mini-map)
+function InitialViewSetter({ initialView, deployments }) {
+  const map = useMap()
+  const fittedRef = useRef(false)
+
+  useEffect(() => {
+    if (!fittedRef.current) {
+      if (initialView) {
+        // Use exact zoom and center from mini-map - this ensures same view
+        map.setView(initialView.center, initialView.zoom, { animate: false })
+      } else if (deployments.length > 0) {
+        // Fallback to fitting all deployments
+        const positions = deployments.map((d) => [d.latitude, d.longitude])
+        const bounds = L.latLngBounds(positions)
+        map.fitBounds(bounds, { padding: [50, 50] })
+      }
+      fittedRef.current = true
+    }
+  }, [initialView, deployments, map])
+
+  return null
+}
+
+export default function DeploymentMapModal({
+  studyId,
+  onChange,
+  onClose,
+  initialView,
+  onViewChange
+}) {
+  const [visibleCount, setVisibleCount] = useState(0)
+
+  // Fetch deployments with coordinates
+  const { data: activityData, isLoading } = useQuery({
+    queryKey: ['deploymentsActivity', studyId],
+    queryFn: async () => {
+      const response = await window.api.getDeploymentsActivity(studyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!studyId
+  })
+
+  // Filter to deployments with valid coordinates
+  const deploymentsWithCoords = useMemo(() => {
+    if (!activityData?.deployments) return []
+    return activityData.deployments.filter((d) => d.latitude && d.longitude)
+  }, [activityData])
+
+  // Handle deployment selection change
+  const handleDeploymentsChange = useCallback(
+    (deploymentIDs) => {
+      setVisibleCount(deploymentIDs.length)
+      onChange(deploymentIDs)
+    },
+    [onChange]
+  )
+
+  // Handle escape key to close modal
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // Create the camera icon
+  const cameraIcon = useMemo(() => createCameraIcon(24), [])
+
+  // Default bounds for MapContainer (will be overridden by InitialViewSetter)
+  const defaultBounds = useMemo(() => {
+    // If we have initialView, we'll use setView instead of bounds, but MapContainer needs bounds
+    if (initialView?.bounds) return initialView.bounds
+    if (deploymentsWithCoords.length === 0) return null
+    if (deploymentsWithCoords.length === 1) {
+      const d = deploymentsWithCoords[0]
+      return L.latLngBounds(
+        [d.latitude - 0.05, d.longitude - 0.05],
+        [d.latitude + 0.05, d.longitude + 0.05]
+      )
+    }
+    const positions = deploymentsWithCoords.map((d) => [d.latitude, d.longitude])
+    return L.latLngBounds(positions)
+  }, [initialView, deploymentsWithCoords])
+
+  // Handle click on backdrop (outside modal content)
+  const handleBackdropClick = useCallback(
+    (e) => {
+      // Only close if clicking directly on the backdrop, not on children
+      if (e.target === e.currentTarget) {
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
+  return (
+    <div
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-white rounded-lg shadow-xl w-[90vw] max-h-[90vh] flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200 flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-semibold text-gray-800">Select Deployments by Area</h2>
+            <span className="text-sm text-gray-500">
+              {visibleCount}/{deploymentsWithCoords.length} deployments in view
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+            title="Close (Esc)"
+          >
+            <X size={20} className="text-gray-500" />
+          </button>
+        </div>
+
+        {/* Map area - same aspect ratio as mini-map (160:130 = 16:13) for consistent bounds */}
+        <div className="relative aspect-[16/13] w-full">
+          {isLoading ? (
+            <div className="w-full h-full flex items-center justify-center bg-gray-100">
+              <div className="animate-pulse text-gray-400">Loading deployments...</div>
+            </div>
+          ) : deploymentsWithCoords.length === 0 ? (
+            <div className="w-full h-full flex items-center justify-center bg-gray-100 text-gray-500">
+              No deployments with coordinates available
+            </div>
+          ) : (
+            <MapContainer
+              bounds={defaultBounds}
+              boundsOptions={{ padding: [0, 0] }}
+              style={{ height: '100%', width: '100%' }}
+              zoomControl={true}
+            >
+              <LayersControl position="topright">
+                <LayersControl.BaseLayer name="Street Map" checked={true}>
+                  <TileLayer
+                    attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                  />
+                </LayersControl.BaseLayer>
+
+                <LayersControl.BaseLayer name="Satellite">
+                  <TileLayer
+                    attribution='&copy; <a href="https://www.esri.com">Esri</a>'
+                    url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+                  />
+                </LayersControl.BaseLayer>
+              </LayersControl>
+
+              <InitialViewSetter initialView={initialView} deployments={deploymentsWithCoords} />
+              <ViewportTracker
+                deployments={deploymentsWithCoords}
+                onChange={handleDeploymentsChange}
+                onViewChange={onViewChange}
+              />
+
+              {deploymentsWithCoords.map((deployment) => (
+                <Marker
+                  key={deployment.deploymentID}
+                  position={[deployment.latitude, deployment.longitude]}
+                  icon={cameraIcon}
+                />
+              ))}
+            </MapContainer>
+          )}
+        </div>
+
+        {/* Footer with instructions */}
+        <div className="px-4 py-2 border-t border-gray-200 bg-gray-50 text-sm text-gray-600 flex-shrink-0">
+          Pan and zoom the map to select deployments. Media will be filtered to show only content
+          from deployments visible in the current view.
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add interactive map filter to select deployments by geographic viewport
- Mini-map in footer allows quick filtering by panning/zooming
- Expandable modal for precise area selection with satellite layer option
- Synchronized viewport between mini-map and modal (zoom, center, deployment count)
- All visualization components (Species Distribution, Daily Activity Radar, Timeline) respect deployment filter

## Changes
- New `DeploymentMapFilter` component (mini-map in footer)
- New `DeploymentMapModal` component (full-screen selection)
- Extended backend queries to support deployment filtering
- Updated IPC API documentation

## Test plan
- [ ] Open media tab, verify mini-map shows deployment locations
- [ ] Pan/zoom mini-map, verify media gallery filters accordingly
- [ ] Click expand button, verify modal opens with same view
- [ ] Pan/zoom in modal, verify mini-map syncs (viewport + count)
- [ ] Verify Species Distribution, Daily Activity Radar, and Timeline respect filter