### PR TITLE
Fix missing bboxes when importing camtrapDP datasets with zero coordinates

### DIFF
--- a/src/main/camtrap.js
+++ b/src/main/camtrap.js
@@ -345,10 +345,12 @@ function transformObservationRow(row) {
     sex: row.sex || null,
     behavior: row.behavior || null,
     // Bounding box fields (Camtrap DP format)
-    bboxX: parseFloat(row.bboxX || row.bbox_x) || null,
-    bboxY: parseFloat(row.bboxY || row.bbox_y) || null,
-    bboxWidth: parseFloat(row.bboxWidth || row.bbox_width) || null,
-    bboxHeight: parseFloat(row.bboxHeight || row.bbox_height) || null
+    // Use ?? (nullish coalescing) to prefer the first column name, falling back to snake_case
+    // Use parseFloatOrNull to properly handle 0 values (which are falsy but valid coordinates)
+    bboxX: parseFloatOrNull(row.bboxX ?? row.bbox_x),
+    bboxY: parseFloatOrNull(row.bboxY ?? row.bbox_y),
+    bboxWidth: parseFloatOrNull(row.bboxWidth ?? row.bbox_width),
+    bboxHeight: parseFloatOrNull(row.bboxHeight ?? row.bbox_height)
   }
 }
 
