### PR TITLE
feat: cache remote images in Best Captures for offline access

### DIFF
--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -379,6 +379,35 @@ if (isRemote) {
 }
 ```
 
+## Remote Image Caching (Best Captures)
+
+Remote images from GBIF, Agouti, and LILA imports are cached to disk for offline access and performance. This caching is **automatic and transparent** - no user action required.
+
+**How it works:**
+
+1. When Best Captures carousel displays remote images, it uses the `cached-image://` protocol
+2. Main process checks if image is already cached
+3. If cached → serves from local disk (instant)
+4. If not cached → redirects to original URL + triggers background download
+5. Next view → serves from cache
+
+**Cache characteristics:**
+- **Location:** `{userData}/biowatch-data/studies/{studyId}/cache/images/`
+- **Key:** SHA256 hash of URL (first 16 characters)
+- **Expiration:** 30 days (auto-cleaned at app startup)
+- **Strategy:** Lazy caching (on first display, not eagerly)
+
+**Key file:** `src/main/image-cache.js`
+
+```javascript
+// Protocol flow
+// 1. Renderer loads: cached-image://cache?studyId=X&url=https://example.com/img.jpg
+// 2. Main process:
+//    - Check cache: {studyId}/cache/images/{hash}_img.jpg
+//    - If exists: serve from disk
+//    - If not: redirect to original URL, start background download
+```
+
 ## Cancellation
 
 Exports support cancellation:
