### PR TITLE
fix: overview map updates when deployments are added/edited

### DIFF
--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -415,6 +415,8 @@ export default function Deployments({ studyId }) {
         console.error('Error updating latitude:', result.error)
       } else {
         console.log('Latitude updated successfully')
+        // Invalidate the Overview tab's deployments cache so map updates
+        queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
       }
     } catch (error) {
       console.error('Error updating latitude:', error)
@@ -442,6 +444,8 @@ export default function Deployments({ studyId }) {
         console.error('Error updating longitude:', result.error)
       } else {
         console.log('Longitude updated successfully')
+        // Invalidate the Overview tab's deployments cache so map updates
+        queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
       }
     } catch (error) {
       console.error('Error updating longitude:', error)


### PR DESCRIPTION
## Summary

- Fixes bug where the Overview tab map would not reflect updated deployment coordinates after editing them in the Deployments tab
- The map would continue showing "No Geographic Coordinates" placeholder even after coordinates were set

## Root Cause

The Deployments tab and Overview tab use different React Query cache keys:
- Deployments tab: `['deploymentsActivity', studyId]`
- Overview tab: `['deployments', studyId]`

When coordinates were updated, only the Deployments tab cache was updated. The Overview tab cache was never invalidated.

## Fix

Added cache invalidation for `['deployments', studyId]` after successful coordinate updates in both `onNewLatitude` and `onNewLongitude` functions.

## Test plan

1. Run ML model on a media directory with no deployment info
2. Go to Deployments tab and add coordinates for a deployment
3. Switch to Overview tab - map should now display the deployment marker instead of placeholder