### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to Biowatch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-01-15
+
+### Added
+
+- LILA datasets import with batch inserts, progress tracking, and remote video handling
+- E2E testing with Playwright (Windows, macOS, Linux)
+- Smart restart and error handling for ML servers
+- UI navigation controls in media tab
+- Species tooltip using Radix UI
+- Blank media preview in media overview tab
+- Prefetch next sequences when navigating for smoother experience
+- Improved algorithm for selecting diverse best captures
+- Cache best captures images from remote sources
+- Toast notifications for ML model download completion
+- Active state styling for Settings button
+- Auto-adjust number of columns in media tab
+- Improved deployment map pin selection
+- Spinning wheel indicator on AI Models tab
+
+### Changed
+
+- Upgrade Electron from 34 to 39
+- Upgrade to React 19 with compatible react-leaflet
+- Upgrade to Vite 7
+- Upgrade to electron-builder 26
+- Upgrade eslint-plugin-react-hooks to 7
+- Reorganize src/main with 3-layer architecture (app, ipc, services)
+- Reorganize database code structure
+- Reorganize test files to mirror src/ structure
+- Use native tar extraction for faster imports
+- Sort humans/vehicles last in species list
+- Change demo dataset to GitHub-hosted camtrapDP zip
+- Update dependencies: tailwindcss 4.1.18, drizzle-orm 0.45.1, zod 4.3.5, react-router 7.11.0, better-sqlite3 12.5.0, and more
+
+### Fixed
+
+- Map and timeline fixed while deployment list scrolls
+- Prevent error notification when pausing ML model run
+- Cross-platform path splitting for database connections on Windows
+- Close database connection before deleting study on Windows
+- Remove best captures that do not have a scientific name
+- Arrow navigation for null timestamp media
+- Sequence grouping for null timestamp observations
+- Button text wrapping issues
+
 ## [1.5.0] - 2025-12-15
 
 ### Added
@@ -148,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Activity heatmaps
 - Overview statistics
 
+[1.6.0]: https://github.com/earthtoolsmaker/biowatch/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/earthtoolsmaker/biowatch/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/earthtoolsmaker/biowatch/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/earthtoolsmaker/biowatch/releases/tag/v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biowatch",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Analyse and visualise camera trap datasets",
   "main": "./out/main/index.js",
   "author": "earthtoolsmaker.org",


### PR DESCRIPTION
## Summary
- Update version in package.json to 1.6.0
- Add changelog entry for v1.6.0 release

## Release Notes
See CHANGELOG.md for full details including:
- LILA datasets import
- E2E testing with Playwright
- Electron 39, React 19, Vite 7 upgrades
- Windows compatibility fixes
- And more