### PR TITLE
fix: add node-abi override for Electron 39 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6069,25 +6069,25 @@
       "license": "ISC"
     },
     "node_modules/electron-updater": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
-      "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
+      "version": "6.7.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.7.3.tgz",
+      "integrity": "sha512-EgkT8Z9noqXKbwc3u5FkJA+r48jwZ5DTUiOkJMOTEEH//n5Am6wfQGz7nvSFEA2oIAMv9jRzn5JKTyWeSKOPgg==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.3.1",
+        "builder-util-runtime": "9.5.1",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.6.3",
+        "semver": "~7.7.3",
         "tiny-typed-emitter": "^2.1.0"
       }
     },
     "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
-      "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
+      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -9485,15 +9485,15 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.85.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
-      "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.24.0.tgz",
+      "integrity": "sha512-u2EC1CeNe25uVtX3EZbdQ275c74zdZmmpzrHEQh2aIYqoVjlglfUpOX9YY85x1nlBydEKDVaSmMNhR7N82Qj8A==",
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/node-abi/node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -81,5 +81,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "vite": "^6.1.0"
+  },
+  "overrides": {
+    "node-abi": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Fixes `npm install` / `make install` failing with:
```
Could not detect abi for version 39.2.7 and runtime electron.
Updating "node-abi" might help solve this issue if it is a new release of electron
```

## Root Cause

- Electron 39.2.7 is very new (released Oct 2025)
- The bundled `node-abi` v3.75.0 only supports up to Electron 37.x
- Latest `node-abi` v4.x has Electron 39 support

## Solution

Add an npm override in `package.json` to force all dependencies to use `node-abi@^4.0.0`.

## Test plan

- [x] `npm install` succeeds with native deps rebuilt
- [x] `npm run build` succeeds