### PR TITLE
Fix media modal navigation bbox flash

### DIFF
--- a/src/renderer/src/hooks/useImagePrefetch.js
+++ b/src/renderer/src/hooks/useImagePrefetch.js
@@ -1,0 +1,116 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+/**
+ * Custom hook for prefetching neighboring images in a navigable collection.
+ * Maintains an LRU cache of loaded images to enable instant navigation.
+ *
+ * @param {Object} options
+ * @param {Function} options.constructImageUrl - URL constructor function
+ * @param {Function} options.isVideoMedia - Video detection function
+ * @param {number} options.prefetchRadius - Number of images to prefetch in each direction (default: 2)
+ */
+export function useImagePrefetch({ constructImageUrl, isVideoMedia, prefetchRadius = 2 } = {}) {
+  // Map of mediaID -> { loaded: boolean, error: boolean }
+  const [loadState, setLoadState] = useState(new Map())
+
+  // Cache of Image instances (for cleanup)
+  const imageCache = useRef(new Map()) // mediaID -> Image
+
+  // Check if a specific image is ready
+  const isImageReady = useCallback(
+    (mediaID) => {
+      const state = loadState.get(mediaID)
+      return state?.loaded === true
+    },
+    [loadState]
+  )
+
+  // Prefetch a single image
+  const prefetchImage = useCallback(
+    (media) => {
+      if (!media || isVideoMedia(media)) return
+
+      const { mediaID, filePath } = media
+
+      // Already cached or loading
+      if (imageCache.current.has(mediaID)) return
+
+      const img = new Image()
+      imageCache.current.set(mediaID, img)
+
+      img.onload = () => {
+        setLoadState((prev) => new Map(prev).set(mediaID, { loaded: true, error: false }))
+      }
+
+      img.onerror = () => {
+        setLoadState((prev) => new Map(prev).set(mediaID, { loaded: false, error: true }))
+      }
+
+      img.src = constructImageUrl(filePath)
+    },
+    [constructImageUrl, isVideoMedia]
+  )
+
+  // Prefetch neighbors around current position
+  const prefetchNeighbors = useCallback(
+    (allItems, currentIndex) => {
+      if (!allItems?.length || currentIndex < 0) return
+
+      const start = Math.max(0, currentIndex - prefetchRadius)
+      const end = Math.min(allItems.length - 1, currentIndex + prefetchRadius)
+
+      // Collect media items to prefetch
+      const toPrefetch = []
+      for (let i = start; i <= end; i++) {
+        const item = allItems[i]
+        if (item?.items) {
+          // Sequence - prefetch all items in sequence
+          item.items.forEach((m) => toPrefetch.push(m))
+        } else {
+          toPrefetch.push(item)
+        }
+      }
+
+      // Prefetch each
+      toPrefetch.forEach(prefetchImage)
+
+      // Cleanup: remove items outside window from cache
+      const validMediaIds = new Set(toPrefetch.map((m) => m.mediaID))
+      imageCache.current.forEach((img, mediaID) => {
+        if (!validMediaIds.has(mediaID)) {
+          img.src = '' // Cancel loading
+          imageCache.current.delete(mediaID)
+          setLoadState((prev) => {
+            const next = new Map(prev)
+            next.delete(mediaID)
+            return next
+          })
+        }
+      })
+    },
+    [prefetchImage, prefetchRadius]
+  )
+
+  // Mark an image as loaded (called from img onLoad in component)
+  const markLoaded = useCallback((mediaID) => {
+    setLoadState((prev) => new Map(prev).set(mediaID, { loaded: true, error: false }))
+  }, [])
+
+  // Cleanup on unmount
+  useEffect(() => {
+    const cache = imageCache.current
+    return () => {
+      cache.forEach((img) => {
+        img.src = ''
+      })
+      cache.clear()
+    }
+  }, [])
+
+  return {
+    isImageReady,
+    prefetchNeighbors,
+    markLoaded,
+    loadState
+  }
+}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -35,6 +35,7 @@ import {
   screenToNormalizedWithZoom
 } from './utils/bboxCoordinates'
 import { useZoomPan } from './hooks/useZoomPan'
+import { useImagePrefetch } from './hooks/useImagePrefetch'
 import { groupMediaIntoSequences, groupMediaByEventID } from './utils/sequenceGrouping'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 
