### PR TITLE
feat: set demo dataset name to Demo Dataset

### DIFF
--- a/src/main/import/camtrap.js
+++ b/src/main/import/camtrap.js
@@ -42,7 +42,13 @@ async function initializeElectronModules() {
 export async function importCamTrapDataset(directoryPath, id, onProgress = null, options = {}) {
   await initializeElectronModules()
   const biowatchDataPath = path.join(app.getPath('userData'), 'biowatch-data')
-  return await importCamTrapDatasetWithPath(directoryPath, biowatchDataPath, id, onProgress, options)
+  return await importCamTrapDatasetWithPath(
+    directoryPath,
+    biowatchDataPath,
+    id,
+    onProgress,
+    options
+  )
 }
 
 /**

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1253,22 +1253,27 @@ app.whenReady().then(async () => {
       })
 
       const id = crypto.randomUUID()
-      const { data } = await importCamTrapDataset(camtrapDpDirPath, id, (csvProgress) => {
-        sendDemoImportProgress({
-          stage: 'importing_csvs',
-          stageIndex: 2,
-          totalStages: 3,
-          datasetTitle,
-          csvProgress: {
-            currentFile: csvProgress.currentFile,
-            fileIndex: csvProgress.fileIndex,
-            totalFiles: csvProgress.totalFiles,
-            insertedRows: csvProgress.insertedRows || 0,
-            totalRows: csvProgress.totalRows || 0,
-            phase: csvProgress.phase
-          }
-        })
-      }, { nameOverride: datasetTitle })
+      const { data } = await importCamTrapDataset(
+        camtrapDpDirPath,
+        id,
+        (csvProgress) => {
+          sendDemoImportProgress({
+            stage: 'importing_csvs',
+            stageIndex: 2,
+            totalStages: 3,
+            datasetTitle,
+            csvProgress: {
+              currentFile: csvProgress.currentFile,
+              fileIndex: csvProgress.fileIndex,
+              totalFiles: csvProgress.totalFiles,
+              insertedRows: csvProgress.insertedRows || 0,
+              totalRows: csvProgress.totalRows || 0,
+              phase: csvProgress.phase
+            }
+          })
+        },
+        { nameOverride: datasetTitle }
+      )
 
       const result = {
         path: camtrapDpDirPath,


### PR DESCRIPTION
## Summary

- Sets the imported demo dataset name to "Demo Dataset" instead of using the name from the downloaded datapackage.json
- Adds `nameOverride` option to `importCamTrapDataset` function for flexible name customization
- Documents the new options parameter in JSDoc

## Test plan

- [x] Import the demo dataset and verify the study name displays as "Demo Dataset"
- [x] Verify other CamTrap DP imports still use the name from datapackage.json