### PR TITLE
feat: persist image EXIF data to database

### DIFF
--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -73,7 +73,7 @@ dataset/
 | `filePublic` | boolean | Whether file is publicly accessible |
 | `fileMediatype` | string | MIME type (e.g., `image/jpeg`, `video/mp4`) |
 | `fileName` | string | Original file name |
-| `exifData` | object | EXIF/metadata as JSON (e.g., `{"fps": 30, "duration": 60}` for videos) |
+| `exifData` | object | EXIF/metadata as JSON. For images: camera settings, GPS, timestamps (e.g., `{"Make": "RECONYX", "Model": "HP2X", "DateTimeOriginal": "2024-03-20T14:30:15.000Z", "latitude": 46.77, "longitude": 6.64}`). For videos: `{"fps": 30, "duration": 60, "frameCount": 1800}` |
 
 ### observations.csv
 

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -84,6 +84,8 @@ Media file metadata.
 | `fileName` | TEXT | | Original file name |
 | `importFolder` | TEXT | | Source import folder |
 | `folderName` | TEXT | | Subfolder name within import |
+| `fileMediatype` | TEXT | | IANA media type (e.g., `image/jpeg`, `video/mp4`) |
+| `exifData` | TEXT | JSON | EXIF/metadata as JSON (see below) |
 
 ```javascript
 export const media = sqliteTable('media', {
@@ -93,8 +95,41 @@ export const media = sqliteTable('media', {
   filePath: text('filePath'),
   fileName: text('fileName'),
   importFolder: text('importFolder'),
-  folderName: text('folderName')
+  folderName: text('folderName'),
+  fileMediatype: text('fileMediatype').default('image/jpeg'),
+  exifData: text('exifData', { mode: 'json' })
 })
+```
+
+#### exifData Field
+
+The `exifData` field stores extracted metadata as JSON. All Date values are serialized as ISO 8601 strings.
+
+**For images** (full EXIF extracted via exifr):
+```json
+{
+  "Make": "RECONYX",
+  "Model": "HP2X",
+  "DateTimeOriginal": "2024-03-20T14:30:15.000Z",
+  "ExposureTime": 0.004,
+  "FNumber": 2.8,
+  "ISO": 400,
+  "FocalLength": 3.1,
+  "latitude": 46.7712,
+  "longitude": 6.6413,
+  "GPSAltitude": 1250,
+  "ImageWidth": 3840,
+  "ImageHeight": 2160
+}
+```
+
+**For videos** (extracted from ML model response):
+```json
+{
+  "fps": 30,
+  "duration": 60.5,
+  "frameCount": 1815
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Store full EXIF metadata for images in the `exifData` JSON column, mirroring how video metadata is already stored
- Add `serializeExifData()` helper to convert Date objects to ISO strings for JSON storage
- Update documentation with `exifData` and `fileMediatype` column descriptions

## Changes

- `src/main/importer.js`: Add serialization helper and persist EXIF data in `processMediaDeployment()`
- `docs/database-schema.md`: Document `exifData` and `fileMediatype` columns with JSON format examples
- `docs/data-formats.md`: Expand `exifData` description to include image EXIF example

## Test plan

- [x] Import folder with images containing EXIF data
- [x] Verify `exifData` is populated for all images (244/244 images have exifData)
- [x] Verify Date fields are serialized as ISO 8601 strings
- [x] Lint and format checks pass