### PR TITLE
Increase ML server startup timeout to 4 minutes

### DIFF
--- a/src/main/services/ml/server.ts
+++ b/src/main/services/ml/server.ts
@@ -134,7 +134,7 @@ export async function startAndWaitTillServerHealty({
   scriptArgs,
   healthEndpoint,
   retryInterval = 1000,
-  maxRetries = 120,
+  maxRetries = 240,
   restartRetries = 60,
   maxRestarts = 1,
   env = {}


### PR DESCRIPTION
## Summary
- Increases the ML server startup timeout from 2 minutes (120s) to 4 minutes (240s)
- Gives more time for model initialization on slower machines or first-time cold starts

## Test plan
- [x] Verify ML servers (SpeciesNet, DeepFaune, Manas) start successfully
- [x] Confirm timeout behavior on slow startup scenarios