### PR TITLE
feat: improve contributor forms and hide temporal data in overview

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -858,6 +858,16 @@ export default function Overview({ data, studyId, studyName }) {
               key={index}
               ref={editingContributorIndex === index ? editingContributorRef : null}
               className="flex flex-col flex-shrink-0 w-64 p-4 border border-gray-200 rounded-md shadow-sm bg-white group relative"
+              onKeyDown={
+                editingContributorIndex === index
+                  ? (e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        saveContributor(index)
+                      }
+                    }
+                  : undefined
+              }
             >
               {editingContributorIndex === index ? (
                 // Edit mode
@@ -976,6 +986,12 @@ export default function Overview({ data, studyId, studyName }) {
             <div
               ref={addContributorRef}
               className="flex flex-col flex-shrink-0 w-64 p-4 border border-blue-300 rounded-md shadow-sm bg-blue-50"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  addContributor()
+                }
+              }}
             >
               <div className="flex flex-col gap-2">
                 <input


### PR DESCRIPTION
## Summary
- Add click-outside handling to close contributor forms (both add and edit) when clicking outside
- Hide start date and end date from the overview tab
- Align form buttons (Cancel/Save/Add) to the right for better UX

## Test plan
- [x] Open overview tab, click "+ Add contributor", then click outside the form → form should close
- [x] Edit an existing contributor, click outside → form should close
- [x] Verify start/end dates are no longer visible in overview tab
- [x] Verify Cancel/Save buttons are aligned to the right in both add and edit forms