### PR TITLE
feat: make pencil icon clickable in detection list

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -106,7 +106,16 @@ function ObservationListPanel({ bboxes, selectedId, onSelect, onDelete }) {
                     {Math.round(bbox.classificationProbability * 100)}%
                   </span>
                 )}
-                <Pencil size={14} className="text-gray-400" />
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onSelect(bbox.observationID)
+                  }}
+                  className="p-1 rounded hover:bg-lime-100 text-gray-400 hover:text-lime-600 transition-colors"
+                  title="Edit bounding box"
+                >
+                  <Pencil size={14} />
+                </button>
                 <button
                   onClick={(e) => {
                     e.stopPropagation()


### PR DESCRIPTION
## Summary

- Makes the pencil icon in the ObservationListPanel clickable to select the corresponding bbox for geometry editing
- Clicking the pencil icon now selects the detection and shows editing handles on the image

## Test plan

- [x] Open the media modal for an image with detections
- [x] Expand the detection list (click "N detections" header)
- [x] Click the pencil icon on a detection
- [x] Verify the corresponding bbox shows editing handles (green border with drag handles)
- [x] Verify you can drag to resize or move the bbox
- [x] Verify clicking pencil on a different detection switches selection