### PR TITLE
feat: change demo dataset to GitHub-hosted camtrapDP zip

### DIFF
--- a/src/main/ipc/import.js
+++ b/src/main/ipc/import.js
@@ -243,7 +243,8 @@ export function registerImportIPCHandlers() {
         mkdirSync(downloadDir, { recursive: true })
       }
 
-      const demoDatasetUrl = 'https://gbif.mnhn.lu/ipt/archive.do?r=luxvalmoni20223025'
+      const demoDatasetUrl =
+        'https://github.com/earthtoolsmaker/biowatch/releases/download/v1.5.0/camtrapdp-demo-dataset.zip'
       const zipPath = join(downloadDir, 'demo-dataset.zip')
       const extractPath = join(downloadDir, 'extracted')
 


### PR DESCRIPTION
## Summary
- Updates the demo dataset URL to use a camtrapDP zip file hosted on GitHub releases
- New URL: https://github.com/earthtoolsmaker/biowatch/releases/download/v1.5.0/camtrapdp-demo-dataset.zip

## Test plan
- [x] Run the app and click "Use Demo Dataset" on the Import page
- [x] Verify the dataset downloads and imports successfully