### PR TITLE
fix: add no-wrap to Not downloaded status badge

### DIFF
--- a/src/renderer/src/models.jsx
+++ b/src/renderer/src/models.jsx
@@ -221,7 +221,7 @@ function ModelRow({ model, pythonEnvironment, platform, isDev = false, refreshKe
               Downloading
             </span>
           ) : (
-            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+            <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-800 whitespace-nowrap">
               Not downloaded
             </span>
           )}


### PR DESCRIPTION
## Summary
- Prevent text wrapping on the "Not downloaded" status badge in AI Models settings tab

## Test plan
- [x] Open Settings > AI Models tab
- [x] Verify the "Not downloaded" badge no longer wraps text