### PR TITLE
feat: extract EXIF data to populate deployment metadata

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -55,6 +55,11 @@ Camera trap deployment information.
 | `deploymentEnd` | TEXT | | ISO 8601 datetime |
 | `latitude` | REAL | | Decimal degrees |
 | `longitude` | REAL | | Decimal degrees |
+| `cameraModel` | TEXT | | Camera make-model from EXIF (CamtrapDP format: "Make-Model") |
+| `cameraID` | TEXT | | Camera serial number from EXIF |
+| `coordinateUncertainty` | INTEGER | | GPS horizontal error in meters from EXIF |
+
+The EXIF-derived fields (`cameraModel`, `cameraID`, `coordinateUncertainty`) are automatically populated during import using mode aggregation (most common value) across all media in the deployment. This ensures CamtrapDP compliance.
 
 ```javascript
 // src/main/db/schema.js
@@ -65,7 +70,11 @@ export const deployments = sqliteTable('deployments', {
   deploymentStart: text('deploymentStart'),
   deploymentEnd: text('deploymentEnd'),
   latitude: real('latitude'),
-  longitude: real('longitude')
+  longitude: real('longitude'),
+  // CamtrapDP fields extracted from EXIF
+  cameraModel: text('cameraModel'),
+  cameraID: text('cameraID'),
+  coordinateUncertainty: integer('coordinateUncertainty')
 })
 ```
 

--- a/src/main/camtrap.js
+++ b/src/main/camtrap.js
@@ -280,6 +280,16 @@ function transformDeploymentRow(row) {
     return null
   }
 
