### PR TITLE
fix: Linux AppImage sandbox compatibility

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -262,7 +262,18 @@ chmod +x Biowatch-*.AppImage
 ./Biowatch-*.AppImage
 ```
 
-If FUSE issues:
+**SUID sandbox error** ("chrome-sandbox is not configured correctly"):
+```bash
+# Option 1: Run with --no-sandbox flag
+./Biowatch-*.AppImage --no-sandbox
+
+# Option 2: Extract and run
+./Biowatch-*.AppImage --appimage-extract-and-run
+```
+
+Note: Starting from v1.5.0, the app automatically handles this.
+
+**FUSE issues:**
 ```bash
 ./Biowatch-*.AppImage --appimage-extract-and-run
 ```

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -58,6 +58,10 @@ linux:
   maintainer: electronjs.org
   category: Utility
 
+# Linux sandbox fix: creates wrapper script for AppImage compatibility
+# Only runs on Linux builds - see scripts/afterPack.js and docs/development.md
+afterPack: ./scripts/afterPack.js
+
 appImage:
   artifactName: ${name}.${ext}
 npmRebuild: false

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,0 +1,83 @@
+/**
+ * electron-builder afterPack hook to fix SUID sandbox issues on Linux
+ *
+ * PLATFORM: Linux only (skipped on macOS and Windows)
+ *
+ * PROBLEM:
+ * On Linux, Electron requires the chrome-sandbox binary to be owned by root
+ * with SUID bit set (mode 4755). AppImages extract to /tmp where this is
+ * impossible, causing the error:
+ *   "The SUID sandbox helper binary was found, but is not configured correctly."
+ *
+ * This affects systems where unprivileged user namespaces are disabled:
+ * - Ubuntu 24.04+ (restricted by AppArmor)
+ * - Debian (disabled by default)
+ * - Some enterprise Linux distributions
+ *
+ * SOLUTION:
+ * This script creates a wrapper that:
+ * 1. Renames the original binary to <name>.bin
+ * 2. Creates a shell script wrapper with the original name
+ * 3. The wrapper checks kernel settings at runtime and passes --no-sandbox
+ *    only when necessary (unprivileged_userns_clone=0 or apparmor restriction)
+ *
+ * REFERENCES:
+ * - https://github.com/gergof/electron-builder-sandbox-fix
+ * - https://github.com/AppImage/AppImageKit/issues/1414
+ * - https://github.com/electron-userland/electron-builder/issues/5371
+ */
+
+const fs = require('fs/promises')
+const path = require('path')
+
+const log = (message, isError = false) => {
+  const prefix = isError ? '\x1b[31m•\x1b[0m' : '\x1b[34m•\x1b[0m'
+  console.log(`  ${prefix} ${message}`)
+}
+
+const afterPackHook = async (params) => {
+  // Only apply this fix on Linux - macOS and Windows don't have this issue
+  if (params.electronPlatformName !== 'linux') {
+    return
+  }
+
+  log('applying fix for sandboxing on unsupported kernels')
+
+  const executable = path.join(params.appOutDir, params.packager.executableName)
+  const productName = params.packager.appInfo.productName
+  const executableName = params.packager.executableName
+
+  const loaderScript = `#!/usr/bin/env bash
+set -u
+
+UNPRIVILEGED_USERNS_ENABLED=$(cat /proc/sys/kernel/unprivileged_userns_clone 2>/dev/null)
+RESTRICT_UNPRIVILEGED_USERNS=$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null)
+SCRIPT_DIR="$( cd "$( dirname "\${BASH_SOURCE[0]}" )" && pwd )"
+
+!([ "$UNPRIVILEGED_USERNS_ENABLED" != 1 ] || [ "$RESTRICT_UNPRIVILEGED_USERNS" == 1 ])
+APPLY_NO_SANDBOX_FLAG=$?
+
+if [ "$SCRIPT_DIR" == "/usr/bin" ]; then
+	SCRIPT_DIR="/opt/${productName}"
+fi
+
+if [ "$APPLY_NO_SANDBOX_FLAG" == 1 ]; then
+	echo "Note: Running with --no-sandbox since unprivileged_userns_clone is disabled or apparmor_restrict_unprivileged_userns is enabled."
+fi
+
+exec "$SCRIPT_DIR/${executableName}.bin" "$([ "$APPLY_NO_SANDBOX_FLAG" == 1 ] && echo '--no-sandbox')" "$@"
+`
+
+  try {
+    await fs.rename(executable, executable + '.bin')
+    await fs.writeFile(executable, loaderScript)
+    await fs.chmod(executable, 0o755)
+  } catch (e) {
+    log('failed to create loader for sandbox fix: ' + e.message, true)
+    throw new Error('Failed to create loader for sandbox fix')
+  }
+
+  log('sandbox fix successfully applied')
+}
+
+module.exports = afterPackHook


### PR DESCRIPTION
## Summary

- Fix SUID sandbox error when running AppImage on Linux systems with restricted kernel settings
- Add `afterPack` hook that creates a wrapper script for AppImage builds
- The wrapper detects kernel settings at runtime and passes `--no-sandbox` only when necessary

## Problem

On Linux distributions where unprivileged user namespaces are disabled (Ubuntu 24.04+, Debian, some enterprise distros), the AppImage fails with:

```
FATAL:setuid_sandbox_host.cc: The SUID sandbox helper binary was found,
but is not configured correctly.
```

## Solution

The `scripts/afterPack.js` hook (Linux-only, skipped on macOS/Windows):
1. Renames the binary to `biowatch.bin`
2. Creates a shell wrapper that checks `/proc/sys/kernel/unprivileged_userns_clone` at runtime
3. Passes `--no-sandbox` only when the kernel doesn't support unprivileged namespaces

This preserves sandbox security on systems that support it while ensuring compatibility on restricted systems.

## Files changed

- `scripts/afterPack.js` - New electron-builder hook
- `electron-builder.yml` - Reference to afterPack hook
- `docs/development.md` - Linux build documentation
- `docs/troubleshooting.md` - User-facing troubleshooting guide

## Test plan

- [x] Build AppImage on Linux: `npm run build:linux`
- [x] Run AppImage on system with restricted namespaces
- [x] Verify wrapper script passes `--no-sandbox` when needed
- [x] Verify macOS/Windows builds are unaffected