@@ -507,6 +508,8 @@ function ImageModal({
   const [isDrawMode, setIsDrawMode] = useState(false)
   const [videoError, setVideoError] = useState(false)
   const [imageError, setImageError] = useState(false)
+  // Track when current image has finished loading (for coordinating bbox rendering)
+  const [isCurrentImageReady, setIsCurrentImageReady] = useState(false)
   // Transcoding state: 'idle' | 'checking' | 'transcoding' | 'ready' | 'error'
   const [transcodeState, setTranscodeState] = useState('idle')
   const [transcodeProgress, setTranscodeProgress] = useState(0)
@@ -1220,10 +1223,11 @@ function ImageModal({
     zoomOut
   ])
 
-  // Reset selection, draw mode, and zoom when changing images
+  // Reset selection, draw mode, zoom, and image ready state when changing images
   useEffect(() => {
     setSelectedBboxId(null)
     setIsDrawMode(false)
+    setIsCurrentImageReady(false)
     resetZoom()
   }, [media?.mediaID, resetZoom])
 
@@ -1500,11 +1504,18 @@ function ImageModal({
                     src={constructImageUrl(media.filePath)}
                     alt={media.fileName || `Media ${media.mediaID}`}
                     className="max-w-full max-h-[calc(90vh-120px)] w-auto h-auto object-contain"
+                    onLoad={() => setIsCurrentImageReady(true)}
                     onError={() => setImageError(true)}
                     draggable={false}
                   />
-                  {/* Bbox overlay - editable bounding boxes (only for images) */}
-                  {showBboxes && hasBboxes && (
+                  {/* Loading overlay - show spinner while image is loading */}
+                  {!isCurrentImageReady && !imageError && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-gray-900/30 z-10 pointer-events-none">
+                      <Loader2 size={32} className="animate-spin text-white/70" />
+                    </div>
+                  )}
+                  {/* Bbox overlay - editable bounding boxes (only for images, only after image loads) */}
+                  {showBboxes && hasBboxes && isCurrentImageReady && (
                     <>
                       <svg
                         className="absolute inset-0 w-full h-full"
@@ -2606,6 +2617,13 @@ function Gallery({ species, dateRange, timeRange, includeNullTimestamps = false 
     return `local-file://get?path=${encodeURIComponent(fullFilePath)}`
   }
 
+  // Image prefetching for smooth modal navigation
+  const { prefetchNeighbors } = useImagePrefetch({
+    constructImageUrl,
+    isVideoMedia,
+    prefetchRadius: 2
+  })
+
   // Handle click on single image or sequence
   const handleImageClick = (media, sequence = null) => {
     setSelectedMedia(media)
@@ -2733,6 +2751,13 @@ function Gallery({ species, dateRange, timeRange, includeNullTimestamps = false 
   const hasNextInSequence =
     currentSequence && currentSequenceIndex < currentSequence.items.length - 1
   const hasPreviousInSequence = currentSequence && currentSequenceIndex > 0
+
+  // Prefetch neighboring images when modal is open
+  useEffect(() => {
+    if (isModalOpen && currentSeqIdx >= 0) {
+      prefetchNeighbors(allNavigableItems, currentSeqIdx)
+    }
+  }, [isModalOpen, currentSeqIdx, allNavigableItems, prefetchNeighbors])
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Add image prefetching hook with LRU cache for neighboring images (2 ahead/behind)
- Coordinate bbox rendering with image load to prevent flash on old images
- Show loading spinner while image is loading

## Problem
When navigating between images in the media modal, bounding boxes would briefly render on the old image before the new image loaded, causing a confusing visual flash.

## Solution
- Created `useImagePrefetch` hook that prefetches neighboring images using `Image()` constructor
- Added `isCurrentImageReady` state that resets on navigation and sets true on `onLoad`
- Guard bbox overlay rendering with `isCurrentImageReady` condition
- Added subtle loading spinner for slow image loads

## Test plan
- [x] Navigate forward/backward in modal - no bbox flash on old image
- [x] Rapid arrow key presses - smooth transitions
- [x] Multi-item sequences - works correctly
- [x] Videos - no prefetch attempted, existing behavior preserved