### PR TITLE
Fix CI test coverage and missing datapackage.json handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Rebuild better-sqlite3 for Node.js
-        run: npm run test:rebuild
-
       - name: Run tests
-        run: node --test test/**/*.test.js
+        run: npm test

--- a/src/main/services/import/parsers/camtrapDP.js
+++ b/src/main/services/import/parsers/camtrapDP.js
@@ -67,15 +67,16 @@ export async function importCamTrapDatasetWithPath(
 
   // Get dataset name from datapackage.json
   let data
+  const datapackagePath = path.join(directoryPath, 'datapackage.json')
+  if (!fs.existsSync(datapackagePath)) {
+    const errorMessage = 'datapackage.json not found in directory'
+    log.error(errorMessage)
+    return { error: errorMessage }
+  }
   try {
-    const datapackagePath = path.join(directoryPath, 'datapackage.json')
-    if (fs.existsSync(datapackagePath)) {
-      const datapackage = JSON.parse(fs.readFileSync(datapackagePath, 'utf8'))
-      data = datapackage
-      log.info(`Found dataset name: ${data.name}`)
-    } else {
-      throw new Error('datapackage.json not found in directory')
-    }
+    const datapackage = JSON.parse(fs.readFileSync(datapackagePath, 'utf8'))
+    data = datapackage
+    log.info(`Found dataset name: ${data.name}`)
   } catch (error) {
     log.error('Error reading datapackage.json:', error)
     throw error


### PR DESCRIPTION
## Summary

- Use `npm test` in CI workflow instead of duplicating the test command, which fixes CI only running 5 of 27 test files due to unquoted glob pattern
- Return error object instead of throwing when `datapackage.json` is missing in CamTrapDP import (matches test expectations)

## Test plan

- [x] All 750 tests pass locally
- [ ] CI workflow runs all 27 test files