### PR TITLE
feat: remove the drawing bbox option for videos

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1243,25 +1243,27 @@ function ImageModal({
           </button>
         )}
 
-        {/* Add bbox button */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            setIsDrawMode(true)
-            setSelectedBboxId(null)
-            setShowSpeciesSelector(false)
-            setShowBboxes(true) // Ensure bboxes are visible when adding
-          }}
-          className={`absolute top-0 z-10 rounded-full p-2 transition-colors ${
-            hasBboxes ? 'right-36' : 'right-24'
-          } ${
-            isDrawMode ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-white hover:bg-gray-100'
-          }`}
-          aria-label="Add new bounding box"
-          title="Add new detection (click and drag on image)"
-        >
-          <Plus size={24} />
-        </button>
+        {/* Add bbox button - only for images (not videos) */}
+        {!isVideoMedia(media) && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setIsDrawMode(true)
+              setSelectedBboxId(null)
+              setShowSpeciesSelector(false)
+              setShowBboxes(true) // Ensure bboxes are visible when adding
+            }}
+            className={`absolute top-0 z-10 rounded-full p-2 transition-colors ${
+              hasBboxes ? 'right-36' : 'right-24'
+            } ${
+              isDrawMode ? 'bg-blue-500 text-white hover:bg-blue-600' : 'bg-white hover:bg-gray-100'
+            }`}
+            aria-label="Add new bounding box"
+            title="Add new detection (click and drag on image)"
+          >
+            <Plus size={24} />
+          </button>
+        )}
 
         <div
           className="bg-white rounded-lg overflow-hidden shadow-2xl max-h-[90vh] flex flex-col max-w-full"


### PR DESCRIPTION
## Summary

- Hide the bounding box drawing button ("+") when viewing video media in the media tab
- Videos do not support bbox annotations, so this option should not be shown

## Changes

- Wrapped the "Add bbox button" with a conditional `!isVideoMedia(media)` check in `src/renderer/src/media.jsx`

## Test plan

- [x] Open an image in the media modal - verify the "+" button is visible
- [x] Open a video in the media modal - verify the "+" button is NOT visible
- [x] Navigate from an image to a video - verify the button disappears
- [x] Navigate from a video back to an image - verify the button reappears