### PR TITLE
fix: app not quitting on macos

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1295,8 +1295,8 @@ app.on('before-quit', async (event) => {
     log.error('[Shutdown] Error during graceful shutdown:', error)
   }
 
-  // Now actually quit
-  app.quit()
+  // Now actually quit, we call exit so we don't re-enter this handler
+  app.exit()
 })
 
 // Handle Unix/macOS termination signals for graceful shutdown


### PR DESCRIPTION
app.quit will call the same before-quit handler in a pseudo look.

app.exit makes sure that the second time (after preventing the initial quit), we exit the app