### PR TITLE
feat(README): add badges and installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,9 @@ Biowatch is a free, open-source desktop application for wildlife researchers and
 ## Installation
 
 <p align="center">
-  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch-setup.exe">
-    <img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" />
-  </a>
-  &nbsp;&nbsp;
-  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch.dmg">
-    <img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" />
-  </a>
-  &nbsp;&nbsp;
-  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch.AppImage">
-    <img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" />
-  </a>
-</p>
-
-<p align="center">
-  <a href="https://github.com/earthtoolsmaker/biowatch/releases">View all releases</a>
+  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch-setup.exe"><img src="https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white" alt="Download for Windows" /></a>
+  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch.dmg"><img src="https://img.shields.io/badge/macOS-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download for macOS" /></a>
+  <a href="https://github.com/earthtoolsmaker/biowatch/releases/latest/download/Biowatch.AppImage"><img src="https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black" alt="Download for Linux" /></a>
 </p>
 
 <details>


### PR DESCRIPTION
## Summary

- Add license badge (CC BY-NC 4.0) with link to LICENSE file
- Add JS Lint CI badge for the new linting workflow
- Add Installation section with platform-specific download buttons and instructions

## Changes

### Badges
- License: CC BY-NC 4.0
- JS Lint: GitHub Actions workflow status

### Installation Section
- Three platform download badges (Windows, macOS, Linux) linking to latest release assets
- Collapsible platform-specific instructions:
  - **Windows**: NSIS installer steps
  - **macOS**: DMG installation + Gatekeeper note
  - **Linux**: AppImage and .deb options with sandbox note for Ubuntu 24.04+
- Link to all releases page

## Test plan

- [x] Verify badges render correctly on GitHub
- [x] Verify download links point to correct release assets
- [x] Verify collapsible sections expand/collapse properly