### PR TITLE
Fix Python environment version extraction in CI workflow

### DIFF
--- a/.github/workflows/build_python_environments.yml
+++ b/.github/workflows/build_python_environments.yml
@@ -86,7 +86,7 @@ jobs:
           mkdir -p dist
           CONDA_BASE=$(conda info --base)
           CONDA_ENV_PATH=$CONDA_BASE/envs/common
-          ENVIRONMENT_VERSION=$(grep 'version' ./python-environments/common/pyproject.toml | awk -F '=' '{print $2}' | tr -d ' "')
+          ENVIRONMENT_VERSION=$(grep '^version' ./python-environments/common/pyproject.toml | awk -F '=' '{print $2}' | tr -d ' "')
           echo "${ENVIRONMENT_VERSION}"
 
           tar -czf dist/common-"${ENVIRONMENT_VERSION}"-${{ runner.os }}.tar.gz -C "${CONDA_BASE}"/envs common


### PR DESCRIPTION
## Summary

- Fix grep pattern in `build_python_environments.yml` to only match the project version line
- Add `^` anchor to exclude `target-version = "py312"` from ruff config that was causing incorrect archive naming

## Problem

The `grep 'version'` pattern was matching two lines in `pyproject.toml`:
1. `version = "0.1.3"` (intended)
2. `target-version = "py312"` (unintended, from ruff config)

This caused `ENVIRONMENT_VERSION` to contain both values, resulting in malformed archive names.

## Test plan

- [x] Verify CI produces correctly named archives: `common-0.1.3-{Linux,macOS,Windows}.tar.gz`