@@ -407,3 +436,5 @@ if (activeExport.isCancelled) {
 | `src/main/export.js` | All export functionality |
 | `src/main/download.ts` | File download with retry |
 | `src/main/transformers/index.js` | Bbox format conversions |
+| `src/main/image-cache.js` | Remote image caching for Best Captures |
+| `src/main/cache-cleanup.js` | Cache expiration cleanup |

--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -197,6 +197,30 @@ const unsubscribe = window.api.transcode.onProgress(({ filePath, progress }) => 
 // Later: unsubscribe()
 ```
 
+### Remote Image Caching
+
+| Method | Channel | Parameters | Returns |
+|--------|---------|------------|---------|
+| `imageCache.getCached(studyId, url)` | `image-cache:get-cached` | studyId, remote URL | `string \| null` (cached path) |
+| `imageCache.download(studyId, url)` | `image-cache:download` | studyId, remote URL | `{ success, path? } \| { success: false, error }` |
+| `imageCache.getCacheStats(studyId)` | `image-cache:stats` | studyId | `{ size: number, count: number }` |
+| `imageCache.clearCache(studyId)` | `image-cache:clear` | studyId | `{ cleared: number, freedBytes: number }` |
+
+**Notes:**
+- Caches remote images (from GBIF, Agouti imports) to disk for offline access
+- Uses the `cached-image://` custom protocol for transparent caching
+- **Cache location:** `studies/{studyId}/cache/images/`
+- **Cache key:** SHA256 hash of URL (first 16 characters)
+- **Auto-expiration:** Cached images are automatically deleted after 30 days
+- **Lazy caching:** Images are cached on first display (not eagerly)
+- **Fallback:** If download fails, original remote URL is used via redirect
+
+**Protocol flow:**
+1. Renderer requests `cached-image://cache?studyId=X&url=Y`
+2. Main process checks cache → if cached, serves from disk
+3. If not cached → redirects to original URL, triggers background download
+4. Next request serves from cache
+
 ### Utilities
 
 | Method | Channel | Parameters | Returns |
@@ -288,3 +312,4 @@ const data = response.data
 | `src/main/export.js` | Export handler implementations |
 | `src/main/models.ts` | ML model handler implementations |
 | `src/main/transcoder.js` | Video transcoding with FFmpeg |
+| `src/main/image-cache.js` | Remote image caching for GBIF/Agouti imports |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biowatch",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biowatch",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/src/main/image-cache.js
+++ b/src/main/image-cache.js
@@ -1,0 +1,280 @@
+/**
+ * Remote image caching module for storing remote images locally.
+ *
+ * Caches images from remote URLs (GBIF, Agouti, etc.) to disk for offline access
+ * and improved performance. Follows the same patterns as transcoder.js.
+ */
+
+import { createHash } from 'crypto'
+import { app, ipcMain } from 'electron'
+import log from 'electron-log'
+import { existsSync, mkdirSync, statSync, readdirSync, rmSync, writeFileSync } from 'fs'
+import { join, basename, extname } from 'path'
+
+import { downloadFileWithRetry } from './download'
+import { cleanExpiredImageCacheImpl } from './cache-cleanup.js'
+
+// Track in-progress downloads to prevent duplicates
+const inProgressDownloads = new Map()
+
+// Image extensions we cache
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp'])
+
+/**
+ * Get the cache directory for a specific study.
+ * @param {string} studyId - The study ID
+ * @returns {string} Path to the study's cache directory
+ */
+function getStudyCacheDir(studyId) {
+  return join(app.getPath('userData'), 'biowatch-data', 'studies', studyId, 'cache')
+}
+
+/**
+ * Get the image cache directory for a specific study.
+ * @param {string} studyId - The study ID
+ * @returns {string} Path to the study's image cache directory
+ */
+export function getImageCacheDir(studyId) {
+  return join(getStudyCacheDir(studyId), 'images')
+}
+
+/**
+ * Ensure the image cache directory exists for a study.
+ * @param {string} studyId - The study ID
+ */
+function ensureImageCacheDir(studyId) {
+  const imageCacheDir = getImageCacheDir(studyId)
+  if (!existsSync(imageCacheDir)) {
+    mkdirSync(imageCacheDir, { recursive: true })
+    log.info(`[ImageCache] Created image cache directory: ${imageCacheDir}`)
+  }
+}
+
+/**
+ * Generate a unique cache key from a URL.
+ * @param {string} url - The remote URL
+ * @returns {string} SHA256 hash (first 16 chars) to use as cache key
+ */
+export function getCacheKeyFromUrl(url) {
+  return createHash('sha256').update(url).digest('hex').substring(0, 16)
+}
+
+/**
+ * Extract filename and extension from a URL.
+ * @param {string} url - The remote URL
+ * @returns {{ filename: string, ext: string }} Filename and extension
+ */
+function getFilenameFromUrl(url) {
+  try {
+    const urlObj = new URL(url)
+    const pathname = urlObj.pathname
+    const fullFilename = basename(pathname)
+    const ext = extname(fullFilename).toLowerCase()
+    const filename = basename(fullFilename, ext)
+    return { filename: filename || 'image', ext: ext || '.jpg' }
+  } catch {
+    return { filename: 'image', ext: '.jpg' }
+  }
+}
+
+/**
+ * Get the cache path for an image.
+ * @param {string} studyId - The study ID
+ * @param {string} url - The remote URL
+ * @returns {string} Path to the cached file
+ */
+export function getCachedImagePath(studyId, url) {
+  const cacheKey = getCacheKeyFromUrl(url)
+  const { filename, ext } = getFilenameFromUrl(url)
+  return join(getImageCacheDir(studyId), `${cacheKey}_${filename}${ext}`)
+}
+
+/**
+ * Check if a cached image exists.
+ * @param {string} studyId - The study ID
+ * @param {string} url - The remote URL
+ * @returns {string|null} Path to cached file if exists, null otherwise
+ */
+export function getCachedImage(studyId, url) {
+  const cachedPath = getCachedImagePath(studyId, url)
+  return existsSync(cachedPath) ? cachedPath : null
+}
+
+/**
+ * Check if a download is already in progress for a URL.
+ * @param {string} url - The remote URL
+ * @returns {boolean} True if download is in progress
+ */
+export function isDownloadInProgress(url) {
+  return inProgressDownloads.has(url)
+}
+
+/**
+ * Download and cache an image from a remote URL.
+ * @param {string} studyId - The study ID
+ * @param {string} url - The remote URL
+ * @returns {Promise<string>} Path to the cached file
+ */
+export async function downloadAndCacheImage(studyId, url) {
+  // Check if already in progress
+  if (inProgressDownloads.has(url)) {
+    log.info(`[ImageCache] Download already in progress for: ${url}`)
+    return inProgressDownloads.get(url)
+  }
+
+  ensureImageCacheDir(studyId)
+  const destPath = getCachedImagePath(studyId, url)
+
+  // Check if already cached
+  if (existsSync(destPath)) {
+    log.info(`[ImageCache] Using cached image: ${destPath}`)
+    return destPath
+  }
+
+  log.info(`[ImageCache] Downloading image: ${url} -> ${destPath}`)
+
+  // Create a promise for the download and track it
+  // Using empty callback since we don't need progress updates for background image caching
+  const downloadPromise = downloadFileWithRetry(url, destPath, () => {})
+    .then(() => {
+      log.info(`[ImageCache] Image cached: ${destPath}`)
+      return destPath
+    })
+    .catch((error) => {
+      log.error(`[ImageCache] Failed to cache image: ${error.message}`)
+      throw error
+    })
+    .finally(() => {
+      inProgressDownloads.delete(url)
+    })
+
+  inProgressDownloads.set(url, downloadPromise)
+  return downloadPromise
+}
+
+/**
+ * Save image buffer directly to cache.
+ * Used by protocol handler to cache fetched images.
+ * @param {string} studyId - The study ID
+ * @param {string} url - The remote URL (used for cache key)
+ * @param {Buffer} buffer - The image data
+ * @returns {Promise<string>} Path to the cached file
+ */
+export async function saveImageToCache(studyId, url, buffer) {
+  ensureImageCacheDir(studyId)
+  const destPath = getCachedImagePath(studyId, url)
+  writeFileSync(destPath, buffer)
+  log.info(`[ImageCache] Saved to cache: ${destPath}`)
+  return destPath
+}
+
+/**
+ * Get MIME type from file extension.
+ * @param {string} filePath - Path to the file
+ * @returns {string} MIME type
+ */
+export function getMimeType(filePath) {
+  const ext = extname(filePath).toLowerCase()
+  const mimeTypes = {
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.png': 'image/png',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp'
+  }
+  return mimeTypes[ext] || 'application/octet-stream'
+}
+
+/**
+ * Get cache statistics for a study.
+ * @param {string} studyId - The study ID
+ * @returns {{ size: number, count: number }} Cache size in bytes and file count
+ */
+export function getImageCacheStats(studyId) {
+  const imageCacheDir = getImageCacheDir(studyId)
+
+  let totalSize = 0
+  let count = 0
+
+  try {
+    if (existsSync(imageCacheDir)) {
+      const files = readdirSync(imageCacheDir)
+      for (const file of files) {
+        const ext = extname(file).toLowerCase()
+        if (IMAGE_EXTENSIONS.has(ext)) {
+          const filePath = join(imageCacheDir, file)
+          const stats = statSync(filePath)
+          totalSize += stats.size
+          count++
+        }
+      }
+    }
+  } catch (e) {
+    log.error(`[ImageCache] Error getting cache stats: ${e.message}`)
+  }
+
+  return { size: totalSize, count }
+}
+
+/**
+ * Clear the image cache for a study.
+ * @param {string} studyId - The study ID
+ * @returns {{ cleared: number, freedBytes: number }} Number of files cleared and bytes freed
+ */
+export function clearImageCache(studyId) {
+  const imageCacheDir = getImageCacheDir(studyId)
+  const stats = getImageCacheStats(studyId)
+
+  try {
+    if (existsSync(imageCacheDir)) {
+      rmSync(imageCacheDir, { recursive: true, force: true })
+      mkdirSync(imageCacheDir, { recursive: true })
+    }
+  } catch (e) {
+    log.error(`[ImageCache] Error clearing cache: ${e.message}`)
+  }
+
+  return { cleared: stats.count, freedBytes: stats.size }
+}
+
+/**
+ * Clean expired image cache files across all studies.
+ * Runs asynchronously in background without blocking app startup.
+ * Deletes image files older than 30 days.
+ */
+export async function cleanExpiredImageCache() {
+  const studiesPath = join(app.getPath('userData'), 'biowatch-data', 'studies')
+  return cleanExpiredImageCacheImpl(studiesPath, undefined, { log })
+}
+
+/**
+ * Register IPC handlers for image cache operations.
+ */
+export function registerImageCacheIPCHandlers() {
+  // Check if a cached version exists
+  ipcMain.handle('image-cache:get-cached', (event, studyId, url) => {
+    return getCachedImage(studyId, url)
+  })
+
+  // Manually trigger caching of an image
+  ipcMain.handle('image-cache:download', async (event, studyId, url) => {
+    try {
+      const cachedPath = await downloadAndCacheImage(studyId, url)
+      return { success: true, path: cachedPath }
+    } catch (error) {
+      return { success: false, error: error.message }
+    }
+  })
+
+  // Get cache statistics for a study
+  ipcMain.handle('image-cache:stats', (event, studyId) => {
+    return getImageCacheStats(studyId)
+  })
+
+  // Clear the cache for a study
+  ipcMain.handle('image-cache:clear', (event, studyId) => {
+    return clearImageCache(studyId)
+  })
+
+  log.info('[ImageCache] IPC handlers registered')
+}

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -295,6 +295,26 @@ const api = {
     extract: async (studyId, filePath) => {
       return await electronAPI.ipcRenderer.invoke('thumbnail:extract', studyId, filePath)
     }
+  },
+
+  // Remote image caching (for GBIF/Agouti imported images)
+  imageCache: {
+    // Get cached image path if it exists
+    getCached: async (studyId, url) => {
+      return await electronAPI.ipcRenderer.invoke('image-cache:get-cached', studyId, url)
+    },
+    // Manually trigger caching of an image
+    download: async (studyId, url) => {
+      return await electronAPI.ipcRenderer.invoke('image-cache:download', studyId, url)
+    },
+    // Get cache statistics for a study
+    getCacheStats: async (studyId) => {
+      return await electronAPI.ipcRenderer.invoke('image-cache:stats', studyId)
+    },
+    // Clear the image cache for a study
+    clearCache: async (studyId) => {
+      return await electronAPI.ipcRenderer.invoke('image-cache:clear', studyId)
+    }
   }
 }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: https: http:; media-src 'self' local-file: https: http:"
+      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: cached-image: https: http:; media-src 'self' local-file: https: http:"
     />
   </head>
 


### PR DESCRIPTION
## Summary

- Add disk caching for remote images (GBIF, Agouti) displayed in Best Captures carousel
- Implement `cached-image://` custom protocol for transparent caching
- Images are lazily cached on first display, then served from disk on subsequent views
- Cache automatically expires after 30 days

## Changes

- **New `src/main/image-cache.js`**: Core caching module with SHA256-based cache keys
- **Modified `src/main/index.js`**: Register `cached-image://` protocol handler using `net.fetch()` proxy pattern
- **Modified `src/main/cache-cleanup.js`**: Add image cache cleanup (30-day expiration)
- **Modified `src/renderer/src/ui/BestMediaCarousel.jsx`**: Use new protocol for remote URLs
- **Modified `src/preload/index.js`**: Expose imageCache API for manual cache management
- **Modified `src/renderer/index.html`**: Add `cached-image:` to CSP img-src directive
- **Updated docs**: ipc-api.md and import-export.md

## Technical Details

- Cache location: `{userData}/biowatch-data/studies/{studyId}/cache/images/`
- Cache key: SHA256 hash of URL (first 16 characters)
- Protocol handler fetches remote images via `net.fetch()` and returns content directly (redirects don't work in Electron custom protocols)
- Background cache save on first fetch, immediate disk serve on subsequent requests

## Test plan

- [x] Import a GBIF or Agouti dataset with remote images
- [x] View Best Captures carousel - images should load
- [x] Check cache directory is populated
- [x] Restart app offline - cached images should still display
- [x] Wait 30+ days or manually test cleanup function