### PR TITLE
fix: overview map showing only one deployment marker

### DIFF
--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -146,10 +146,10 @@ export async function getDeployments(dbPath) {
         latitude: subquery.latitude
       })
       .from(subquery)
-      .groupBy(subquery.locationID)
+      .groupBy(subquery.latitude, subquery.longitude)
 
     const elapsedTime = Date.now() - startTime
-    log.info(`Retrieved distinct deployments: ${result.length} locations found in ${elapsedTime}ms`)
+    log.info(`Retrieved distinct deployments: ${result.length} unique coordinates found in ${elapsedTime}ms`)
 
     return result
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fixed overview map displaying only one marker instead of all deployment locations
- Changed query to group by coordinates (latitude, longitude) instead of locationID
- When locationID is NULL/empty for all deployments, the previous GROUP BY collapsed all rows into one

## Test plan
- [x] Import a study with multiple deployments at different coordinates
- [x] Verify overview map shows all unique coordinate locations
- [x] Verify Activity and Deployments tabs still work correctly