### PR TITLE
chore: migrate from local/speciesnet to local/ml_run

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -241,6 +241,7 @@ export const metadata = sqliteTable('metadata', {
 - `camtrap/datapackage` - CamTrap DP import
 - `wildlife/folder` - Wildlife Insights import
 - `local/images` - Image folder import
+- `local/ml_run` - Local folder with ML model processing
 - `deepfaune/csv` - DeepFaune CSV import
 
 ---

--- a/src/main/db/schemas.js
+++ b/src/main/db/schemas.js
@@ -28,7 +28,7 @@ export const importerNames = [
   'wildlife/folder',
   'deepfaune/csv',
   'local/images',
-  'local/speciesnet',
+  'local/ml_run',
   'gbif/dataset'
 ]
 

--- a/src/main/import/importer.js
+++ b/src/main/import/importer.js
@@ -1266,7 +1266,7 @@ ipcMain.handle(
         title: null,
         description: null,
         created: new Date().toISOString(),
-        importerName: `local/${modelReference.id}`,
+        importerName: 'local/ml_run',
         contributors: null
       }
       await insertMetadata(db, metadataRecord)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1382,7 +1382,7 @@ app.whenReady().then(async () => {
     }
   })
 
-  // Add handler for getting files data for local/speciesnet studies
+  // Add handler for getting files data for local/ml_run studies
   ipcMain.handle('files:get-data', async (_, studyId) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)

--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -1019,7 +1019,7 @@ export async function getDeploymentsActivity(dbPath) {
 }
 
 /**
- * Get files data (directories with image counts and processing progress) for local/speciesnet studies
+ * Get files data (directories with image counts and processing progress) for local/ml_run studies
  * @param {string} dbPath - Path to the SQLite database
  * @returns {Promise<Array>} - Array of directory objects with image counts and processing progress
  */


### PR DESCRIPTION
## Summary

- Change `importerName` for ML-processed local studies from model-specific (`local/speciesnet`) to generic `local/ml_run`
- Model-specific info (modelID, modelVersion, timestamps) is already stored in the `modelRuns` table

## Rationale

The `importerName` was conflating import method with ML model identity. Now:
- `importerName` indicates *how* data was imported (`local/ml_run` = local folder with ML processing)
- `modelRuns` table stores *which* model was used (already implemented)

## Changes

- `src/main/import/importer.js` - Use `'local/ml_run'` instead of template literal
- `src/main/db/schemas.js` - Update valid importer names
- `src/main/index.js` - Update comment
- `src/main/queries.js` - Update comment  
- `docs/database-schema.md` - Add `local/ml_run` to documentation