### PR TITLE
feat: add blank media detection and display in media tab

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -20,6 +20,7 @@ import {
   checkMediaHaveBboxes,
   getSpeciesDailyActivity,
   getSpeciesDistribution,
+  getBlankMediaCount,
   getSpeciesHeatmapData,
   getSpeciesTimeseries,
   getFilesData,
@@ -775,6 +776,23 @@ app.whenReady().then(async () => {
       return { data: distribution }
     } catch (error) {
       log.error('Error getting species distribution:', error)
+      return { error: error.message }
+    }
+  })
+
+  // Add blank media count handler
+  ipcMain.handle('species:get-blank-count', async (_, studyId) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const blankCount = await getBlankMediaCount(dbPath)
+      return { data: blankCount }
+    } catch (error) {
+      log.error('Error getting blank media count:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -27,6 +27,9 @@ const api = {
   getSpeciesDistribution: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('species:get-distribution', studyId)
   },
+  getBlankMediaCount: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('species:get-blank-count', studyId)
+  },
   getDeployments: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('deployments:get', studyId)
   },

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -2693,6 +2693,17 @@ export default function Activity({ studyData, studyId }) {
     enabled: !!actualStudyId
   })
 
+  // Fetch blank media count (media without observations)
+  const { data: blankCount = 0 } = useQuery({
+    queryKey: ['blankMediaCount', actualStudyId],
+    queryFn: async () => {
+      const response = await window.api.getBlankMediaCount(actualStudyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!actualStudyId
+  })
+
   // Initialize selectedSpecies when speciesDistributionData loads
   // Excludes humans/vehicles from default selection
   useEffect(() => {
@@ -2805,6 +2816,7 @@ export default function Activity({ studyData, studyId }) {
                   selectedSpecies={selectedSpecies}
                   onSpeciesChange={handleSpeciesChange}
                   palette={palette}
+                  blankCount={blankCount}
                 />
               )}
             </div>

--- a/src/renderer/src/utils/speciesUtils.js
+++ b/src/renderer/src/utils/speciesUtils.js
@@ -1,7 +1,20 @@
 /**
  * Utility functions for species sorting and filtering.
- * These functions help move humans and vehicles to the bottom of species lists.
+ * These functions help move humans and vehicles to the bottom of species lists,
+ * and blanks (media without observations) to the very end.
  */
+
+/**
+ * Sentinel value for blank media (media without observations)
+ */
+export const BLANK_SENTINEL = '__blank__'
+
+/**
+ * Check if a species entry represents blank media (no observations)
+ * @param {string} scientificName - The scientific name to check
+ * @returns {boolean} - True if this is the blank sentinel value
+ */
+export const isBlank = (scientificName) => scientificName === BLANK_SENTINEL
 
 /**
  * Check if a species is human or vehicle (should be sorted to bottom of lists)
@@ -29,31 +42,39 @@ export const isHumanOrVehicle = (scientificName) => {
 }
 
 /**
- * Sort species data with humans/vehicles at the bottom.
- * Within each group (regular species and humans/vehicles), sorts by count descending.
+ * Sort species data with humans/vehicles near the bottom and blanks at the very end.
+ * Order: regular species (by count) > humans/vehicles (by count) > blank
  * @param {Array} data - Array of species objects with scientificName and count properties
  * @returns {Array} - Sorted array (does not mutate original)
  */
 export const sortSpeciesHumansLast = (data) => {
   if (!data || !Array.isArray(data)) return []
   return [...data].sort((a, b) => {
-    const aIsBottom = isHumanOrVehicle(a.scientificName)
-    const bIsBottom = isHumanOrVehicle(b.scientificName)
-    if (aIsBottom !== bIsBottom) return aIsBottom ? 1 : -1
+    // Blanks always at the very end
+    const aIsBlank = isBlank(a.scientificName)
+    const bIsBlank = isBlank(b.scientificName)
+    if (aIsBlank !== bIsBlank) return aIsBlank ? 1 : -1
+
+    // Then humans/vehicles
+    const aIsHumanVehicle = isHumanOrVehicle(a.scientificName)
+    const bIsHumanVehicle = isHumanOrVehicle(b.scientificName)
+    if (aIsHumanVehicle !== bIsHumanVehicle) return aIsHumanVehicle ? 1 : -1
+
+    // Within groups, sort by count descending
     return b.count - a.count
   })
 }
 
 /**
- * Get the top N non-human/vehicle species, sorted by count descending.
+ * Get the top N non-human/vehicle/blank species, sorted by count descending.
  * Used for default species selection in Activity and Media tabs.
  * @param {Array} data - Array of species objects with scientificName and count properties
  * @param {number} n - Number of species to return (default: 2)
- * @returns {Array} - Top N non-human/vehicle species
+ * @returns {Array} - Top N non-human/vehicle/blank species
  */
 export const getTopNonHumanSpecies = (data, n = 2) => {
   if (!data || !Array.isArray(data)) return []
   return sortSpeciesHumansLast(data)
-    .filter((s) => !isHumanOrVehicle(s.scientificName))
+    .filter((s) => !isHumanOrVehicle(s.scientificName) && !isBlank(s.scientificName))
     .slice(0, n)
 }


### PR DESCRIPTION
## Summary

- Add blank detection to show media without observations in the species distribution sidebar
- Support filtering media gallery by blanks (media with no associated observations)
- Handle event based timestamp ranges which are too slow to query) - the demo dataset for instance

<img width="3178" height="1427" alt="image" src="https://github.com/user-attachments/assets/f0a7fd72-cdf6-44ac-b6d9-ff7ae0b515aa" />


## Changes

- **queries.js**: Add `getBlankMediaCount()` function and `isTimestampBasedDataset()` helper to detect dataset type
- **speciesDistribution.jsx**: Display blank count in species list with styling
- **speciesUtils.js**: Add `BLANK_SENTINEL` constant and `isBlank()` helper for blank identification
- **media.jsx**: Fetch and pass blank count to species distribution component
- **IPC handlers**: Add `get-blank-media-count` handler

## Dataset Type Handling

| Dataset Type | Blank Detection |
|--------------|-----------------|
| mediaID-based (ML runs, Wildlife Insights) | Full support via `NOT EXISTS` subquery |
| Timestamp-based (CamTrap DP) | Returns 0 (range queries too slow) |

## Test Plan

- [x] Added 7 new tests for blank detection in `test/queries.test.js`
- [x] All 596 tests pass