### PR TITLE
feat: add spinning wheel on AI Models tab during download

### DIFF
--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -120,6 +120,9 @@ const api = {
   clearAllLocalMLModel: async () => {
     return await electronAPI.ipcRenderer.invoke('model:clear-all')
   },
+  getGlobalModelDownloadStatus: async () => {
+    return await electronAPI.ipcRenderer.invoke('model:get-global-download-status')
+  },
 
   downloadPythonEnvironment: async ({ id, version, requestingModelId }) => {
     return await electronAPI.ipcRenderer.invoke(

--- a/src/renderer/src/components/Tab.jsx
+++ b/src/renderer/src/components/Tab.jsx
@@ -6,7 +6,7 @@ function classNames(...classes) {
 }
 
 // Tab component
-export function Tab({ to, icon: Icon, children, end = false }) {
+export function Tab({ to, icon: Icon, children, end = false, indicator = null }) {
   return (
     <NavLink
       to={to}
@@ -24,6 +24,7 @@ export function Tab({ to, icon: Icon, children, end = false }) {
         <>
           <Icon size={20} className={classNames(isActive ? 'text-blue-600' : 'text-gray-500')} />
           {children}
+          {indicator}
         </>
       )}
     </NavLink>

--- a/src/renderer/src/settings.jsx
+++ b/src/renderer/src/settings.jsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router'
 import { ErrorBoundary } from 'react-error-boundary'
-import { BrainCircuit, Info, Github, Earth } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { BrainCircuit, Info, Github, Earth, Loader2 } from 'lucide-react'
 import Zoo from './models'
 import { modelZoo } from '../../shared/mlmodels'
 import { Tab } from './components/Tab'
@@ -114,11 +115,27 @@ export default function SettingsPage() {
   const version = import.meta.env.VITE_APP_VERSION
   const platform = window.electron.process.platform
 
+  // Poll model download status to show spinner on AI Models tab
+  const { data: modelDownloadStatus } = useQuery({
+    queryKey: ['modelGlobalDownloadStatus'],
+    queryFn: () => window.api.getGlobalModelDownloadStatus(),
+    refetchInterval: 2000
+  })
+  const isModelDownloading = modelDownloadStatus?.isDownloading
+
   return (
     <div className="flex gap-4 flex-col h-full">
       <header className="w-full border-b border-gray-200 sticky top-0 bg-white z-10">
         <nav aria-label="Tabs" className="-mb-px flex space-x-8 px-4">
-          <Tab to="/settings/ml_zoo" icon={BrainCircuit}>
+          <Tab
+            to="/settings/ml_zoo"
+            icon={BrainCircuit}
+            indicator={
+              isModelDownloading ? (
+                <Loader2 size={16} className="animate-spin text-blue-600" />
+              ) : null
+            }
+          >
             AI Models
           </Tab>
           <Tab to="/settings/info" icon={Info}>


### PR DESCRIPTION
## Summary

- Adds a spinning wheel indicator to the AI Models tab when a model or Python environment is being downloaded
- Follows the same pattern used for the OCR spinner on the Settings tab in studies

## Changes

- Added `indicator` prop to Tab component for displaying status indicators
- Added `getGlobalModelDownloadStatus()` IPC handler to check if any model/environment is downloading
- Settings page polls download status every 2 seconds and shows spinner when active

## Test plan

- [x] Start downloading a model from the AI Models tab
- [x] Navigate away from the AI Models tab
- [x] Verify the spinning wheel appears next to "AI Models" in the tab bar
- [x] Verify the spinner disappears when download completes