### PR TITLE
feat: rename confidence field to classificationProbability

### DIFF
--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -152,7 +152,7 @@ Combined media + observations in one file:
 | `filename` | fileName |
 | `genus` + `species` | scientificName |
 | `common_name` | commonName |
-| `cv_confidence` | confidence |
+| `cv_confidence` | classificationProbability |
 | `number_of_objects` | count |
 | `age` | lifeStage |
 | `sex` | sex |
@@ -175,7 +175,7 @@ Single CSV file with image paths and predictions.
 |--------|-------------|
 | `filename` | Image file path |
 | `prediction` | Species prediction |
-| `confidence` | Prediction confidence |
+| `score` | Classification probability |
 
 **Key file:** `src/main/deepfaune.js`
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -114,7 +114,7 @@ Species observations linked to media.
 | `scientificName` | TEXT | | Latin species name |
 | `observationType` | TEXT | | `animal`, `blank`, etc. |
 | `commonName` | TEXT | | Common name |
-| `confidence` | REAL | | Classification confidence (0-1) |
+| `classificationProbability` | REAL | | Classification probability (0-1) |
 | `count` | INTEGER | | Number of individuals |
 | `lifeStage` | TEXT | | `adult`, `juvenile`, etc. |
 | `age` | TEXT | | Age descriptor |
