### PR TITLE
chore: add caching to GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,19 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-22.04]
+        include:
+          - os: windows-latest
+            npm-cache: ~\AppData\Local\npm-cache
+            electron-cache: ~\AppData\Local\electron\Cache
+            electron-builder-cache: ~\AppData\Local\electron-builder\Cache
+          - os: macos-latest
+            npm-cache: ~/.npm
+            electron-cache: ~/Library/Caches/electron
+            electron-builder-cache: ~/Library/Caches/electron-builder
+          - os: ubuntu-22.04
+            npm-cache: ~/.npm
+            electron-cache: ~/.cache/electron
+            electron-builder-cache: ~/.cache/electron-builder
 
     steps:
       - name: Check out Git repository
@@ -28,9 +41,20 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Cache npm and Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ matrix.npm-cache }}
+            ${{ matrix.electron-cache }}
+            ${{ matrix.electron-builder-cache }}
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-electron-
+            ${{ runner.os }}-npm-electron-
+
       - name: Install Node.js dependencies
-        run: |
-          npm install
+        run: npm ci
 
       - name: Build on MacOS
         env:

--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -13,6 +13,19 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-22.04]
+        include:
+          - os: windows-latest
+            npm-cache: ~\AppData\Local\npm-cache
+            electron-cache: ~\AppData\Local\electron\Cache
+            electron-builder-cache: ~\AppData\Local\electron-builder\Cache
+          - os: macos-latest
+            npm-cache: ~/.npm
+            electron-cache: ~/Library/Caches/electron
+            electron-builder-cache: ~/Library/Caches/electron-builder
+          - os: ubuntu-22.04
+            npm-cache: ~/.npm
+            electron-cache: ~/.cache/electron
+            electron-builder-cache: ~/.cache/electron-builder
 
     steps:
       - name: Check out Git repository
@@ -25,9 +38,20 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Cache npm and Electron
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ matrix.npm-cache }}
+            ${{ matrix.electron-cache }}
+            ${{ matrix.electron-builder-cache }}
+          key: ${{ runner.os }}-${{ runner.arch }}-npm-electron-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-npm-electron-
+            ${{ runner.os }}-npm-electron-
+
       - name: Install Node.js dependencies
-        run: |
-          npm install
+        run: npm ci
 
       - name: Build on MacOS
         env:

--- a/.github/workflows/js_lint.yml
+++ b/.github/workflows/js_lint.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Cache ESLint
+        uses: actions/cache@v4
+        with:
+          path: .eslintcache
+          key: eslint-${{ hashFiles('eslint.config.mjs', 'package-lock.json') }}-${{ github.ref_name }}
+          restore-keys: |
+            eslint-${{ hashFiles('eslint.config.mjs', 'package-lock.json') }}-
+            eslint-
+
       - name: Run ESLint
         run: npm run lint
 

--- a/.github/workflows/python_e2e_tests.yml
+++ b/.github/workflows/python_e2e_tests.yml
@@ -29,14 +29,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
-
-      - name: Cache uv dependencies
-        uses: actions/cache@v4
         with:
-          path: ~/.cache/uv
-          key: uv-${{ hashFiles('python-environments/common/uv.lock') }}
-          restore-keys: |
-            uv-
+          enable-cache: true
+          cache-dependency-glob: 'python-environments/common/uv.lock'
 
       - name: Cache ML models
         id: cache-models

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -21,6 +21,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: 'python-environments/common/uv.lock'
 
       - name: Install dependencies
         working-directory: python-environments/common


### PR DESCRIPTION
## Summary

- Add npm + Electron + electron-builder caching to build workflows (3 platforms)
- Enable uv caching in python_lint.yml
- Simplify uv caching in python_e2e_tests.yml (use built-in action cache)
- Add ESLint cache persistence in js_lint.yml

## Details

**Build workflows (`build.yml`, `build_preview.yml`):**
- Cache npm packages, Electron binaries, and electron-builder binaries
- Platform-specific cache paths for Windows/macOS/Linux
- Cache key includes `runner.arch` for ARM vs x64 compatibility
- Changed `npm install` to `npm ci` for deterministic builds

**Python workflows:**
- Use built-in `enable-cache` option in `astral-sh/setup-uv@v4`

**JS lint:**
- Persist `.eslintcache` between runs for incremental linting

## Why caching is safe for catching regressions

The caches **only store downloaded packages**, not installed code or test results:

| Cache | What's cached | What still runs fresh |
|-------|---------------|----------------------|
| npm cache (`~/.npm`) | Downloaded tarballs | `npm ci` still installs fresh `node_modules/` |
| Electron cache | Electron binary downloads | Binary is extracted fresh each run |
| uv cache | Python package downloads | `uv sync` creates fresh venv |
| ESLint cache | Lint results per file | Cache invalidated when `eslint.config.mjs` or `package-lock.json` changes |

**Key points:**
- `npm ci` **deletes** `node_modules/` and reinstalls from scratch every time
- Tests run on freshly installed dependencies, just faster (no network download)
- Cache keys include `package-lock.json` hash - any dependency change invalidates the cache

The cache is essentially a local mirror of npm/PyPI registries, not cached test results or build artifacts.

## Test plan

- [x] First PR run populates caches (cache miss expected)
- [x] Re-run workflows to verify cache hits
- [ ] Check build times improve on subsequent runs