### PR TITLE
feat: add toast notification when model download completes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react-leaflet-cluster": "^2.1.0",
         "react-router": "^7.5.0",
         "recharts": "^2.15.3",
+        "sonner": "^2.0.7",
         "stream-json": "^1.9.1",
         "tailwindcss": "^4.1.8",
         "tree-kill": "^1.2.2",
@@ -11345,6 +11346,16 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-leaflet-cluster": "^2.1.0",
     "react-router": "^7.5.0",
     "recharts": "^2.15.3",
+    "sonner": "^2.0.7",
     "stream-json": "^1.9.1",
     "tailwindcss": "^4.1.8",
     "tree-kill": "^1.2.2",

--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -2,6 +2,7 @@ import { Pencil, Plus, Settings, Trash2, Search, ChevronRight } from 'lucide-rea
 import { ErrorBoundary } from 'react-error-boundary'
 import { HashRouter, NavLink, Route, Routes, useLocation, useNavigate } from 'react-router'
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
+import { Toaster } from 'sonner'
 import Import from './import'
 import Study from './study'
 import SettingsPage from './settings'
@@ -392,6 +393,7 @@ function AppContent() {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <Toaster position="top-right" richColors />
       <HashRouter>
         <ErrorBoundary FallbackComponent={ErrorFallback}>
           <AppContent />

--- a/src/renderer/src/models.jsx
+++ b/src/renderer/src/models.jsx
@@ -10,6 +10,7 @@ import {
   Server,
   Mail
 } from 'lucide-react'
+import { toast } from 'sonner'
 import { platformToKey, findPythonEnvironment } from '../../shared/mlmodels'
 import {
   isOwnEnvironmentDownload,
@@ -156,6 +157,10 @@ function ModelRow({ model, pythonEnvironment, platform, isDev = false, refreshKe
       setModelDownloadStatus(downloadStatus)
       setIsDownloading(false)
       setIsDownloaded(true)
+      toast.success(`${model.name} downloaded`, {
+        description: 'The model is ready to use.',
+        duration: 5000
+      })
     } catch (error) {
       setIsDownloading(false)
       console.error('Failed to download model:', error)


### PR DESCRIPTION
## Summary

- Add sonner toast library for notifications
- Show success toast when ML model download completes

## Changes

- Add `sonner` dependency to package.json
- Add `<Toaster>` component in base.jsx
- Trigger `toast.success()` in models.jsx when download finishes

## Test plan

- [x] Download a model (e.g., DeepFaune, Manas)
- [x] Verify toast appears in top-right corner on completion
- [x] Verify toast shows model name and "ready to use" message