@@ -360,6 +362,19 @@ function transformDateField(dateValue) {
 
   const date = DateTime.fromISO(dateValue)
   return date.isValid ? date.toUTC().toISO() : null
+}
+
+/**
+ * Safely parse a float value, preserving 0 as a valid value
+ * @param {*} value - The value to parse
+ * @returns {number|null} - Parsed float or null if invalid/missing
+ */
+function parseFloatOrNull(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+  const parsed = parseFloat(value)
+  return Number.isNaN(parsed) ? null : parsed
 }
 
 /**

--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -440,7 +440,7 @@ export default function Overview({ data, studyId, studyName }) {
         saveTitle()
       }
     }
-    document.addEventListener('mousedown', handleClickOutside, true)  // capture phase
+    document.addEventListener('mousedown', handleClickOutside, true) // capture phase
     return () => document.removeEventListener('mousedown', handleClickOutside, true)
   }, [isEditingTitle, editedTitle, studyName])
 
@@ -460,7 +460,7 @@ export default function Overview({ data, studyId, studyName }) {
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside, true)  // capture phase
+    document.addEventListener('mousedown', handleClickOutside, true) // capture phase
     document.addEventListener('keydown', handleKeyDown)
     return () => {
       document.removeEventListener('mousedown', handleClickOutside, true)

--- a/test/camtrap-import.test.js
+++ b/test/camtrap-import.test.js
@@ -215,6 +215,94 @@ describe('CamTrapDP Import Tests', () => {
       )
     })
 
+    test('should import bounding boxes correctly including zero values', async () => {
+      const studyId = 'test-camtrap-bboxes'
+      await importCamTrapDatasetWithPath(testCamTrapDataPath, testBiowatchDataPath, studyId)
+
+      const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
+
+      // Test obs001: normal bbox values (0.1, 0.2, 0.3, 0.4)
+      const obs001 = queryDatabase(
+        dbPath,
+        "SELECT bboxX, bboxY, bboxWidth, bboxHeight FROM observations WHERE observationID = 'obs001'"
+      )
+      assert.equal(obs001.length, 1, 'Should find obs001')
+      assert.equal(obs001[0].bboxX, 0.1, 'obs001: bboxX should be 0.1')
+      assert.equal(obs001[0].bboxY, 0.2, 'obs001: bboxY should be 0.2')
+      assert.equal(obs001[0].bboxWidth, 0.3, 'obs001: bboxWidth should be 0.3')
+      assert.equal(obs001[0].bboxHeight, 0.4, 'obs001: bboxHeight should be 0.4')
+
+      // Test obs002: bboxX=0 (edge case - should NOT be null)
+      const obs002 = queryDatabase(
+        dbPath,
+        "SELECT bboxX, bboxY, bboxWidth, bboxHeight FROM observations WHERE observationID = 'obs002'"
+      )
+      assert.equal(obs002.length, 1, 'Should find obs002')
+      assert.equal(obs002[0].bboxX, 0, 'obs002: bboxX=0 should be preserved as 0, not null')
+      assert.equal(obs002[0].bboxY, 0.5, 'obs002: bboxY should be 0.5')
+      assert.equal(obs002[0].bboxWidth, 0.25, 'obs002: bboxWidth should be 0.25')
+      assert.equal(obs002[0].bboxHeight, 0.35, 'obs002: bboxHeight should be 0.35')
+
+      // Test obs004: bboxY=0 (edge case - should NOT be null)
+      const obs004 = queryDatabase(
+        dbPath,
+        "SELECT bboxX, bboxY, bboxWidth, bboxHeight FROM observations WHERE observationID = 'obs004'"
+      )
+      assert.equal(obs004.length, 1, 'Should find obs004')
+      assert.equal(obs004[0].bboxX, 0.15, 'obs004: bboxX should be 0.15')
+      assert.equal(obs004[0].bboxY, 0, 'obs004: bboxY=0 should be preserved as 0, not null')
+      assert.equal(obs004[0].bboxWidth, 0.2, 'obs004: bboxWidth should be 0.2')
+      assert.equal(obs004[0].bboxHeight, 0.3, 'obs004: bboxHeight should be 0.3')
+
+      // Test obs006: both bboxX=0 AND bboxY=0 (double edge case)
+      const obs006 = queryDatabase(
+        dbPath,
+        "SELECT bboxX, bboxY, bboxWidth, bboxHeight FROM observations WHERE observationID = 'obs006'"
+      )
+      assert.equal(obs006.length, 1, 'Should find obs006')
+      assert.equal(obs006[0].bboxX, 0, 'obs006: bboxX=0 should be preserved as 0, not null')
+      assert.equal(obs006[0].bboxY, 0, 'obs006: bboxY=0 should be preserved as 0, not null')
+      assert.equal(obs006[0].bboxWidth, 0.5, 'obs006: bboxWidth should be 0.5')
+      assert.equal(obs006[0].bboxHeight, 0.6, 'obs006: bboxHeight should be 0.6')
+
+      // Test obs003: empty observation (no bbox values - should all be null)
+      const obs003 = queryDatabase(
+        dbPath,
+        "SELECT bboxX, bboxY, bboxWidth, bboxHeight FROM observations WHERE observationID = 'obs003'"
+      )
+      assert.equal(obs003.length, 1, 'Should find obs003')
+      assert.equal(obs003[0].bboxX, null, 'obs003: bboxX should be null for empty observation')
+      assert.equal(obs003[0].bboxY, null, 'obs003: bboxY should be null for empty observation')
+      assert.equal(
+        obs003[0].bboxWidth,
+        null,
+        'obs003: bboxWidth should be null for empty observation'
+      )
+      assert.equal(
+        obs003[0].bboxHeight,
+        null,
+        'obs003: bboxHeight should be null for empty observation'
+      )
+
+      // Verify count of observations with valid bboxes (where bboxX IS NOT NULL)
+      const bboxCount = queryDatabase(
+        dbPath,
+        'SELECT COUNT(*) as count FROM observations WHERE bboxX IS NOT NULL'
+      )
+      assert.equal(bboxCount[0].count, 8, 'Should have 8 observations with bounding boxes')
+
+      // Verify count of observations without bboxes
+      const noBboxCount = queryDatabase(
+        dbPath,
+        'SELECT COUNT(*) as count FROM observations WHERE bboxX IS NULL'
+      )
+      assert.equal(
+        noBboxCount[0].count,
+        2,
+        'Should have 2 observations without bounding boxes (Empty observations)'
+      )
+    })
+
     test('should handle scientific name and empty observations correctly', async () => {
       const studyId = 'test-camtrap-taxonomy'
       await importCamTrapDatasetWithPath(testCamTrapDataPath, testBiowatchDataPath, studyId)

--- a/test/data/camtrap/observations.csv
+++ b/test/data/camtrap/observations.csv
@@ -1,11 +1,11 @@
-observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,classificationProbability,count
-obs001,media001,deploy001,event001,2023-03-20T14:30:15Z,2023-03-20T14:30:45Z,Cervus elaphus,Red Deer,0.95,2
-obs002,media002,deploy001,event002,2023-03-25T08:45:22Z,2023-03-25T08:45:52Z,Sus scrofa,Wild Boar,0.87,1
-obs003,media003,deploy001,event003,2023-04-10T16:20:10Z,2023-04-10T16:20:40Z,,Empty,1.0,0
-obs004,media004,deploy002,event004,2023-04-05T11:15:30Z,2023-04-05T11:16:00Z,Lepus europaeus,European Hare,0.92,1
-obs005,media005,deploy002,event005,2023-04-20T07:55:45Z,2023-04-20T07:56:15Z,Vulpes vulpes,Red Fox,0.89,1
-obs006,media006,deploy002,event006,2023-05-15T19:30:12Z,2023-05-15T19:30:42Z,Capreolus capreolus,Roe Deer,0.93,3
-obs007,media007,deploy003,event007,2023-05-10T12:10:18Z,2023-05-10T12:10:48Z,Castor fiber,Eurasian Beaver,0.91,1
-obs008,media008,deploy003,event008,2023-06-01T15:45:33Z,2023-06-01T15:46:03Z,Meles meles,European Badger,0.88,1
-obs009,media009,deploy003,event009,2023-06-20T09:25:27Z,2023-06-20T09:25:57Z,,Empty,1.0,0
-obs010,media010,deploy001,event010,2023-05-30T18:15:40Z,2023-05-30T18:16:10Z,Sciurus vulgaris,Red Squirrel,0.85,2
+observationID,mediaID,deploymentID,eventID,eventStart,eventEnd,scientificName,commonName,classificationProbability,count,bboxX,bboxY,bboxWidth,bboxHeight
+obs001,media001,deploy001,event001,2023-03-20T14:30:15Z,2023-03-20T14:30:45Z,Cervus elaphus,Red Deer,0.95,2,0.1,0.2,0.3,0.4
+obs002,media002,deploy001,event002,2023-03-25T08:45:22Z,2023-03-25T08:45:52Z,Sus scrofa,Wild Boar,0.87,1,0,0.5,0.25,0.35
+obs003,media003,deploy001,event003,2023-04-10T16:20:10Z,2023-04-10T16:20:40Z,,Empty,1.0,0,,,,
+obs004,media004,deploy002,event004,2023-04-05T11:15:30Z,2023-04-05T11:16:00Z,Lepus europaeus,European Hare,0.92,1,0.15,0,0.2,0.3
+obs005,media005,deploy002,event005,2023-04-20T07:55:45Z,2023-04-20T07:56:15Z,Vulpes vulpes,Red Fox,0.89,1,0.5,0.5,0.4,0.4
+obs006,media006,deploy002,event006,2023-05-15T19:30:12Z,2023-05-15T19:30:42Z,Capreolus capreolus,Roe Deer,0.93,3,0,0,0.5,0.6
+obs007,media007,deploy003,event007,2023-05-10T12:10:18Z,2023-05-10T12:10:48Z,Castor fiber,Eurasian Beaver,0.91,1,0.25,0.3,0.35,0.45
+obs008,media008,deploy003,event008,2023-06-01T15:45:33Z,2023-06-01T15:46:03Z,Meles meles,European Badger,0.88,1,0.6,0.7,0.2,0.15
+obs009,media009,deploy003,event009,2023-06-20T09:25:27Z,2023-06-20T09:25:57Z,,Empty,1.0,0,,,,
+obs010,media010,deploy001,event010,2023-05-30T18:15:40Z,2023-05-30T18:16:10Z,Sciurus vulgaris,Red Squirrel,0.85,2,0.3,0.4,0.15,0.2


### PR DESCRIPTION
## Summary

- Fix bug where bounding boxes with `bboxX=0` or `bboxY=0` were not being stored in the database during camtrapDP import
- Add regression tests covering bbox edge cases

## Problem

When importing a camtrapDP dataset, observations with `bboxX=0` or `bboxY=0` had their bbox coordinates incorrectly converted to `NULL`. This caused these bboxes to be missing in the media tab.

**Root cause:** The bbox parsing logic used JavaScript's falsy check (`|| null`), which treated `0` as falsy:
```javascript
bboxX: parseFloat(row.bboxX || row.bbox_x) || null  // 0 || null = null
```

## Solution

- Added `parseFloatOrNull()` helper function that properly handles `0` as a valid value
- Updated bbox parsing to use nullish coalescing (`??`) instead of OR (`||`)
- Added comprehensive regression test covering:
  - Normal bbox values
  - `bboxX=0` edge case
  - `bboxY=0` edge case
  - Both `bboxX=0` AND `bboxY=0`
  - Empty observations (all bbox fields null)

## Test plan

- [x] Run `npm test` - all tests pass
- [x] Verify observations with `bboxX=0` are now stored with `bboxX=0` (not NULL)
- [x] Re-import a camtrapDP dataset and verify bboxes display correctly in media tab