### PR TITLE
fix: resolve infinite useEffect loop in Import component causing slow navigation

### DIFF
--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -166,9 +166,19 @@ export default function Import({ onNewStudy }) {
 
         if (completelyInstalledModels.length > 0) {
           const firstCompleteModel = completelyInstalledModels[0]
-          if (!selectedModel || !isModelCompletelyInstalled(selectedModel)) {
-            setSelectedModel(firstCompleteModel.reference)
-          }
+          // Use functional update to avoid depending on selectedModel in deps
+          setSelectedModel((currentSelected) => {
+            if (!currentSelected) {
+              return firstCompleteModel.reference
+            }
+            // Check if current selection is still valid
+            const isCurrentValid = completelyInstalledModels.some(
+              (m) =>
+                m.reference.id === currentSelected.id &&
+                m.reference.version === currentSelected.version
+            )
+            return isCurrentValid ? currentSelected : firstCompleteModel.reference
+          })
         }
       } catch (error) {
         console.error('Failed to fetch installed models and environments:', error)
@@ -177,7 +187,7 @@ export default function Import({ onNewStudy }) {
       }
     }
     fetchInstalledData()
-  }, [selectedModel, isModelCompletelyInstalled])
+  }, []) // Run only on mount - callbacks close over current state
 
   const getCompletelyInstalledModels = () => {
     return modelZoo.filter(

--- a/src/renderer/src/models.jsx
+++ b/src/renderer/src/models.jsx
@@ -102,7 +102,7 @@ function ModelRow({ model, pythonEnvironment, platform, isDev = false, refreshKe
     }
 
     getMLModelDownloadStatus()
-  }, [model.reference, pythonEnvironment.reference, refreshKey]) // Run this effect when the model reference changes or refreshKey changes
+  }, [model.reference, pythonEnvironment.reference, refreshKey])
 
   const handleRunHTTPServer = async ({ modelReference, pythonEnvironment }) => {
     setIsHTTPServerStarting(true)


### PR DESCRIPTION
## Summary

- Fixed infinite useEffect loop in Import component that caused 10-23 second delays when navigating to AI Models tab
- The useEffect had `selectedModel` and `isModelCompletelyInstalled` in its dependency array, but `isModelCompletelyInstalled` is a callback that gets recreated when state changes, causing the effect to re-run infinitely

## Changes

- Changed dependency array to `[]` (run only on mount)
- Used functional `setSelectedModel()` update to avoid depending on `selectedModel` in deps

## Test plan

- [x] Navigate to Import screen
- [x] Click "Install AI Models" button - should be instant now (was 10-23 seconds before)
- [x] Click Settings in sidebar - should remain fast
- [x] All tests pass (137/137)