### PR TITLE
Improve map tooltip styling on overview page

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -162,12 +162,11 @@ function DeploymentMap({ deployments, studyId }) {
           >
             <Popup>
               <div>
-                <h3 className="font-medium">{deployment.locationName || 'Unnamed Location'}</h3>
+                <h3 className="text-base font-semibold">
+                  {deployment.locationName || 'Unnamed Location'}
+                </h3>
                 <p className="text-sm">
                   {formatDate(deployment.deploymentStart)} - {formatDate(deployment.deploymentEnd)}
-                </p>
-                <p className="text-xs text-gray-500">
-                  Coordinates: {deployment.latitude}, {deployment.longitude}
                 </p>
               </div>
             </Popup>


### PR DESCRIPTION
## Summary
- Make deployment name more prominent with larger, bolder text
- Remove coordinates display from tooltip for cleaner presentation

## Test plan
- [x] Run the app with `npm run dev`
- [x] Navigate to a study with deployments that have coordinates
- [x] Click on a map marker and verify the tooltip shows the deployment name prominently without coordinates