### PR TITLE
fix: remove stray colon in Activity tab

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -452,8 +452,7 @@ export default function Activity({ studyData, studyId }) {
                     timeRange.end
                   }
                 />
-              )}{' '}
-              :
+              )}
               {heatmapStatus === 'noData' && !isHeatmapLoading && (
                 <PlaceholderMap
                   title="No Species Location Data"


### PR DESCRIPTION
## Summary
- Removes a stray `:` character that was being rendered as text between the map and temporal distributions in the Activity tab

## Test plan
- [x] Open the Activity tab
- [x] Verify no colon appears between the map and temporal distribution sections