### PR TITLE
Add behavior annotation to media tab

### DIFF
--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -98,6 +98,7 @@ export async function getMediaBboxes(dbPath, mediaID, includeWithoutBbox = false
         classificationTimestamp: observations.classificationTimestamp,
         sex: observations.sex,
         lifeStage: observations.lifeStage,
+        behavior: observations.behavior,
         modelID: modelRuns.modelID,
         modelVersion: modelRuns.modelVersion
       })
@@ -148,7 +149,8 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
         classifiedBy: observations.classifiedBy,
         classificationTimestamp: observations.classificationTimestamp,
         sex: observations.sex,
-        lifeStage: observations.lifeStage
+        lifeStage: observations.lifeStage,
+        behavior: observations.behavior
       })
       .from(observations)
       .where(and(inArray(observations.mediaID, mediaIDs), isNotNull(observations.bboxX)))

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -14,3 +14,16 @@ export const BLANK_SENTINEL = '__blank__f47ac10b-58cc-4372-a567-0e02b2c3d479__'
  * Used when no user preference is set.
  */
 export const DEFAULT_SEQUENCE_GAP = 120
+
+/**
+ * Behavior categories for the UI.
+ * Groups behaviors by type for better organization in dropdown menus.
+ * Values must match those in suggestedBehaviorValues from validators.js
+ */
+export const behaviorCategories = /** @type {const} */ ({
+  Movement: ['running', 'walking', 'standing', 'resting', 'alert', 'vigilance'],
+  'Feeding (Herbivore)': ['grazing', 'browsing', 'rooting', 'foraging'],
+  'Feeding (Predator)': ['hunting', 'stalking', 'chasing', 'feeding', 'carrying prey'],
+  Social: ['grooming', 'playing', 'fighting', 'mating', 'nursing'],
+  Other: ['drinking', 'scent-marking', 'digging']
+})


### PR DESCRIPTION
## Summary

- Add behavior annotation feature to the media tab
- Users can select multiple behaviors from a categorized dropdown (Movement, Feeding, Social, etc.)
- Behaviors are saved when dropdown closes for better performance
- Display individual behavior tags in the detection list and on bbox labels


<img width="339" height="441" alt="image" src="https://github.com/user-attachments/assets/a12a01b2-57c0-4d6f-b24e-ac2395cc8614" />

<img width="350" height="446" alt="image" src="https://github.com/user-attachments/assets/e7a49250-a4fd-49c5-9bdc-2cc4072db1ce" />

<img width="1110" height="88" alt="image" src="https://github.com/user-attachments/assets/5085fe8c-8ffb-4064-b980-da0b38637ac0" />



## Changes

- **src/shared/constants.js**: Added `behaviorCategories` grouping 25 behaviors into 5 categories
- **src/renderer/src/media.jsx**: Added `BehaviorSelector` component with multi-select dropdown, integrated into ObservationEditor attributes tab
- **src/main/database/queries/media.js**: Added `behavior` field to `getMediaBboxes` and `getMediaBboxesBatch` queries

## Test plan

- [ ] Open media tab, click on a media with observations
- [ ] Select a bbox, go to Attributes tab
- [ ] Verify behavior dropdown appears with categorized options
- [ ] Select multiple behaviors, close dropdown, verify they save
- [ ] Verify behaviors display on bbox label (emerald colored)
- [ ] Verify behaviors display in detection list below media
- [ ] Refresh/reload, verify behaviors persist