### PR TITLE
Improve Overview tab editing UX

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -440,8 +440,8 @@ export default function Overview({ data, studyId, studyName }) {
         saveTitle()
       }
     }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
+    document.addEventListener('mousedown', handleClickOutside, true)  // capture phase
+    return () => document.removeEventListener('mousedown', handleClickOutside, true)
   }, [isEditingTitle, editedTitle, studyName])
 
   // Handle click outside to save and Escape key to cancel description editing
@@ -460,10 +460,10 @@ export default function Overview({ data, studyId, studyName }) {
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('mousedown', handleClickOutside, true)  // capture phase
     document.addEventListener('keydown', handleKeyDown)
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('mousedown', handleClickOutside, true)
       document.removeEventListener('keydown', handleKeyDown)
     }
   }, [isEditingDescription, editedDescription, data, studyId])
@@ -766,7 +766,7 @@ export default function Overview({ data, studyId, studyName }) {
         {/* Description with inline editing */}
         <div className="relative group">
           {isEditingDescription ? (
-            <div ref={descriptionEditRef} className="flex flex-col gap-2">
+            <div ref={descriptionEditRef}>
               <textarea
                 value={editedDescription}
                 onChange={(e) => setEditedDescription(e.target.value)}
@@ -775,22 +775,6 @@ export default function Overview({ data, studyId, studyName }) {
                 autoFocus
                 placeholder="Camera trap dataset containing deployment information, media files metadata, and species observations collected during wildlife monitoring."
               />
-              <div className="flex gap-1">
-                <button
-                  onClick={cancelEditingDescription}
-                  className="p-1 hover:bg-red-100 rounded text-red-600"
-                  title="Cancel (Escape)"
-                >
-                  <X size={16} />
-                </button>
-                <button
-                  onClick={saveDescription}
-                  className="p-1 hover:bg-green-100 rounded text-green-600"
-                  title="Save (Cmd+Enter)"
-                >
-                  <Check size={16} />
-                </button>
-              </div>
             </div>
           ) : (
             <>


### PR DESCRIPTION
## Summary
- Add click-outside-to-save behavior for title and description fields
- Add global Escape key handling to cancel editing (works regardless of focus)
- Remove redundant save/cancel buttons from title and description (auto-save UX)
- Add confirmation modal when deleting a contributor
- Add Escape key support for the add contributor form

## Changes
- Title field: click outside saves, Enter saves, Escape cancels
- Description field: click outside saves, Cmd+Enter saves, Escape cancels
- Delete contributor now shows confirmation modal to prevent accidental deletions
- Uses capture phase for mousedown events to work with Leaflet map

## Test plan
- [x] Edit title, click outside → should save
- [x] Edit title, press Enter → should save
- [x] Edit title, press Escape → should cancel
- [x] Edit description, click outside (including on map) → should save
- [x] Edit description, press Cmd+Enter → should save
- [x] Edit description, press Escape → should cancel
- [x] Click delete on contributor → should show confirmation modal
- [x] Add contributor form, press Escape → should close form