### PR TITLE
fix: grid dimensions when not so many elements

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -2547,7 +2547,7 @@ function Gallery({ species, dateRange, timeRange }) {
         />
 
         {/* Grid */}
-        <div className="flex flex-wrap gap-[12px] flex-1 overflow-auto p-3">
+        <div className="flex flex-wrap gap-[12px] flex-1 overflow-auto p-3 content-start">
           {groupedMedia.map((sequence) => {
             const isMultiItem = sequence.items.length > 1
 


### PR DESCRIPTION
## Summary
- Fix media grid cards stretching vertically when there are few items
- Add `content-start` to prevent flex lines from stretching to fill container

## Test plan
- [x] Open the media tab with only 2-3 items
- [x] Verify cards maintain natural height instead of stretching vertically