### PR TITLE
feat: cache remote media for faster navigation

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: https: http:; media-src 'self' local-file:"
+      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: cached-media: https: http:; media-src 'self' local-file: cached-media:"
     />
   </head>
 

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -2351,7 +2351,7 @@ function Gallery({ species, dateRange, timeRange }) {
 
   const constructImageUrl = (fullFilePath) => {
     if (fullFilePath.startsWith('http')) {
-      return fullFilePath
+      return `cached-media://get?url=${encodeURIComponent(fullFilePath)}`
     }
 
     return `local-file://get?path=${encodeURIComponent(fullFilePath)}`

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -9,7 +9,9 @@ import { ChevronLeft, ChevronRight, CameraOff, X } from 'lucide-react'
  */
 function constructImageUrl(fullFilePath) {
   if (!fullFilePath) return ''
-  if (fullFilePath.startsWith('http')) return fullFilePath
+  if (fullFilePath.startsWith('http')) {
+    return `cached-media://get?url=${encodeURIComponent(fullFilePath)}`
+  }
   return `local-file://get?path=${encodeURIComponent(fullFilePath)}`
 }
 


### PR DESCRIPTION
## Summary

- Add `cached-media://` protocol handler to cache remote media (HTTP/HTTPS URLs)
- Route remote URLs through the new protocol with `Cache-Control` headers
- Chromium's built-in disk cache handles storage automatically
- Cached media persists across app restarts (30-day expiration)

## Changes

- `src/main/index.js`: Add `registerCachedMediaProtocol()` function using Electron's `net.fetch()`
- `src/renderer/index.html`: Add `cached-media:` to CSP `img-src` and `media-src` directives
- `src/renderer/src/media.jsx`: Route HTTP URLs through `cached-media://`
- `src/renderer/src/ui/BestMediaCarousel.jsx`: Same URL routing change

## How it works

1. Remote URLs rewritten: `https://example.com/img.jpg` → `cached-media://get?url=...`
2. Protocol handler fetches remote file, returns with `Cache-Control: max-age=2592000` (30 days)
3. Chromium caches response to disk automatically
4. Subsequent requests served from cache without network

## Test plan

- [x] Import a dataset with remote media URLs
- [x] Open gallery, navigate to an image
- [x] Navigate away, then back to the same image
- [x] Verify in DevTools Network tab: second request shows "(disk cache)" or instant load
- [x] Restart app, verify cached images still load quickly