### PR TITLE
feat: improve GBIF import with mediaID association

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -200,7 +200,6 @@ export {
   // Utils
   formatToMatchOriginal,
   getStudyIdFromPath,
-  isTimestampBasedDataset,
   checkStudyHasEventIDs,
   createImageDirectoryDatabase,
   // Deployments

--- a/src/main/database/migrations/0012_add_media_compound_index.sql
+++ b/src/main/database/migrations/0012_add_media_compound_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS `idx_media_deploymentID_timestamp` ON `media` (`deploymentID`, `timestamp`);

--- a/src/main/database/models.js
+++ b/src/main/database/models.js
@@ -37,7 +37,8 @@ export const media = sqliteTable(
     index('idx_media_deploymentID').on(table.deploymentID),
     index('idx_media_timestamp').on(table.timestamp),
     index('idx_media_filePath').on(table.filePath),
-    index('idx_media_folderName').on(table.folderName)
+    index('idx_media_folderName').on(table.folderName),
+    index('idx_media_deploymentID_timestamp').on(table.deploymentID, table.timestamp)
   ]
 )
 

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -7,7 +7,6 @@
 export {
   formatToMatchOriginal,
   getStudyIdFromPath,
-  isTimestampBasedDataset,
   checkStudyHasEventIDs,
   createImageDirectoryDatabase
 } from './utils.js'

--- a/src/main/database/queries/utils.js
+++ b/src/main/database/queries/utils.js
@@ -5,6 +5,7 @@
 
 import { getDrizzleDb, getStudyDatabase, observations } from '../index.js'
 import { sql } from 'drizzle-orm'
+// Note: observations import kept for checkStudyHasEventIDs
 import log from 'electron-log'
 
 /**
@@ -51,24 +52,6 @@ export function formatToMatchOriginal(newDateTime, originalString) {
 export function getStudyIdFromPath(dbPath) {
   const pathParts = dbPath.split(/[/\\]/)
   return pathParts[pathParts.length - 2] || 'unknown'
-}
-
-/**
- * Check if a dataset uses timestamp-based linking (CamTrap DP format)
- * These datasets have NULL mediaID in all observations and link via eventStart/eventEnd ranges.
- * For these datasets, blank detection is not supported (would require slow range queries).
- * @param {object} db - Drizzle database instance
- * @returns {Promise<boolean>} - True if timestamp-based (all observations have NULL mediaID)
- */
-export async function isTimestampBasedDataset(db) {
-  const result = await db
-    .select({
-      hasMediaID: sql`CASE WHEN COUNT(CASE WHEN mediaID IS NOT NULL THEN 1 END) > 0 THEN 1 ELSE 0 END`
-    })
-    .from(observations)
-    .get()
-
-  return result?.hasMediaID === 0
 }
 
 /**

--- a/src/main/services/import/parsers/deepfaune.js
+++ b/src/main/services/import/parsers/deepfaune.js
@@ -12,32 +12,8 @@ import {
   insertMetadata
 } from '../../../database/index.js'
 import { eq } from 'drizzle-orm'
-
-// Conditionally import electron modules for production, use fallback for testing
-let app, log
-
-// Initialize electron modules with proper async handling
-async function initializeElectronModules() {
-  if (app && log) return // Already initialized
-
-  try {
-    const electron = await import('electron')
-    app = electron.app
-    const electronLog = await import('electron-log')
-    log = electronLog.default
-  } catch {
-    // Fallback for testing environment
-    app = {
-      getPath: () => '/tmp'
-    }
-    log = {
-      info: () => {},
-      error: () => {},
-      warn: () => {},
-      debug: () => {}
-    }
-  }
-}
+import log from '../../logger.js'
+import { getBiowatchDataPath } from '../../paths.js'
 
 /**
  * Import Deepfaune CSV dataset from a CSV file into a SQLite database
@@ -46,8 +22,7 @@ async function initializeElectronModules() {
  * @returns {Promise<Object>} - Object containing study data
  */
 export async function importDeepfauneDataset(csvPath, id) {
-  await initializeElectronModules()
-  const biowatchDataPath = path.join(app.getPath('userData'), 'biowatch-data')
+  const biowatchDataPath = getBiowatchDataPath()
   return await importDeepfauneDatasetWithPath(csvPath, biowatchDataPath, id)
 }
 