@@ -141,7 +141,7 @@ export const observations = sqliteTable('observations', {
   scientificName: text('scientificName'),
   observationType: text('observationType'),
   commonName: text('commonName'),
-  confidence: real('confidence'),
+  classificationProbability: real('classificationProbability'),
   count: integer('count'),
   lifeStage: text('lifeStage'),
   age: text('age'),

--- a/src/main/camtrap.js
+++ b/src/main/camtrap.js
@@ -337,7 +337,7 @@ function transformObservationRow(row) {
     scientificName: row.scientificName || row.scientific_name || null,
     observationType: row.observationType || row.observation_type || null,
     commonName: row.commonName || row.common_name || null,
-    confidence: parseFloat(row.confidence) || null,
+    classificationProbability: parseFloat(row.classificationProbability) || null,
     count: parseInt(row.count) || null,
     prediction: row.prediction || null,
     lifeStage: row.lifeStage || row.life_stage || null,

--- a/src/main/db/migrations/0007_rename_confidence_to_classification_probability.sql
+++ b/src/main/db/migrations/0007_rename_confidence_to_classification_probability.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `observations` RENAME COLUMN "confidence" TO "classificationProbability";

--- a/src/main/db/migrations/meta/0007_snapshot.json
+++ b/src/main/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,584 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f9627794-31d8-4b1f-8373-745aa7d98a13",
+  "prevId": "205a6a00-1427-4dde-9e7e-2918d70f3aa9",
+  "tables": {
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationID": {
+          "name": "locationID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationName": {
+          "name": "locationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentStart": {
+          "name": "deploymentStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentEnd": {
+          "name": "deploymentEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importFolder": {
+          "name": "importFolder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folderName": {
+          "name": "folderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_deploymentID_deployments_deploymentID_fk": {
+          "name": "media_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "media",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata": {
+      "name": "metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "importerName": {
+          "name": "importerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributors": {
+          "name": "contributors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_outputs": {
+      "name": "model_outputs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runID": {
+          "name": "runID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawOutput": {
+          "name": "rawOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_outputs_mediaID_runID_unique": {
+          "name": "model_outputs_mediaID_runID_unique",
+          "columns": [
+            "mediaID",
+            "runID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_outputs_mediaID_media_mediaID_fk": {
+          "name": "model_outputs_mediaID_media_mediaID_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_outputs_runID_model_runs_id_fk": {
+          "name": "model_outputs_runID_model_runs_id_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "model_runs",
+          "columnsFrom": [
+            "runID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_runs": {
+      "name": "model_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelID": {
+          "name": "modelID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelVersion": {
+          "name": "modelVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "importPath": {
+          "name": "importPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observations": {
+      "name": "observations",
+      "columns": {
+        "observationID": {
+          "name": "observationID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventStart": {
+          "name": "eventStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventEnd": {
+          "name": "eventEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scientificName": {
+          "name": "scientificName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observationType": {
+          "name": "observationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commonName": {
+          "name": "commonName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationProbability": {
+          "name": "classificationProbability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifeStage": {
+          "name": "lifeStage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "behavior": {
+          "name": "behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxX": {
+          "name": "bboxX",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxY": {
+          "name": "bboxY",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxWidth": {
+          "name": "bboxWidth",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxHeight": {
+          "name": "bboxHeight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detectionConfidence": {
+          "name": "detectionConfidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modelOutputID": {
+          "name": "modelOutputID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationMethod": {
+          "name": "classificationMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classifiedBy": {
+          "name": "classifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationTimestamp": {
+          "name": "classificationTimestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "observations_mediaID_media_mediaID_fk": {
+          "name": "observations_mediaID_media_mediaID_fk",
+          "tableFrom": "observations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_deploymentID_deployments_deploymentID_fk": {
+          "name": "observations_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "observations",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_modelOutputID_model_outputs_id_fk": {
+          "name": "observations_modelOutputID_model_outputs_id_fk",
+          "tableFrom": "observations",
+          "tableTo": "model_outputs",
+          "columnsFrom": [
+            "modelOutputID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {
+      "\"observations\".\"confidence\"": "\"observations\".\"classificationProbability\""
+    }
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/main/db/migrations/meta/_journal.json
+++ b/src/main/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1765038114335,
       "tag": "0006_add_detection_confidence",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1765294041320,
+      "tag": "0007_rename_confidence_to_classification_probability",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.js
+++ b/src/main/db/schema.js
@@ -71,7 +71,7 @@ export const observations = sqliteTable('observations', {
   scientificName: text('scientificName'),
   observationType: text('observationType'),
   commonName: text('commonName'),
-  confidence: real('confidence'),
+  classificationProbability: real('classificationProbability'),
   count: integer('count'),
   lifeStage: text('lifeStage'),
   age: text('age'),

--- a/src/main/deepfaune.js
+++ b/src/main/deepfaune.js
@@ -254,7 +254,7 @@ async function insertDeepfauneData(db, csvPath) {
         // Prepare observation record if there's a prediction
         if (row.prediction && row.prediction !== '') {
           const observationID = `${mediaID}_obs`
-          const confidence = row.score ? parseFloat(row.score) : null
+          const classificationProbability = row.score ? parseFloat(row.score) : null
           const count = row.humancount ? parseInt(row.humancount) : 1
 
           observationRows.push({
@@ -267,7 +267,7 @@ async function insertDeepfauneData(db, csvPath) {
             scientificName: row.prediction, // Use prediction as scientificName
             observationType: null,
             commonName: row.prediction, // Use prediction as commonName too
-            confidence,
+            classificationProbability,
             count,
             prediction: row.prediction,
             lifeStage: null,

--- a/src/main/export.js
+++ b/src/main/export.js
@@ -764,7 +764,7 @@ export async function exportCamtrapDP(studyId, options = {}) {
         classificationMethod: observations.classificationMethod,
         classifiedBy: observations.classifiedBy,
         classificationTimestamp: observations.classificationTimestamp,
-        confidence: observations.confidence
+        classificationProbability: observations.classificationProbability
       })
       .from(observations)
       .where(and(...obsConditions))
@@ -793,7 +793,7 @@ export async function exportCamtrapDP(studyId, options = {}) {
           classificationMethod: observations.classificationMethod,
           classifiedBy: observations.classifiedBy,
           classificationTimestamp: observations.classificationTimestamp,
-          confidence: observations.confidence
+          classificationProbability: observations.classificationProbability
         })
         .from(observations)
         .where(isNull(observations.scientificName))
@@ -888,7 +888,7 @@ export async function exportCamtrapDP(studyId, options = {}) {
       classificationMethod: o.classificationMethod,
       classifiedBy: o.classifiedBy,
       classificationTimestamp: o.classificationTimestamp,
-      classificationProbability: o.confidence
+      classificationProbability: o.classificationProbability
     }))
 
     // Generate CSV files

--- a/src/main/importer.js
+++ b/src/main/importer.js
@@ -329,7 +329,7 @@ async function insertPrediction(db, prediction, modelInfo = {}) {
     eventStart: mediaRecord.timestamp,
     eventEnd: mediaRecord.timestamp,
     scientificName: resolvedScientificName,
-    confidence: prediction.prediction_score,
+    classificationProbability: prediction.prediction_score,
     count: 1,
     modelOutputID: modelInfo.modelOutputID || null,
     classificationMethod: modelInfo.modelOutputID ? 'machine' : null,

--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -858,7 +858,7 @@ export async function insertObservations(manager, observationsData) {
             eventEnd: observation.eventEnd ? observation.eventEnd.toISO() : null,
             scientificName: observation.scientificName,
             commonName: observation.commonName,
-            confidence: observation.confidence !== undefined ? observation.confidence : null,
+            classificationProbability: observation.classificationProbability !== undefined ? observation.classificationProbability : null,
             count: observation.count !== undefined ? observation.count : null
           })
           .run()
@@ -1091,7 +1091,7 @@ export async function getMediaBboxes(dbPath, mediaID) {
       .select({
         observationID: observations.observationID,
         scientificName: observations.scientificName,
-        confidence: observations.confidence,
+        classificationProbability: observations.classificationProbability,
         detectionConfidence: observations.detectionConfidence,
         bboxX: observations.bboxX,
         bboxY: observations.bboxY,
@@ -1141,7 +1141,7 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
         mediaID: observations.mediaID,
         observationID: observations.observationID,
         scientificName: observations.scientificName,
-        confidence: observations.confidence,
+        classificationProbability: observations.classificationProbability,
         detectionConfidence: observations.detectionConfidence,
         bboxX: observations.bboxX,
         bboxY: observations.bboxY,
@@ -1231,7 +1231,7 @@ export async function getMediaPredictions(dbPath, mediaID) {
         scientificName: observations.scientificName,
         observationType: observations.observationType,
         commonName: observations.commonName,
-        confidence: observations.confidence,
+        classificationProbability: observations.classificationProbability,
         count: observations.count,
         lifeStage: observations.lifeStage,
         age: observations.age,
@@ -1257,7 +1257,7 @@ export async function getMediaPredictions(dbPath, mediaID) {
       .leftJoin(modelOutputs, eq(observations.modelOutputID, modelOutputs.id))
       .leftJoin(modelRuns, eq(modelOutputs.runID, modelRuns.id))
       .where(eq(observations.mediaID, mediaID))
-      .orderBy(desc(modelRuns.startedAt), desc(observations.confidence))
+      .orderBy(desc(modelRuns.startedAt), desc(observations.classificationProbability))
 
     const elapsedTime = Date.now() - startTime
     log.info(`Retrieved ${rows.length} predictions for media ${mediaID} in ${elapsedTime}ms`)
@@ -1433,7 +1433,7 @@ export async function updateMediaTimestamp(dbPath, mediaID, newTimestamp) {
  * - classificationMethod is set to 'human'
  * - classifiedBy is set to 'User'
  * - classificationTimestamp is set to current ISO 8601 timestamp
- * - confidence is cleared (null) for human classifications per CamTrap DP spec
+ * - classificationProbability is cleared (null) for human classifications per CamTrap DP spec
  *
  * @param {string} dbPath - Path to the SQLite database
  * @param {string} observationID - The observation ID to update
@@ -1462,7 +1462,7 @@ export async function updateObservationClassification(dbPath, observationID, upd
       classificationTimestamp: new Date().toISOString(),
       // Per CamTrap DP spec: "Omit or provide an approximate probability for human classifications"
       // We set to null to indicate this is a human classification without probability
-      confidence: null
+      classificationProbability: null
     }
 
     // Add optional fields if provided
@@ -1679,7 +1679,7 @@ export async function createObservation(dbPath, observationData) {
       scientificName: scientificName || null,
       commonName: commonName || null,
       observationType: 'animal',
-      confidence: null, // Human classification - no confidence score
+      classificationProbability: null, // Human classification - no classificationProbability score
       count: 1,
       bboxX,
       bboxY,

--- a/src/main/wildlife.js
+++ b/src/main/wildlife.js
@@ -329,7 +329,7 @@ async function insertObservations(db, csvPath) {
         scientificName: scientificName,
         observationType: null, // Not available in Wildlife Insights format
         commonName: row.common_name || null,
-        confidence: row.cv_confidence ? parseFloat(row.cv_confidence) : null,
+        classificationProbability: row.cv_confidence ? parseFloat(row.cv_confidence) : null,
         count: row.number_of_objects ? parseInt(row.number_of_objects) : 1,
         prediction: row.common_name || null,
         lifeStage: row.age || null,

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -66,8 +66,8 @@ function ObservationListPanel({ bboxes, selectedId, onSelect, onDelete }) {
             )}
           </button>
           <div className="flex items-center gap-2">
-            {bbox.confidence && (
-              <span className="text-xs text-gray-400">{Math.round(bbox.confidence * 100)}%</span>
+            {bbox.classificationProbability && (
+              <span className="text-xs text-gray-400">{Math.round(bbox.classificationProbability * 100)}%</span>
             )}
             <Pencil size={14} className="text-gray-400" />
             <button
@@ -253,7 +253,7 @@ const BboxLabel = forwardRef(function BboxLabel(
   ref
 ) {
   const displayName = bbox.scientificName || 'Blank'
-  const confidence = bbox.confidence ? `${Math.round(bbox.confidence * 100)}%` : null
+  const confidence = bbox.classificationProbability ? `${Math.round(bbox.classificationProbability * 100)}%` : null
 
   // Use the extracted positioning function
   const { left: leftPos, top: topPos, transform: transformVal } = computeBboxLabelPosition(bbox)
@@ -788,10 +788,10 @@ function ImageModal({
   const getDefaultSpecies = useCallback(() => {
     if (!bboxes || bboxes.length === 0) return { scientificName: null, commonName: null }
 
-    // Find observation with highest confidence
-    const withConfidence = bboxes.filter((b) => b.confidence != null)
-    if (withConfidence.length === 0) {
-      // No confidence scores - use first with a species name
+    // Find observation with highest classificationProbability
+    const withProbability = bboxes.filter((b) => b.classificationProbability != null)
+    if (withProbability.length === 0) {
+      // No classification probability scores - use first with a species name
       const withSpecies = bboxes.find((b) => b.scientificName)
       return {
         scientificName: withSpecies?.scientificName || null,
@@ -799,8 +799,8 @@ function ImageModal({
       }
     }
 
-    const mostConfident = withConfidence.reduce((best, b) =>
-      b.confidence > best.confidence ? b : best
+    const mostConfident = withProbability.reduce((best, b) =>
+      b.classificationProbability > best.classificationProbability ? b : best
     )
     return {
       scientificName: mostConfident.scientificName,

--- a/test/camtrap-import.test.js
+++ b/test/camtrap-import.test.js
@@ -208,7 +208,7 @@ describe('CamTrapDP Import Tests', () => {
         'Should have correct scientific name'
       )
       assert.equal(redDeerObs.count, 2, 'Should have correct count')
-      assert.equal(redDeerObs.confidence, 0.95, 'Should have correct confidence')
+      assert.equal(redDeerObs.classificationProbability, 0.95, 'Should have correct classificationProbability')
     })
 
     test('should handle scientific name and empty observations correctly', async () => {

--- a/test/camtrap-null-fks.test.js
+++ b/test/camtrap-null-fks.test.js
@@ -160,7 +160,7 @@ describe('CamTrapDP NULL Foreign Keys Tests', () => {
       const standalone = completelyStandalone[0]
       assert.equal(standalone.observationID, 'obs004', 'Should find completely standalone obs004')
       assert.equal(standalone.commonName, 'European Hare', 'Should have species data')
-      assert.equal(standalone.confidence, 0.92, 'Should have confidence value')
+      assert.equal(standalone.classificationProbability, 0.92, 'Should have classificationProbability value')
     })
 
     test('should maintain referential integrity for non-NULL foreign keys', async () => {

--- a/test/data/camtrap-null-fks/datapackage.json
+++ b/test/data/camtrap-null-fks/datapackage.json
@@ -70,7 +70,7 @@
           {"name": "eventEnd", "type": "datetime"},
           {"name": "scientificName", "type": "string"},
           {"name": "commonName", "type": "string"},
-          {"name": "confidence", "type": "number"},
+          {"name": "classificationProbability", "type": "number"},
           {"name": "count", "type": "integer"}
         ]
       }

--- a/test/data/camtrap-null-fks/observations.csv
+++ b/test/data/camtrap-null-fks/observations.csv
@@ -1,4 +1,4 @@
-observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,confidence,count
+observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,classificationProbability,count
 obs001,media001,deploy001,event001,2023-03-20T14:30:15Z,2023-03-20T14:30:45Z,Cervus elaphus,Red Deer,0.95,2
 obs002,,deploy001,event002,2023-03-25T08:45:22Z,2023-03-25T08:45:52Z,Sus scrofa,Wild Boar,0.87,1
 obs003,media003,,event003,2023-04-10T16:20:10Z,2023-04-10T16:20:40Z,,Empty,1.0,0

--- a/test/data/camtrap/datapackage.json
+++ b/test/data/camtrap/datapackage.json
@@ -70,7 +70,7 @@
           {"name": "eventEnd", "type": "datetime"},
           {"name": "scientificName", "type": "string"},
           {"name": "commonName", "type": "string"},
-          {"name": "confidence", "type": "number"},
+          {"name": "classificationProbability", "type": "number"},
           {"name": "count", "type": "integer"}
         ]
       }

--- a/test/data/camtrap/observations.csv
+++ b/test/data/camtrap/observations.csv
@@ -1,4 +1,4 @@
-observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,confidence,count
+observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,classificationProbability,count
 obs001,media001,deploy001,event001,2023-03-20T14:30:15Z,2023-03-20T14:30:45Z,Cervus elaphus,Red Deer,0.95,2
 obs002,media002,deploy001,event002,2023-03-25T08:45:22Z,2023-03-25T08:45:52Z,Sus scrofa,Wild Boar,0.87,1
 obs003,media003,deploy001,event003,2023-04-10T16:20:10Z,2023-04-10T16:20:40Z,,Empty,1.0,0

--- a/test/database-schema.test.js
+++ b/test/database-schema.test.js
@@ -156,7 +156,7 @@ async function createComprehensiveTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-03-20T14:30:45.456Z'),
       scientificName: 'Cervus elaphus',
       commonName: 'Red Deer',
-      confidence: 0.95,
+      classificationProbability: 0.95,
       count: 2,
       prediction: 'cervus_elaphus'
     },
@@ -169,7 +169,7 @@ async function createComprehensiveTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-03-26T00:00:29.999Z'),
       scientificName: 'Species with "quotes" & special chars',
       commonName: 'Test Species',
-      confidence: 0.01, // Very low confidence
+      classificationProbability: 0.01, // Very low classificationProbability
       count: 100, // Large count
       prediction: 'test_species'
     },
@@ -182,7 +182,7 @@ async function createComprehensiveTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-04-05T00:00:00.001Z'), // Very short event
       scientificName: null, // Null scientific name
       commonName: 'Empty',
-      confidence: null, // Null confidence
+      classificationProbability: null, // Null classificationProbability
       count: 0, // Zero count
       prediction: 'empty'
     }
@@ -298,7 +298,7 @@ describe('Database Schema and Integrity Tests', () => {
         { name: 'scientificName', type: 'TEXT', pk: 0 },
         { name: 'observationType', type: 'TEXT', pk: 0 },
         { name: 'commonName', type: 'TEXT', pk: 0 },
-        { name: 'confidence', type: 'REAL', pk: 0 },
+        { name: 'classificationProbability', type: 'REAL', pk: 0 },
         { name: 'count', type: 'INTEGER', pk: 0 },
         { name: 'lifeStage', type: 'TEXT', pk: 0 },
         { name: 'age', type: 'TEXT', pk: 0 },
@@ -440,7 +440,7 @@ describe('Database Schema and Integrity Tests', () => {
       assert.equal(southPole.longitude, 180.0, 'Should handle maximum longitude')
     })
 
-    test('should handle edge cases in confidence values', async () => {
+    test('should handle edge cases in classificationProbability values', async () => {
       const { manager } = await createComprehensiveTestData(testDbPath)
 
       const edgeCaseObservations = [
@@ -453,7 +453,7 @@ describe('Database Schema and Integrity Tests', () => {
           eventEnd: DateTime.now().plus({ seconds: 10 }),
           scientificName: 'Perfect Confidence',
           commonName: 'Perfect Species',
-          confidence: 1.0, // Maximum confidence
+          classificationProbability: 1.0, // Maximum classificationProbability
           count: 1,
           prediction: 'perfect_species'
         },
@@ -466,7 +466,7 @@ describe('Database Schema and Integrity Tests', () => {
           eventEnd: DateTime.now().plus({ minutes: 1, seconds: 10 }),
           scientificName: 'Zero Confidence',
           commonName: 'Zero Species',
-          confidence: 0.0, // Minimum confidence
+          classificationProbability: 0.0, // Minimum classificationProbability
           count: 1,
           prediction: 'zero_species'
         }
@@ -480,13 +480,13 @@ describe('Database Schema and Integrity Tests', () => {
         .from(observations)
         .where(sql`${observations.observationID} IN ('conf001', 'conf002')`)
 
-      assert.equal(results.length, 2, 'Should insert edge case confidence values')
+      assert.equal(results.length, 2, 'Should insert edge case classificationProbability values')
 
       const perfectConf = results.find((o) => o.observationID === 'conf001')
       const zeroConf = results.find((o) => o.observationID === 'conf002')
 
-      assert.equal(perfectConf.confidence, 1.0, 'Should handle maximum confidence')
-      assert.equal(zeroConf.confidence, 0.0, 'Should handle minimum confidence')
+      assert.equal(perfectConf.classificationProbability, 1.0, 'Should handle maximum classificationProbability')
+      assert.equal(zeroConf.classificationProbability, 0.0, 'Should handle minimum classificationProbability')
     })
 
     test('should handle timestamp precision and edge cases', async () => {
@@ -583,7 +583,7 @@ describe('Database Schema and Integrity Tests', () => {
 
       assert(nullObservation, 'Should find observation with null values')
       assert.equal(nullObservation.scientificName, null, 'Scientific name should be null')
-      assert.equal(nullObservation.confidence, null, 'Confidence should be null')
+      assert.equal(nullObservation.classificationProbability, null, 'ClassificationProbability should be null')
       assert.equal(nullObservation.count, 0, 'Count should be zero')
     })
 
@@ -630,7 +630,7 @@ describe('Database Schema and Integrity Tests', () => {
           eventEnd: timestamp.plus({ seconds: 30 }),
           scientificName: i % 2 === 0 ? 'Cervus elaphus' : null,
           commonName: i % 2 === 0 ? 'Red Deer' : 'Empty',
-          confidence: i % 2 === 0 ? Math.random() : null,
+          classificationProbability: i % 2 === 0 ? Math.random() : null,
           count: i % 2 === 0 ? Math.floor(Math.random() * 5) + 1 : 0,
           prediction: i % 2 === 0 ? 'cervus_elaphus' : 'empty'
         })

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -158,7 +158,7 @@ async function createTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-03-20T14:30:45Z'),
       scientificName: 'Cervus elaphus',
       commonName: 'Red Deer',
-      confidence: 0.95,
+      classificationProbability: 0.95,
       count: 2,
       prediction: 'cervus_elaphus'
     },
@@ -171,7 +171,7 @@ async function createTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-03-25T16:46:00Z'),
       scientificName: 'Vulpes vulpes',
       commonName: 'Red Fox',
-      confidence: 0.87,
+      classificationProbability: 0.87,
       count: 1,
       prediction: 'vulpes_vulpes'
     },
@@ -184,7 +184,7 @@ async function createTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-04-05T12:15:30Z'),
       scientificName: 'Cervus elaphus',
       commonName: 'Red Deer',
-      confidence: 0.92,
+      classificationProbability: 0.92,
       count: 1,
       prediction: 'cervus_elaphus'
     },
@@ -197,7 +197,7 @@ async function createTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-04-10T08:31:15Z'),
       scientificName: null, // Empty observation
       commonName: 'Empty',
-      confidence: null,
+      classificationProbability: null,
       count: 0,
       prediction: 'empty'
     },
@@ -210,7 +210,7 @@ async function createTestData(dbPath) {
       eventEnd: DateTime.fromISO('2023-03-25T22:00:30Z'),
       scientificName: 'Sus scrofa',
       commonName: 'Wild Boar',
-      confidence: 0.78,
+      classificationProbability: 0.78,
       count: 3,
       prediction: 'sus_scrofa'
     }


### PR DESCRIPTION
## Summary

- Rename `confidence` field to `classificationProbability` throughout the codebase to align with the native Camtrap-DP specification
- Add Drizzle migration (0007) to rename the database column
- Update all imports, exports, queries, UI components, tests, and documentation

## Changes

- **Schema**: Renamed column in `observations` table
- **Migration**: `ALTER TABLE observations RENAME COLUMN confidence TO classificationProbability`
- **Import**: CamtrapDP, Wildlife Insights, DeepFaune, and ML model importers updated
- **Export**: CamtrapDP export outputs `classificationProbability` column
- **UI**: Media tab displays classification probability correctly
- **Tests**: All test data and assertions updated
- **Docs**: database-schema.md and data-formats.md updated

## Test plan

- [x] Run `npm test` - all 276 tests pass
- [x] Import a CamtrapDP dataset with `classificationProbability` column
- [x] Export a study and verify `classificationProbability` appears in observations.csv
- [x] Run ML inference and verify classification probabilities are stored correctly