### PR TITLE
fix: disable dark mode styling for study tabs

### DIFF
--- a/src/renderer/src/components/Tab.jsx
+++ b/src/renderer/src/components/Tab.jsx
@@ -14,8 +14,8 @@ export function Tab({ to, icon: Icon, children, end = false }) {
       className={({ isActive }) =>
         classNames(
           isActive
-            ? 'border-blue-600 text-blue-600 dark:border-blue-400 dark:text-blue-400'
-            : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700 dark:text-gray-400 dark:hover:border-white/20 dark:hover:text-gray-200',
+            ? 'border-blue-600 text-blue-600'
+            : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700',
           'border-b-2 px-1 py-4 pb-3 text-sm font-medium whitespace-nowrap flex items-center gap-2'
         )
       }
@@ -25,7 +25,7 @@ export function Tab({ to, icon: Icon, children, end = false }) {
           <Icon
             size={20}
             className={classNames(
-              isActive ? 'text-blue-600 dark:text-blue-400' : 'text-gray-500 dark:text-gray-400'
+              isActive ? 'text-blue-600' : 'text-gray-500'
             )}
           />
           {children}

--- a/src/renderer/src/study.jsx
+++ b/src/renderer/src/study.jsx
@@ -163,7 +163,7 @@ export default function Study() {
 
   return (
     <div className="flex gap-4 flex-col h-full">
-      <header className="w-full border-b border-gray-200 dark:border-gray-700 sticky top-0 bg-white dark:bg-gray-900 z-10">
+      <header className="w-full border-b border-gray-200 sticky top-0 bg-white z-10">
         <div className="flex items-center">
           <nav aria-label="Tabs" className="-mb-px flex space-x-8 px-4">
             <Tab to={`/study/${id}`} icon={NotebookText} end>


### PR DESCRIPTION
## Summary
- Remove dark mode CSS classes from study tabs to use light mode styling consistently
- Affects the header and tab navigation in the study view

## Changes
- `Tab.jsx`: Remove `dark:` prefixed classes from active/inactive tab and icon styling
- `study.jsx`: Remove `dark:` prefixed classes from header background and border

## Test plan
- [x] Open app in dark mode
- [x] Verify study tabs display with white background and light mode colors