### PR TITLE
fix: filter out unknown species from best captures

### DIFF
--- a/src/main/queries.js
+++ b/src/main/queries.js
@@ -2070,6 +2070,7 @@ export async function getBestMedia(dbPath, options = {}) {
           AND mediaID IS NULL
       ) o2 ON m.timestamp = o2.eventStart AND o2.rn = 1
       WHERE m.favorite = 1
+        AND COALESCE(o1.scientificName, o2.scientificName) IS NOT NULL
       ORDER BY m.timestamp DESC
       LIMIT ?
     `


### PR DESCRIPTION
## Summary

- Fix "Unknown species" appearing in Best Captures carousel for CamTrap DP imports (like GBIF datasets)
- Add filter to exclude favorites without matching species from the query results

## Problem

When importing CamTrap DP datasets where observations link via timestamp (not mediaID), some favorited media items had no matching observation record. The favorites query used LEFT JOINs but didn't filter out NULL species, causing "Unknown species" to display in the carousel.

## Solution

Added `COALESCE(o1.scientificName, o2.scientificName) IS NOT NULL` filter to the favorites query in `getBestMedia()` to ensure only favorites with valid species are returned.

## Test plan

- [x] Verify "Unknown species" no longer appears in Best Captures with awd_pilot1 dataset
- [x] Verify favorites with valid species still appear correctly
- [x] Lint and format pass