### PR TITLE
feat: add hover tooltips to activity map pie chart markers

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -314,3 +314,19 @@ input::-webkit-inner-spin-button {
     transform: scale(0.95);
   }
 }
+
+/* Activity map species tooltip styles */
+.leaflet-tooltip.species-map-tooltip {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 0;
+  opacity: 1 !important;
+}
+
+.leaflet-tooltip.species-map-tooltip::before {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- Replace click-based Leaflet Popup with hover-based `bindTooltip()` for species observation markers on the activity map
- Tooltips display species names with colored dots matching pie chart colors, individual observation counts, and total count
- Works on both individual markers and cluster markers

## Changes

- Add `createTooltipContent` function for generating tooltip HTML
- Create `PieChartMarker` component with `useRef` for tooltip binding
- Bind tooltips to cluster markers in `iconCreateFunction`
- Add CSS styles for `species-map-tooltip` class

## Test plan

- [x] Navigate to Activity tab for a study with species data
- [x] Hover over individual pie chart markers - tooltip should appear above
- [x] Hover over cluster markers - tooltip should show aggregated counts
- [x] Verify tooltip styling matches design (white background, rounded corners, colored dots)
- [x] Confirm tooltips disappear when mouse leaves marker