### PR TITLE
Add separate CI preview jobs for Linux deb and AppImage

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -12,7 +12,23 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        include:
+          - os: windows-latest
+            build_script: build:win
+            artifact_name: Biowatch-preview-windows
+            artifact_path: dist/Biowatch-setup.exe
+          - os: macos-latest
+            build_script: build:mac
+            artifact_name: Biowatch-preview-macos
+            artifact_path: dist/Biowatch.dmg
+          - os: ubuntu-22.04
+            build_script: build:linux:appimage:preview
+            artifact_name: Biowatch-preview-linux-appimage
+            artifact_path: dist/*.AppImage
+          - os: ubuntu-22.04
+            build_script: build:linux:deb:preview
+            artifact_name: Biowatch-preview-linux-deb
+            artifact_path: dist/*.deb
 
     steps:
       - name: Check out Git repository
@@ -29,26 +45,17 @@ jobs:
         run: |
           npm install
 
-      - name: Build on MacOS
+      - name: Build application
         env:
-          CSC_LINK: ${{ secrets.APPLE_SIGNING_CERTIFICATE_BASE64 }}
-          CSC_KEY_PASSWORD: ${{ secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        if: matrix.os == 'macos-latest'
-        run: npm run build:mac
-
-      - name: Build on Linux
-        if: matrix.os == 'ubuntu-22.04'
-        run: npm run build:linux
-
-      - name: Build on Windows
-        if: matrix.os == 'windows-latest'
-        run: npm run build:win
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_CERTIFICATE_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
+        run: npm run ${{ matrix.build_script }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: Biowatch-preview-${{matrix.os}}
-          path: dist
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "build:mac": "npm run build && electron-builder --mac --publish always",
     "build:mac:no-sign": "npm run build && electron-builder --mac --publish never --config.mac.identity=null",
     "build:linux": "npm run build && electron-builder --linux --publish always",
+    "build:linux:appimage:preview": "npm run build && electron-builder --linux AppImage --publish never",
+    "build:linux:deb:preview": "npm run build && electron-builder --linux deb --publish never",
     "test": "npm run test:rebuild && node --test test/**/*.test.js && npm run test:rebuild-electron",
     "test:migrations": "npm run test:rebuild && node --test test/migrations.test.js && npm run test:rebuild-electron",
     "test:watch": "npm run test:rebuild && node --test --watch test/**/*.test.js",


### PR DESCRIPTION
## Summary

- Add separate CI preview jobs for Linux `.deb` and `.AppImage` builds
- Each Linux target now runs as an independent job with its own status indicator
- Preview builds use `--publish never` to avoid accidental publishing

## Changes

**package.json**
- Add `build:linux:appimage:preview` script
- Add `build:linux:deb:preview` script

**.github/workflows/build_preview.yml**
- Refactor to matrix-based approach with 4 parallel jobs
- Windows, macOS, Linux AppImage, and Linux deb each run independently
- Upload only the specific artifact per job (smaller downloads)

## PR Preview Artifacts

| Job | Artifact |
|-----|----------|
| Windows | `Biowatch-preview-windows` (.exe) |
| macOS | `Biowatch-preview-macos` (.dmg) |
| Linux AppImage | `Biowatch-preview-linux-appimage` |
| Linux deb | `Biowatch-preview-linux-deb` |