### PR TITLE
feat: hover-to-play sequences in media tab

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1363,40 +1363,40 @@ function SequenceCard({
   showBboxes,
   bboxesByMedia,
   widthClass,
-  cycleInterval = 2000
+  cycleInterval = 1000
 }) {
   const [currentIndex, setCurrentIndex] = useState(0)
-  const [isPaused, setIsPaused] = useState(false)
+  const [isHovering, setIsHovering] = useState(false)
 
   const itemCount = sequence.items.length
   // Guard against currentIndex being out of bounds (can happen when sequence changes)
   const safeIndex = Math.min(currentIndex, itemCount - 1)
   const currentMedia = sequence.items[safeIndex]
 
-  // Auto-cycle effect
+  // Auto-cycle effect - only runs when hovering
   useEffect(() => {
-    if (isPaused || itemCount <= 1) return
+    if (!isHovering || itemCount <= 1) return
 
     const intervalId = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % itemCount)
     }, cycleInterval)
 
     return () => clearInterval(intervalId)
-  }, [itemCount, cycleInterval, isPaused])
+  }, [itemCount, cycleInterval, isHovering])
 
   // Reset index when sequence changes
   useEffect(() => {
     setCurrentIndex(0)
   }, [sequence.id])
 
-  // Preload next image for smooth transitions
+  // Preload next image for smooth transitions (only when hovering)
   useEffect(() => {
-    if (itemCount <= 1) return
+    if (!isHovering || itemCount <= 1) return
     const nextIndex = (safeIndex + 1) % itemCount
     const nextMedia = sequence.items[nextIndex]
     const img = new Image()
     img.src = constructImageUrl(nextMedia.filePath)
-  }, [safeIndex, sequence, constructImageUrl, itemCount])
+  }, [safeIndex, sequence, constructImageUrl, itemCount, isHovering])
 
   const handleClick = () => {
     onSequenceClick(sequence.items[0], sequence)
@@ -1405,8 +1405,11 @@ function SequenceCard({
   return (
     <div
       className={`border border-gray-300 rounded-lg overflow-hidden min-w-[150px] ${widthClass} flex flex-col h-max transition-all relative group`}
-      onMouseEnter={() => setIsPaused(true)}
-      onMouseLeave={() => setIsPaused(false)}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => {
+        setIsHovering(false)
+        setCurrentIndex(0)
+      }}
     >
       {/* Sequence badge */}
       <div className="absolute top-2 right-2 z-20 bg-black/70 text-white px-2 py-0.5 rounded-full text-xs font-medium flex items-center gap-1">


### PR DESCRIPTION
## Summary

- Sequences are now static by default (no auto-cycling)
- Images cycle through only when hovering over a sequence card
- Resets to first image when mouse leaves

## Test plan

- [x] Open media tab with sequences enabled (sequence gap > 0)
- [x] Verify sequences show first image and remain static
- [x] Hover over sequence card - verify it starts cycling
- [x] Move mouse away - verify cycling stops and resets to first image