### PR TITLE
Hide Boxes toggle when no bboxes exist in gallery

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -85,6 +85,7 @@ const { data, error } = await window.api.getMedia(studyId, { limit: 100 })
 | `getMedia(studyId, options)` | `media:get` | studyId, { limit?, offset?, filters? } | `{ data: Media[] }` |
 | `getMediaBboxes(studyId, mediaID)` | `media:get-bboxes` | studyId, mediaID | `{ data: Bbox[] }` |
 | `getMediaBboxesBatch(studyId, mediaIDs)` | `media:get-bboxes-batch` | studyId, mediaID[] | `{ data: Map<mediaID, Bbox[]> }` |
+| `checkMediaHaveBboxes(studyId, mediaIDs)` | `media:have-bboxes` | studyId, mediaID[] | `{ data: boolean }` |
 | `setMediaTimestamp(studyId, mediaID, timestamp)` | `media:set-timestamp` | studyId, mediaID, timestamp | `{ success: boolean }` |
 
 ### Files

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -17,6 +17,7 @@ import {
   getMedia,
   getMediaBboxes,
   getMediaBboxesBatch,
+  checkMediaHaveBboxes,
   getSpeciesDailyActivity,
   getSpeciesDistribution,
   getSpeciesHeatmapData,
@@ -742,6 +743,23 @@ app.whenReady().then(async () => {
       return { data: bboxesByMedia }
     } catch (error) {
       log.error('Error getting media bboxes batch:', error)
+      return { error: error.message }
+    }
+  })
+
+  // Check if any media have bboxes (lightweight boolean check)
+  ipcMain.handle('media:have-bboxes', async (_, studyId, mediaIDs) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const hasBboxes = await checkMediaHaveBboxes(dbPath, mediaIDs)
+      return { data: hasBboxes }
+    } catch (error) {
+      log.error('Error checking media bboxes existence:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -62,6 +62,9 @@ const api = {
   getMediaBboxesBatch: async (studyId, mediaIDs) => {
     return await electronAPI.ipcRenderer.invoke('media:get-bboxes-batch', studyId, mediaIDs)
   },
+  checkMediaHaveBboxes: async (studyId, mediaIDs) => {
+    return await electronAPI.ipcRenderer.invoke('media:have-bboxes', studyId, mediaIDs)
+  },
   getSpeciesDailyActivity: async (studyId, species, startDate, endDate) => {
     return await electronAPI.ipcRenderer.invoke(
       'activity:get-daily',

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1324,6 +1324,7 @@ function formatGapValue(seconds) {
 function GalleryControls({
   showBboxes,
   onToggleBboxes,
+  hasBboxes,
   gridColumns,
   onCycleGrid,
   sequenceGap,
@@ -1368,19 +1369,21 @@ function GalleryControls({
       </div>
 
       <div className="flex items-center gap-2">
-        {/* Show Bboxes Toggle */}
-        <button
-          onClick={onToggleBboxes}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-            showBboxes
-              ? 'bg-lime-500 text-white hover:bg-lime-600'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-          }`}
-          title="Show bounding boxes on thumbnails"
-        >
-          <Square size={16} />
-          <span>Boxes</span>
-        </button>
+        {/* Show Bboxes Toggle - only render if bboxes exist */}
+        {hasBboxes && (
+          <button
+            onClick={onToggleBboxes}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              showBboxes
+                ? 'bg-lime-500 text-white hover:bg-lime-600'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+            title="Show bounding boxes on thumbnails"
+          >
+            <Square size={16} />
+            <span>Boxes</span>
+          </button>
+        )}
 
         {/* Grid Density Cycle */}
         <button
@@ -1716,6 +1719,17 @@ function Gallery({ species, dateRange, timeRange }) {
     staleTime: 60000
   })
 
+  // Check if any media have bboxes (lightweight check for showing/hiding toggle)
+  const { data: anyMediaHaveBboxes = false } = useQuery({
+    queryKey: ['mediaHaveBboxes', id, mediaIDs],
+    queryFn: async () => {
+      const response = await window.api.checkMediaHaveBboxes(id, mediaIDs)
+      return response.data || false
+    },
+    enabled: mediaIDs.length > 0 && !!id,
+    staleTime: 60000
+  })
+
   // Set up Intersection Observer for infinite scrolling
   useEffect(() => {
     const currentLoader = loaderRef.current
@@ -1880,6 +1894,7 @@ function Gallery({ species, dateRange, timeRange }) {
         <GalleryControls
           showBboxes={showThumbnailBboxes}
           onToggleBboxes={() => setShowThumbnailBboxes((prev) => !prev)}
+          hasBboxes={anyMediaHaveBboxes}
           gridColumns={gridColumns}
           onCycleGrid={handleCycleGrid}
           sequenceGap={sequenceGap}


### PR DESCRIPTION
## Summary
- Hide the "Boxes" toggle button in the Gallery controls when no observations with bounding box coordinates exist across the currently displayed media
- Add lightweight `checkMediaHaveBboxes` API endpoint that efficiently checks bbox existence using `LIMIT 1`
- Respects active filters (species, date range, time range) and updates dynamically as more media loads via infinite scroll

## Changes
- `src/main/queries.js`: Add `checkMediaHaveBboxes` query function
- `src/main/index.js`: Add IPC handler `media:have-bboxes`
- `src/preload/index.js`: Expose `checkMediaHaveBboxes` API
- `src/renderer/src/media.jsx`: Add query and conditional rendering in `GalleryControls`
- `docs/ipc-api.md`: Document new API endpoint

## Test plan
- [x] Open Gallery with media that have bboxes → Boxes toggle should be visible
- [x] Open Gallery with media that have no bboxes → Boxes toggle should be hidden
- [x] Apply filters that result in no bboxes → Boxes toggle should disappear
- [x] Scroll to load more media with bboxes → Boxes toggle should appear