### PR TITLE
feat: persist media tab boxes and grid display options per study

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -2095,17 +2095,37 @@ function Gallery({ species, dateRange, timeRange }) {
   const loaderRef = useRef(null)
   const PAGE_SIZE = 15
 
-  // Grid controls state
-  const [showThumbnailBboxes, setShowThumbnailBboxes] = useState(false)
-  const [gridColumns, setGridColumns] = useState(3)
-  const [controlsExpanded, setControlsExpanded] = useState(false)
-
   // Sequence grouping state
   const [currentSequence, setCurrentSequence] = useState(null)
   const [currentSequenceIndex, setCurrentSequenceIndex] = useState(0)
 
   const { id } = useParams()
   const queryClient = useQueryClient()
+
+  // Grid controls state - persisted per study in localStorage
+  const showBboxesKey = `showBboxes:${id}`
+  const [showThumbnailBboxes, setShowThumbnailBboxes] = useState(() => {
+    const saved = localStorage.getItem(showBboxesKey)
+    return saved !== null ? JSON.parse(saved) : false
+  })
+
+  const gridColumnsKey = `gridColumns:${id}`
+  const [gridColumns, setGridColumns] = useState(() => {
+    const saved = localStorage.getItem(gridColumnsKey)
+    return saved !== null ? Number(saved) : 3
+  })
+
+  const [controlsExpanded, setControlsExpanded] = useState(false)
+
+  // Persist showThumbnailBboxes to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem(showBboxesKey, JSON.stringify(showThumbnailBboxes))
+  }, [showThumbnailBboxes, showBboxesKey])
+
+  // Persist gridColumns to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem(gridColumnsKey, gridColumns.toString())
+  }, [gridColumns, gridColumnsKey])
 
   // Check if study has observations with eventIDs (for default slider value)
   const { data: hasEventIDs = false } = useQuery({


### PR DESCRIPTION
## Summary
- Persist the "Boxes" toggle state per study in localStorage
- Persist the grid column density (3x/4x/5x) per study in localStorage
- Settings are now remembered when navigating away and back to the media tab

## Implementation
Follows the existing pattern used for `sequenceGap` persistence:
- `showBboxes:{studyId}` - stores boxes toggle state (boolean)
- `gridColumns:{studyId}` - stores grid density (3, 4, or 5)

## Test plan
- [x] Navigate to a study's media tab
- [x] Toggle boxes ON → navigate away → return → boxes should still be ON
- [x] Change grid to 5x → navigate away → return → grid should still be 5x
- [x] Test with multiple studies - each should have independent settings
- [x] Refresh the app - settings should persist