+  // Parse coordinateUncertainty as integer if present
+  let coordinateUncertainty = null
+  const rawUncertainty = row.coordinateUncertainty || row.coordinate_uncertainty
+  if (rawUncertainty != null && rawUncertainty !== '') {
+    const parsed = parseInt(rawUncertainty, 10)
+    if (!isNaN(parsed) && parsed >= 1) {
+      coordinateUncertainty = parsed
+    }
+  }
+
   const transformed = {
     deploymentID,
     locationID: row.locationID || row.location_id || null,
@@ -287,7 +297,11 @@ function transformDeploymentRow(row) {
     deploymentStart: transformDateField(row.deploymentStart || row.deployment_start),
     deploymentEnd: transformDateField(row.deploymentEnd || row.deployment_end),
     latitude: parseFloat(row.latitude) || null,
-    longitude: parseFloat(row.longitude) || null
+    longitude: parseFloat(row.longitude) || null,
+    // CamtrapDP EXIF fields
+    cameraModel: row.cameraModel || row.camera_model || null,
+    cameraID: row.cameraID || row.camera_id || null,
+    coordinateUncertainty
   }
 
   log.debug('Transformed deployment row:', transformed)

--- a/src/main/db/migrations/0010_add_deployment_exif_fields.sql
+++ b/src/main/db/migrations/0010_add_deployment_exif_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `deployments` ADD `cameraModel` text;--> statement-breakpoint
+ALTER TABLE `deployments` ADD `cameraID` text;--> statement-breakpoint
+ALTER TABLE `deployments` ADD `coordinateUncertainty` integer;

--- a/src/main/db/migrations/meta/0010_snapshot.json
+++ b/src/main/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,715 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "134a1f75-1d62-4e42-89ac-79c9a6771783",
+  "prevId": "43568cd4-3199-40eb-a779-71972278eecd",
+  "tables": {
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationID": {
+          "name": "locationID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationName": {
+          "name": "locationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentStart": {
+          "name": "deploymentStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentEnd": {
+          "name": "deploymentEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cameraModel": {
+          "name": "cameraModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cameraID": {
+          "name": "cameraID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coordinateUncertainty": {
+          "name": "coordinateUncertainty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deployments_locationID": {
+          "name": "idx_deployments_locationID",
+          "columns": [
+            "locationID"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importFolder": {
+          "name": "importFolder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folderName": {
+          "name": "folderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileMediatype": {
+          "name": "fileMediatype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image/jpeg'"
+        },
+        "exifData": {
+          "name": "exifData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_deploymentID": {
+          "name": "idx_media_deploymentID",
+          "columns": [
+            "deploymentID"
+          ],
+          "isUnique": false
+        },
+        "idx_media_timestamp": {
+          "name": "idx_media_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_media_filePath": {
+          "name": "idx_media_filePath",
+          "columns": [
+            "filePath"
+          ],
+          "isUnique": false
+        },
+        "idx_media_folderName": {
+          "name": "idx_media_folderName",
+          "columns": [
+            "folderName"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_deploymentID_deployments_deploymentID_fk": {
+          "name": "media_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "media",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata": {
+      "name": "metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "importerName": {
+          "name": "importerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributors": {
+          "name": "contributors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_outputs": {
+      "name": "model_outputs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runID": {
+          "name": "runID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawOutput": {
+          "name": "rawOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_model_outputs_runID": {
+          "name": "idx_model_outputs_runID",
+          "columns": [
+            "runID"
+          ],
+          "isUnique": false
+        },
+        "model_outputs_mediaID_runID_unique": {
+          "name": "model_outputs_mediaID_runID_unique",
+          "columns": [
+            "mediaID",
+            "runID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_outputs_mediaID_media_mediaID_fk": {
+          "name": "model_outputs_mediaID_media_mediaID_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_outputs_runID_model_runs_id_fk": {
+          "name": "model_outputs_runID_model_runs_id_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "model_runs",
+          "columnsFrom": [
+            "runID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_runs": {
+      "name": "model_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelID": {
+          "name": "modelID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelVersion": {
+          "name": "modelVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "importPath": {
+          "name": "importPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_model_runs_startedAt": {
+          "name": "idx_model_runs_startedAt",
+          "columns": [
+            "startedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observations": {
+      "name": "observations",
+      "columns": {
+        "observationID": {
+          "name": "observationID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventStart": {
+          "name": "eventStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventEnd": {
+          "name": "eventEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scientificName": {
+          "name": "scientificName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observationType": {
+          "name": "observationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commonName": {
+          "name": "commonName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationProbability": {
+          "name": "classificationProbability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifeStage": {
+          "name": "lifeStage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "behavior": {
+          "name": "behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxX": {
+          "name": "bboxX",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxY": {
+          "name": "bboxY",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxWidth": {
+          "name": "bboxWidth",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxHeight": {
+          "name": "bboxHeight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detectionConfidence": {
+          "name": "detectionConfidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modelOutputID": {
+          "name": "modelOutputID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationMethod": {
+          "name": "classificationMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classifiedBy": {
+          "name": "classifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationTimestamp": {
+          "name": "classificationTimestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_observations_mediaID": {
+          "name": "idx_observations_mediaID",
+          "columns": [
+            "mediaID"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_deploymentID": {
+          "name": "idx_observations_deploymentID",
+          "columns": [
+            "deploymentID"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_scientificName": {
+          "name": "idx_observations_scientificName",
+          "columns": [
+            "scientificName"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_eventStart": {
+          "name": "idx_observations_eventStart",
+          "columns": [
+            "eventStart"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_scientificName_eventStart": {
+          "name": "idx_observations_scientificName_eventStart",
+          "columns": [
+            "scientificName",
+            "eventStart"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_mediaID_deploymentID": {
+          "name": "idx_observations_mediaID_deploymentID",
+          "columns": [
+            "mediaID",
+            "deploymentID"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "observations_mediaID_media_mediaID_fk": {
+          "name": "observations_mediaID_media_mediaID_fk",
+          "tableFrom": "observations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_deploymentID_deployments_deploymentID_fk": {
+          "name": "observations_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "observations",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_modelOutputID_model_outputs_id_fk": {
+          "name": "observations_modelOutputID_model_outputs_id_fk",
+          "tableFrom": "observations",
+          "tableTo": "model_outputs",
+          "columnsFrom": [
+            "modelOutputID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/main/db/migrations/meta/_journal.json
+++ b/src/main/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1765378641492,
       "tag": "0009_add_indices",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1765450015870,
+      "tag": "0010_add_deployment_exif_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.js
+++ b/src/main/db/schema.js
@@ -9,7 +9,11 @@ export const deployments = sqliteTable(
     deploymentStart: text('deploymentStart'),
     deploymentEnd: text('deploymentEnd'),
     latitude: real('latitude'),
-    longitude: real('longitude')
+    longitude: real('longitude'),
+    // CamtrapDP fields extracted from EXIF
+    cameraModel: text('cameraModel'), // "Make-Model" format per CamtrapDP spec
+    cameraID: text('cameraID'), // Camera serial number from EXIF
+    coordinateUncertainty: integer('coordinateUncertainty') // GPS horizontal error in meters
   },
   (table) => [index('idx_deployments_locationID').on(table.locationID)]
 )

--- a/src/main/export.js
+++ b/src/main/export.js
@@ -704,7 +704,10 @@ function generateDataPackage(studyId, studyName, metadata = null) {
             { name: 'latitude', type: 'number' },
             { name: 'longitude', type: 'number' },
             { name: 'deploymentStart', type: 'datetime' },
-            { name: 'deploymentEnd', type: 'datetime' }
+            { name: 'deploymentEnd', type: 'datetime' },
+            { name: 'cameraModel', type: 'string' },
+            { name: 'cameraID', type: 'string' },
+            { name: 'coordinateUncertainty', type: 'integer' }
           ]
         }
       },
@@ -835,7 +838,10 @@ export async function exportCamtrapDP(studyId, options = {}) {
         latitude: deployments.latitude,
         longitude: deployments.longitude,
         deploymentStart: deployments.deploymentStart,
-        deploymentEnd: deployments.deploymentEnd
+        deploymentEnd: deployments.deploymentEnd,
+        cameraModel: deployments.cameraModel,
+        cameraID: deployments.cameraID,
+        coordinateUncertainty: deployments.coordinateUncertainty
       })
       .from(deployments)
       .orderBy(asc(deployments.deploymentID))
@@ -852,7 +858,10 @@ export async function exportCamtrapDP(studyId, options = {}) {
         deploymentStart: d.deploymentStart,
         deploymentEnd: d.deploymentEnd,
         locationID: d.locationID,
-        locationName: d.locationName
+        locationName: d.locationName,
+        cameraModel: d.cameraModel,
+        cameraID: d.cameraID,
+        coordinateUncertainty: d.coordinateUncertainty
       }
 
       // Sanitize values to comply with CamtrapDP spec
@@ -1153,7 +1162,10 @@ export async function exportCamtrapDP(studyId, options = {}) {
       'latitude',
       'longitude',
       'deploymentStart',
-      'deploymentEnd'
+      'deploymentEnd',
+      'cameraModel',
+      'cameraID',
+      'coordinateUncertainty'
     ])
 
     const mediaCSV = toCSV(mediaRows, [

--- a/src/main/export/sanitizers.js
+++ b/src/main/export/sanitizers.js
@@ -246,7 +246,13 @@ export function sanitizeDeployment(row) {
 
     // Optional fields
     locationID: row.locationID || null,
-    locationName: row.locationName || null
+    locationName: row.locationName || null,
+
+    // EXIF-extracted CamtrapDP fields
+    cameraModel: row.cameraModel || null,
+    cameraID: row.cameraID || null,
+    coordinateUncertainty:
+      row.coordinateUncertainty != null ? Math.round(row.coordinateUncertainty) : null
   }
 }
 


### PR DESCRIPTION
## Summary

Automatically populate CamtrapDP deployment fields from EXIF data extracted during image import:

- `cameraModel` - Camera make and model in "Make-Model" format (e.g., "RECONYX-HP2X")
- `cameraID` - Camera serial number from EXIF
- `coordinateUncertainty` - GPS horizontal positioning error in meters

Uses **mode aggregation** (most common value) across all media in a deployment to handle cases where cameras may be swapped mid-deployment.

## Changes

- **Database schema**: Added 3 new columns to `deployments` table
- **Import flow**: Extract EXIF metadata and aggregate after processing completes
- **Export**: Include new fields in CamtrapDP export
- **Import**: Preserve fields when importing CamtrapDP datasets

## Test plan

- [x] Verify migration applies correctly to existing databases
- [x] Verify `cameraModel` is populated from Make+Model EXIF fields
- [x] Verify NULL values when EXIF fields are not available (expected behavior)
- [x] Test CamtrapDP export includes new fields
- [x] Test CamtrapDP import preserves new fields