### PR TITLE
feat: add active state styling to Settings button

### DIFF
--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -337,7 +337,11 @@ function AppContent() {
         <div className="p-2 border-t border-gray-200">
           <NavLink
             to="/settings/ml_zoo"
-            className="w-full flex items-center justify-start gap-2 px-3 py-2 text-sm hover:bg-gray-100 rounded-md transition-colors"
+            className={`w-full flex items-center justify-start gap-2 px-3 py-2 text-sm rounded-md transition-colors ${
+              location.pathname.startsWith('/settings')
+                ? 'bg-blue-50 text-blue-700'
+                : 'text-gray-700 hover:bg-gray-100'
+            }`}
           >
             <Settings className="h-4 w-4" />
             Settings


### PR DESCRIPTION
## Summary
- Settings button in the left sidebar now displays a blue background (`bg-blue-50`) when viewing any settings page
- Matches the selected study styling for visual consistency

## Test plan
- [x] Navigate to Settings > AI Models and verify the Settings button shows blue background
- [x] Navigate to Settings > Info and verify the Settings button still shows blue background
- [x] Navigate to a study and verify the Settings button returns to default gray styling