### PR TITLE
fix readonly drizzle instance not running migrations

### DIFF
--- a/test/main/database/manager.test.js
+++ b/test/main/database/manager.test.js
@@ -1,0 +1,63 @@
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import Database from 'better-sqlite3'
+
+import {
+  getStudyDatabase,
+  closeAllDatabases,
+  getMetadata
+} from '../../../src/main/database/index.js'
+
+let testRootPath
+let testDbPath
+let testStudyId
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    const log = electronLog.default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    // electron-log not available in test environment
+  }
+
+  testStudyId = `test-readonly-${Date.now()}`
+  testRootPath = join(tmpdir(), 'biowatch-readonly-test', testStudyId)
+  testDbPath = join(testRootPath, 'studies', testStudyId, 'study.db')
+
+  mkdirSync(join(testRootPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(async () => {
+  await closeAllDatabases()
+
+  if (existsSync(testRootPath)) {
+    rmSync(testRootPath, { recursive: true, force: true })
+  }
+})
+
+describe('Readonly database migration safety', () => {
+  test('should run migrations before opening readonly database', async () => {
+    // Create an empty database file to simulate pre-migration schema
+    const sqlite = new Database(testDbPath)
+    sqlite.close()
+
+    const manager = await getStudyDatabase(testStudyId, testDbPath, { readonly: true })
+
+    await assert.doesNotReject(async () => {
+      const metadata = await getMetadata(manager.getDb())
+      assert.equal(metadata, null)
+    })
+
+    const metadataTable = manager
+      .getSqlite()
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='metadata'")
+      .all()
+
+    assert.equal(metadataTable.length, 1, 'metadata table should exist after migrations')
+  })
+})


### PR DESCRIPTION
When creating a readonly db instance, we were skipping migrations. This means that if a readonly instance is run first, before a readwrite, we could have errors because the db is not migrated and sql except a different format. 

This happened with the new sequenceGap migration and getMetadata function that would error out with "no sequenceGap column". 

We know run the migration in readonly instance by creating a temporary db, running the migrations, closing the temporary db and then opening a readonly one. 

@Chouffe This lazy approach works (only run migrations when we instantiate a db for this specific study) but it might be simpler to have a migration step at startup that migrate all studies. 
The only reason not to do that would be to avoid slow startup but we are anyway opening a db for all studies in order to show the studies list (that require to getMetadata)

In that case, would it be better to checkmigrations -> runmigrations -> open app once at startup and not have to check for every new db instance? 