@@ -59,7 +34,6 @@ export async function importDeepfauneDataset(csvPath, id) {
  * @returns {Promise<Object>} - Object containing study data
  */
 export async function importDeepfauneDatasetWithPath(csvPath, biowatchDataPath, id) {
-  await initializeElectronModules()
   log.info('Starting Deepfaune CSV dataset import')
 
   // Create database in the specified biowatch-data directory

--- a/src/main/services/import/parsers/wildlifeInsights.js
+++ b/src/main/services/import/parsers/wildlifeInsights.js
@@ -10,32 +10,8 @@ import {
   closeStudyDatabase,
   insertMetadata
 } from '../../../database/index.js'
-
-// Conditionally import electron modules for production, use fallback for testing
-let app, log
-
-// Initialize electron modules with proper async handling
-async function initializeElectronModules() {
-  if (app && log) return // Already initialized
-
-  try {
-    const electron = await import('electron')
-    app = electron.app
-    const electronLog = await import('electron-log')
-    log = electronLog.default
-  } catch {
-    // Fallback for testing environment
-    app = {
-      getPath: () => '/tmp'
-    }
-    log = {
-      info: () => {},
-      error: () => {},
-      warn: () => {},
-      debug: () => {}
-    }
-  }
-}
+import log from '../../logger.js'
+import { getBiowatchDataPath } from '../../paths.js'
 
 /**
  * Import Wildlife Insights dataset from a directory into a SQLite database
@@ -44,8 +20,7 @@ async function initializeElectronModules() {
  * @returns {Promise<Object>} - Object containing study data
  */
 export async function importWildlifeDataset(directoryPath, id) {
-  await initializeElectronModules()
-  const biowatchDataPath = path.join(app.getPath('userData'), 'biowatch-data')
+  const biowatchDataPath = getBiowatchDataPath()
   return await importWildlifeDatasetWithPath(directoryPath, biowatchDataPath, id)
 }
 
@@ -57,7 +32,6 @@ export async function importWildlifeDataset(directoryPath, id) {
  * @returns {Promise<Object>} - Object containing study data
  */
 export async function importWildlifeDatasetWithPath(directoryPath, biowatchDataPath, id) {
-  await initializeElectronModules()
   log.info('Starting Wildlife dataset import')
 
   // Create database in the specified biowatch-data directory

--- a/src/main/services/index.js
+++ b/src/main/services/index.js
@@ -2,6 +2,7 @@
  * Services module re-exports
  *
  * Business logic layer providing:
+ * - Logger (centralized electron-log/console fallback)
  * - Path utilities
  * - Progress broadcasting
  * - Dataset extraction
@@ -12,6 +13,7 @@
  * - Cache services
  */
 
+export { default as log, getLogger } from './logger.js'
 export * from './paths.js'
 export * from './progress.js'
 export * from './extractor.js'

--- a/src/main/services/logger.js
+++ b/src/main/services/logger.js
@@ -1,0 +1,26 @@
+/**
+ * Centralized logger module for main process
+ * Provides electron-log in Electron context, console in tests
+ */
+
+let _log = null
+
+export function getLogger() {
+  if (_log) return _log
+  try {
+    _log = require('electron-log')
+  } catch {
+    _log = console
+  }
+  return _log
+}
+
+// Proxy allows: import log from './logger.js'; log.info(...)
+export default new Proxy(
+  {},
+  {
+    get(_, prop) {
+      return getLogger()[prop]
+    }
+  }
+)

--- a/src/main/services/paths.js
+++ b/src/main/services/paths.js
@@ -4,6 +4,28 @@
 
 import { join } from 'path'
 
+// Lazily cached app reference for Electron context
+let _app = null
+
+function getApp() {
+  if (_app) return _app
+  try {
+    _app = require('electron').app
+  } catch {
+    _app = { getPath: () => '/tmp' }
+  }
+  return _app
+}
+
+/**
+ * Get the biowatch data directory path
+ * Uses Electron's app.getPath('userData') in production, '/tmp' in tests
+ * @returns {string} Path to biowatch-data directory
+ */
+export function getBiowatchDataPath() {
+  return join(getApp().getPath('userData'), 'biowatch-data')
+}
+
 /**
  * Get the path to a study's database file
  * @param {string} userDataPath - The user data directory path


### PR DESCRIPTION
## Summary

- Expand event-based observations during CamTrap DP import to create one observation per matching media file
- Simplify queries by removing two-branch patterns (direct mediaID join vs timestamp fallback)
- Enable blank detection for all datasets (previously disabled for timestamp-based datasets)
- Centralize electron module initialization to remove code duplication

## Changes

### Import Pipeline (`src/main/import/camtrap.js`)
- Add `expandObservationsToMedia()` function that runs after CSV import
- For observations with NULL mediaID, find matching media by deploymentID + timestamp range
- Create individual observations linked to each media file, preserving eventID for grouping

### Database (`src/main/db/`)
- Add compound index `idx_media_deploymentID_timestamp` for efficient timestamp matching during expansion

### Queries (`src/main/queries.js`)
- Remove `isTimestampBasedDataset()` function and all its guards
- Simplify `getMedia()` from two-branch union to single mediaID-based join
- Simplify `getBestMedia()` raw SQL query
- Blank detection now works uniformly for all datasets

### Centralized Electron Modules (`src/main/logger.js`, `src/main/paths.js`)
- Extract duplicated `initializeElectronModules()` pattern from 4 import modules
- Create `logger.js` with lazy-init proxy pattern (uses `console` fallback in tests)
- Create `paths.js` with `getBiowatchDataPath()` utility
- Remove hidden async initialization from `expandObservationsToMedia()` and other functions

## Test plan

- [x] All 596 existing tests pass
- [x] Updated tests for new blank detection behavior
- [x] Manual test with demo dataset (luxvalmoni20223025)