### PR TITLE
Add sex annotation to bbox observations

### DIFF
--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -322,6 +322,7 @@ export async function getMediaBboxes(dbPath, mediaID, includeWithoutBbox = false
         classificationMethod: observations.classificationMethod,
         classifiedBy: observations.classifiedBy,
         classificationTimestamp: observations.classificationTimestamp,
+        sex: observations.sex,
         modelID: modelRuns.modelID,
         modelVersion: modelRuns.modelVersion
       })
@@ -370,7 +371,8 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
         bboxHeight: observations.bboxHeight,
         classificationMethod: observations.classificationMethod,
         classifiedBy: observations.classifiedBy,
-        classificationTimestamp: observations.classificationTimestamp
+        classificationTimestamp: observations.classificationTimestamp,
+        sex: observations.sex
       })
       .from(observations)
       .where(and(inArray(observations.mediaID, mediaIDs), isNotNull(observations.bboxX)))

--- a/src/main/database/queries/observations.js
+++ b/src/main/database/queries/observations.js
@@ -39,7 +39,6 @@ export async function updateObservationClassification(dbPath, observationID, upd
 
     // Prepare update values following CamTrap DP specification
     const updateValues = {
-      scientificName: updates.scientificName || null,
       classificationMethod: 'human',
       classifiedBy: 'User',
       classificationTimestamp: new Date().toISOString(),
@@ -48,7 +47,11 @@ export async function updateObservationClassification(dbPath, observationID, upd
       classificationProbability: null
     }
 
-    // Add optional fields if provided
+    // Add optional fields if provided (only update if explicitly passed)
+    if (updates.scientificName !== undefined) {
+      updateValues.scientificName = updates.scientificName || null
+    }
+
     if (updates.commonName !== undefined) {
       updateValues.commonName = updates.commonName
     }

--- a/src/renderer/src/utils/positioning.js
+++ b/src/renderer/src/utils/positioning.js
@@ -25,13 +25,13 @@ export function computeBboxLabelPosition(bbox) {
   // VERTICAL: prefer above bbox, fallback to below when near top
   let top, verticalTransform
   if (isNearTop) {
-    // Place below bbox
+    // Place below bbox with gap
     top = `${(bbox.bboxY + bbox.bboxHeight) * 100}%`
     verticalTransform = 'translateY(4px)'
   } else {
-    // Place above bbox (default)
+    // Place above bbox with gap (default)
     top = `${bbox.bboxY * 100}%`
-    verticalTransform = 'translateY(-100%)'
+    verticalTransform = 'translateY(calc(-100% - 2px))'
   }
 
   // HORIZONTAL: prefer left-aligned, fallback to right-aligned when near right edge

--- a/test/renderer/positioning.test.js
+++ b/test/renderer/positioning.test.js
@@ -27,7 +27,7 @@ describe('computeBboxLabelPosition', () => {
 
     assertPercentApprox(result.left, 30)
     assertPercentApprox(result.top, 30)
-    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.transform, 'translateY(calc(-100% - 2px))')
   })
 
   test('bbox near top edge - label positioned below bbox', () => {
@@ -48,7 +48,7 @@ describe('computeBboxLabelPosition', () => {
     assertPercentApprox(result.left, 90)
     assertPercentApprox(result.top, 30)
     assert.ok(result.transform.includes('translateX(-100%)'))
-    assert.ok(result.transform.includes('translateY(-100%)'))
+    assert.ok(result.transform.includes('translateY(calc(-100% - 2px))'))
   })
 
   test('bbox near top-right corner - label below AND shifted left (regression test)', () => {
@@ -71,7 +71,7 @@ describe('computeBboxLabelPosition', () => {
 
     assertPercentApprox(result.left, 10)
     assertPercentApprox(result.top, 80)
-    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.transform, 'translateY(calc(-100% - 2px))')
   })
 
   test('bbox at bottom-right - label above, shifted left', () => {
@@ -80,7 +80,7 @@ describe('computeBboxLabelPosition', () => {
 
     assertPercentApprox(result.left, 95) // bboxX + bboxWidth
     assert.ok(result.transform.includes('translateX(-100%)'))
-    assert.ok(result.transform.includes('translateY(-100%)'))
+    assert.ok(result.transform.includes('translateY(calc(-100% - 2px))'))
   })
 
   test('edge case: bbox exactly at threshold', () => {
@@ -89,7 +89,7 @@ describe('computeBboxLabelPosition', () => {
     const result = computeBboxLabelPosition(bbox)
 
     // Should be above (not near top)
-    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.transform, 'translateY(calc(-100% - 2px))')
   })
 
   test('edge case: bbox right edge just under threshold', () => {
@@ -99,7 +99,7 @@ describe('computeBboxLabelPosition', () => {
 
     // 0.64 + 0.2 = 0.84, which is NOT > 0.85, so should be left-aligned
     assertPercentApprox(result.left, 64)
-    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.transform, 'translateY(calc(-100% - 2px))')
   })
 
   test('edge case: bbox right edge just over threshold', () => {


### PR DESCRIPTION
## Summary

- Add sex selector (female/male/unknown) to observation editor with tabbed UI
- Display sex indicator (♀/♂) on bbox labels and detection list with color coding (pink/blue)
- Support partial updates when editing observation attributes
- Make sex badge clickable to quickly edit sex attribute
- Add pencil icon handler in detection list to open observation editor

<img width="1104" height="712" alt="image" src="https://github.com/user-attachments/assets/92e5239a-2107-4100-a0bd-ae218f3b6b86" />
<img width="1112" height="196" alt="image" src="https://github.com/user-attachments/assets/7c145ab9-a157-42c7-bffb-200ae41fa113" />


## Changes

- `src/renderer/src/media.jsx`: Add SexSelector component, transform SpeciesSelector into ObservationEditor with tabs
- `src/main/database/queries/media.js`: Include sex field in getMediaBboxes queries
- `src/main/database/queries/observations.js`: Support partial updates in updateObservationClassification
- `src/renderer/src/utils/positioning.js`: Adjust label positioning with 2px gap above bbox
- `test/renderer/positioning.test.js`: Update tests for new positioning

## Test plan

- [ ] Open media item with bboxes
- [ ] Click bbox label to open editor, verify Species/Attributes tabs
- [ ] Select sex in Attributes tab, verify it persists
- [ ] Verify sex symbol displays on bbox label and detection list
- [ ] Click sex badge to open editor directly on Attributes tab
- [ ] Click pencil icon in detection list to open editor
- [ ] Run `npm test` - all 150 tests pass