### PR TITLE
fix: add .deb Linux build target for proper icon integration

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -53,10 +53,14 @@ dmg:
 linux:
   target:
     - AppImage
-    # - snap
-    # - deb
+    - deb
   maintainer: electronjs.org
   category: Utility
+  desktop:
+    StartupWMClass: biowatch
+
+deb:
+  artifactName: ${name}_${version}_${arch}.${ext}
 
 # Linux sandbox fix: creates wrapper script for AppImage compatibility
 # Only runs on Linux builds - see scripts/afterPack.js and docs/development.md


### PR DESCRIPTION
## Summary
- Add `.deb` as a Linux build target alongside AppImage
- Fix `StartupWMClass` to match the app's WM_CLASS (`biowatch`)

## Problem
On Linux, the Biowatch icon shows as a generic gear in the taskbar when running the AppImage. This is due to an Electron limitation where `_NET_WM_ICON` is not properly set, and GNOME looks up icons via `WM_CLASS` → `.desktop` file → system icon directories.

## Solution
- Add `.deb` build target which properly installs:
  - `.desktop` file to `/usr/share/applications/`
  - Icons to `/usr/share/icons/hicolor/*/apps/`
- Set `StartupWMClass: biowatch` to match the app's WM_CLASS

## Build outputs
- `biowatch.AppImage` - portable (users can use AppImageLauncher for icon integration)
- `biowatch_1.4.0_amd64.deb` - proper Linux installation with working icons

## Test plan
- [x] Build with `npm run build:linux`
- [x] Install .deb with `sudo dpkg -i dist/biowatch_*.deb`
- [x] Verify icon appears correctly in taskbar/dock