### PR TITLE
feat: add ability to rename deployment locations

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -64,6 +64,9 @@ const { data, error } = await window.api.getMedia(studyId, { limit: 100 })
 | `getDeploymentsActivity(studyId)` | `deployments:get-activity` | studyId | `{ data: Activity[] }` |
 | `setDeploymentLatitude(studyId, deploymentID, latitude)` | `deployments:set-latitude` | studyId, deploymentID, latitude | `{ success: boolean }` |
 | `setDeploymentLongitude(studyId, deploymentID, longitude)` | `deployments:set-longitude` | studyId, deploymentID, longitude | `{ success: boolean }` |
+| `setDeploymentLocationName(studyId, locationID, locationName)` | `deployments:set-location-name` | studyId, locationID, locationName | `{ success: boolean }` |
+
+**Note on `setDeploymentLocationName`:** This updates the `locationName` for ALL deployments with the given `locationID`. When deployments share a `locationID` (grouped deployments), renaming any one updates the entire group.
 
 ### Locations
 

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -190,6 +190,14 @@ const api = {
       longitude
     )
   },
+  setDeploymentLocationName: async (studyId, locationID, locationName) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'deployments:set-location-name',
+      studyId,
+      locationID,
+      locationName
+    )
+  },
   setMediaTimestamp: async (studyId, mediaID, timestamp) => {
     return await electronAPI.ipcRenderer.invoke('media:set-timestamp', studyId, mediaID, timestamp)
   },


### PR DESCRIPTION
## Summary

- Add the ability to rename deployments with intelligent handling of grouped deployments
- When deployments share the same `locationID`, renaming any one of them renames ALL deployments in the group, ensuring consistency
- Inline editing with click-to-edit, Enter to save, Escape to cancel

## Changes

- **Backend**: Add `deployments:set-location-name` IPC handler that updates `locationName` for all deployments matching the `locationID`
- **Preload**: Add `setDeploymentLocationName` API method
- **Frontend**: Add `EditableLocationName` component with inline editing, update `DeploymentRow`, `LocationGroupHeader`, and `GroupedDeploymentRow`
- **Docs**: Update `docs/ipc-api.md` with new API

## Test plan

- [x] Single deployment: Rename and verify persists after page refresh
- [x] Grouped deployment (from header): Rename group, verify all deployments update
- [x] Grouped deployment (from child): Expand group, rename child, verify all siblings also update
- [x] Cancel: Press Escape, verify no changes
- [x] Map tooltips: Verify map marker tooltips reflect new name