### PR TITLE
feat: add right-click context menu for studies in sidebar

### DIFF
--- a/src/renderer/src/DeleteStudyModal.jsx
+++ b/src/renderer/src/DeleteStudyModal.jsx
@@ -44,7 +44,7 @@ function DeleteStudyModal({ isOpen, onConfirm, onCancel, studyName }) {
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000]"
       onClick={onCancel}
     >
       <div


### PR DESCRIPTION
## Summary
- Add right-click context menu on study items in the left sidebar with Rename and Delete actions
- Rename triggers inline editing directly in the sidebar (Enter to save, Escape to cancel)
- Delete opens the existing DeleteStudyModal for confirmation
- Fix DeleteStudyModal z-index to appear above Leaflet maps

## Test plan
- [x] Right-click on a study in the sidebar to open context menu
- [x] Click "Rename" and verify inline input appears with text selected
- [x] Press Enter to save or Escape to cancel rename
- [x] Click "Delete" and verify the confirmation modal appears above any map content
- [x] Confirm deletion works as expected