### PR TITLE
feat: add placeholder for unavailable media in modal

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -478,6 +478,7 @@ function ImageModal({
   // Draw mode state for creating new bboxes
   const [isDrawMode, setIsDrawMode] = useState(false)
   const [videoError, setVideoError] = useState(false)
+  const [imageError, setImageError] = useState(false)
   // Transcoding state: 'idle' | 'checking' | 'transcoding' | 'ready' | 'error'
   const [transcodeState, setTranscodeState] = useState('idle')
   const [transcodeProgress, setTranscodeProgress] = useState(0)
@@ -502,6 +503,7 @@ function ImageModal({
     setShowDatePicker(false)
     setError(null)
     setVideoError(false)
+    setImageError(false)
     // Reset transcoding state
     setTranscodeState('idle')
     setTranscodeProgress(0)
@@ -1308,6 +1310,12 @@ function ImageModal({
                   }}
                 />
               )
+            ) : imageError ? (
+              <div className="flex flex-col items-center justify-center bg-gray-800 text-gray-400 aspect-[4/3] min-w-[70vw] max-h-[calc(90vh-120px)]">
+                <CameraOff size={128} />
+                <span className="mt-4 text-lg font-medium">Image not available</span>
+                <span className="mt-2 text-sm">{media.fileName}</span>
+              </div>
             ) : (
               <>
                 <img
@@ -1315,6 +1323,7 @@ function ImageModal({
                   src={constructImageUrl(media.filePath)}
                   alt={media.fileName || `Media ${media.mediaID}`}
                   className="max-w-full max-h-[calc(90vh-120px)] w-auto h-auto object-contain"
+                  onError={() => setImageError(true)}
                 />
                 {/* Bbox overlay - editable bounding boxes (only for images) */}
                 {showBboxes && hasBboxes && (


### PR DESCRIPTION
## Summary
- Add a placeholder with CameraOff icon when clicking on media that is not available
- Matches the existing placeholder style used in thumbnail grid cells
- Uses 4:3 aspect ratio consistent with media cells

## Test plan
- Find a media entry pointing to a non-existent file
- Click on the thumbnail showing the placeholder
- Verify the modal displays the same style placeholder with "Image not available" message