### PR TITLE
fix: add Python 3.11 setup for macOS CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Setup Python for node-gyp (macOS)
+        if: matrix.os == 'macos-latest'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - name: Install Node.js dependencies
         run: |
           npm install


### PR DESCRIPTION
## Summary

Fix macOS CI build failure caused by Python 3.14 removing `distutils` module.

## Root Cause

- GitHub Actions `macos-latest` runner now uses Python 3.14.0
- Python 3.12+ removed `distutils` from the standard library
- `node-gyp` (used by `better-sqlite3` native compilation) requires `distutils`

## Fix

Add `actions/setup-python@v5` with Python 3.11 before `npm install` on macOS builds.

## Test plan

- [ ] Verify macOS CI build passes
- [ ] Verify Linux and Windows builds are unaffected