### PR TITLE
fix: ensure cache invalidation completes before navigation after import

### DIFF
--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -242,9 +242,10 @@ export default function Import({ onNewStudy, studiesCount = 0 }) {
       console.log('Demo dataset downloaded:', data, id)
 
       // Brief delay to show completion state, then navigate
-      setTimeout(() => {
+      setTimeout(async () => {
         setIsDemoImporting(false)
         setDemoImportProgress(null)
+        await queryClient.invalidateQueries({ queryKey: ['studies'] })
         onNewStudy({ id, name: data.name, data, path })
         navigate(`/study/${id}`)
       }, 800)
@@ -332,9 +333,10 @@ export default function Import({ onNewStudy, studiesCount = 0 }) {
       console.log('GBIF dataset imported:', data, id)
 
       // Brief delay to show completion state, then navigate
-      setTimeout(() => {
+      setTimeout(async () => {
         setIsGbifImporting(false)
         setGbifImportProgress(null)
+        await queryClient.invalidateQueries({ queryKey: ['studies'] })
         onNewStudy({ id, name: data.name, data, path })
         navigate(`/study/${id}`)
       }, 800)
@@ -371,9 +373,10 @@ export default function Import({ onNewStudy, studiesCount = 0 }) {
       console.log('LILA dataset imported:', data, id)
 
       // Brief delay to show completion state, then navigate
-      setTimeout(() => {
+      setTimeout(async () => {
         setIsLilaImporting(false)
         setLilaImportProgress(null)
+        await queryClient.invalidateQueries({ queryKey: ['studies'] })
         onNewStudy({ id, name: data.name, data, path })
         navigate(`/study/${id}`)
       }, 800)


### PR DESCRIPTION
## Summary

- Fix race condition in `handleDemoDataset`, `handleGbifImport`, and `handleLilaImport` where navigation occurred before the studies cache refetch completed
- Added explicit `await` on `queryClient.invalidateQueries` before navigation to ensure the cache is properly refreshed

## Problem

After importing a dataset (e.g., demo dataset), the sidebar would continue showing "No studies yet" instead of displaying the newly imported study. The cache wasn't being properly invalidated/refetched before navigation.

## Solution

Made the `setTimeout` callbacks async and added `await queryClient.invalidateQueries({ queryKey: ['studies'] })` before calling `onNewStudy` and `navigate`, ensuring the refetch completes before navigation.

## Test plan

- [x] Run existing tests: `npm test` (137 tests pass)
- [x] Start the app with no existing studies
- [x] Import the demo dataset via "Get Started" button
- [x] Verify the sidebar immediately shows the new study after import completes
- [x] Repeat test with GBIF and LILA dataset imports