### PR TITLE
feat: improve copy for Images Directory import when no AI models installed

### DIFF
--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -562,28 +562,18 @@ export default function Import({ onNewStudy, isFirstTimeUser = false }) {
             /* Images Directory Card - for first-time users */
             <Card className="group hover:border-blue-500/20 transition-all hover:shadow-md">
               <CardContent className="p-5">
-                <div className="flex items-start gap-4">
+                <div
+                  className={`flex ${getCompletelyInstalledModels().length === 0 ? 'items-center' : 'items-start'} gap-4`}
+                >
                   <div className="size-12 rounded-xl bg-gray-100 flex items-center justify-center shrink-0 group-hover:bg-blue-50 transition-colors">
                     <FolderOpen className="size-5 text-gray-500 group-hover:text-blue-600 transition-colors" />
                   </div>
                   <div className="flex-1 min-w-0">
                     <h4 className="mb-1 font-medium">Images Directory</h4>
                     {getCompletelyInstalledModels().length === 0 ? (
-                      <>
-                        <p className="text-sm text-gray-500 mb-3">
-                          Import images and classify species using AI
-                        </p>
-                        <div className="flex gap-3 items-center">
-                          <p className="text-sm text-gray-500">Requires an AI model</p>
-                          <Button
-                            variant="outline"
-                            className="shrink-0 w-40 ml-auto"
-                            onClick={() => navigate('/settings/ml_zoo')}
-                          >
-                            Install AI Models
-                          </Button>
-                        </div>
-                      </>
+                      <p className="text-sm text-gray-500">
+                        Import images and classify species using AI
+                      </p>
                     ) : (
                       <>
                         <p className="text-sm text-gray-500 mb-3">
@@ -660,6 +650,15 @@ export default function Import({ onNewStudy, isFirstTimeUser = false }) {
                       </>
                     )}
                   </div>
+                  {getCompletelyInstalledModels().length === 0 && (
+                    <Button
+                      variant="outline"
+                      className="shrink-0 w-40"
+                      onClick={() => navigate('/settings/ml_zoo')}
+                    >
+                      Install AI Models
+                    </Button>
+                  )}
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary
- Added explanatory text when no AI models are installed for the Images Directory import option
- Featured card (returning users): Shows message explaining that an AI model is required to import from an images folder
- Alternative card (first-time users): Shows compact "Requires an AI model" label above the install button
- Removed unused `getInstalledModels` function

<img width="830" height="194" alt="image" src="https://github.com/user-attachments/assets/0626d9a3-9e1b-4cbe-b907-1817e223256d" />

<img width="831" height="230" alt="image" src="https://github.com/user-attachments/assets/3a9df8ab-9265-4c93-9e9a-418a360df80b" />

<img width="851" height="161" alt="image" src="https://github.com/user-attachments/assets/764c0854-27ba-4a06-8e46-39fb1694f632" />

<img width="824" height="118" alt="image" src="https://github.com/user-attachments/assets/eb9d81fe-4a9a-4d74-ab5e-8bebb2ddbe90" />

<img width="825" height="198" alt="image" src="https://github.com/user-attachments/assets/ea820e67-d939-49e0-9da3-f853123ad59b" />


## Test plan
- [x] Start the app with no AI models installed
- [x] Navigate to the Import page as a first-time user → verify the alternative Images Directory card shows "Requires an AI model" text
- [x] Navigate to the Import page as a returning user → verify the featured Images Directory card shows the full explanatory message
- [x] Click "Install AI Models" → verify it navigates to `/settings/ml_zoo`
- [x] Install a model and return to Import page → verify the explanatory messages are replaced with the model selector dropdown