### PR TITLE
feat: group deployments by location in deployments tab

### DIFF
--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -477,9 +477,9 @@ const LocationGroupHeader = memo(function LocationGroupHeader({
   return (
     <div
       onClick={handleClick}
-      className={`flex gap-4 items-center py-3 px-2 hover:bg-gray-50 cursor-pointer border-b border-gray-200 transition-all duration-200 ${
+      className={`flex gap-4 items-center py-4 hover:bg-gray-50 cursor-pointer px-2 border-b border-gray-200 transition-all duration-200 ${
         isSelected
-          ? 'bg-blue-50 border-l-4 border-l-blue-500 pl-3'
+          ? 'bg-blue-50 border-l-4 border-l-blue-500 pl-1'
           : 'border-l-4 border-l-transparent'
       }`}
     >
@@ -544,7 +544,7 @@ const GroupedDeploymentRow = memo(function GroupedDeploymentRow({
   percentile90Count
 }) {
   return (
-    <div className="pl-6 bg-gray-50/50">
+    <div className="ml-6">
       <DeploymentRow
         location={location}
         isSelected={isSelected}
@@ -769,6 +769,7 @@ function LocationsList({
               <div
                 key={virtualRow.key}
                 data-index={virtualRow.index}
+                ref={rowVirtualizer.measureElement}
                 style={{
                   position: 'absolute',
                   top: 0,


### PR DESCRIPTION
## Summary

- Add collapsible location groups for deployments sharing the same location
- Multi-deployment locations appear first as expandable groups (collapsed by default)
- Single-deployment locations render as simple rows without grouping wrapper
- Clicking a map marker expands the corresponding location group in the list

## Changes

- Add `LocationGroupHeader` component with aggregated activity timeline across all deployments
- Add `GroupedDeploymentRow` wrapper for nested deployment rows
- Add utility functions `aggregatePeriods` and `groupDeploymentsByLocation`
- Update virtualizer to handle variable-height rows with `measureElement`
- Connect map marker clicks to expand location groups

## Test plan

- [x] Verify groups are collapsed by default
- [x] Verify clicking chevron expands/collapses group
- [x] Verify clicking map marker expands corresponding group
- [x] Verify single-deployment locations show as simple rows
- [x] Verify hover and selection states work correctly
- [x] Verify no row overlap when scrolling through grouped items