### PR TITLE
allow downloading model from study page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "prettier.prettierPath": "./node_modules/prettier/index.cjs",
   "python.defaultInterpreterPath": "${workspaceFolder}/python/.venv/bin/python",
   "python.analysis.extraPaths": ["${workspaceFolder}/python/.venv/lib/python3.*/site-packages"]
 }

--- a/src/renderer/src/hooks/import.js
+++ b/src/renderer/src/hooks/import.js
@@ -32,8 +32,9 @@ export function useImportStatus(id, interval = 1000) {
       }
     },
     refetchInterval: (query) => {
-      // Only poll if import is running
-      return query?.state?.data?.isRunning ? interval : false
+      const data = query?.state?.data
+      // Poll if import is running OR if model is being downloaded
+      return data?.isRunning || data?.download ? interval : false
     },
     refetchIntervalInBackground: false,
     enabled: !!id


### PR DESCRIPTION
![Screenshot 2026-02-11 at 10 24 07](https://github.com/user-attachments/assets/d577b26d-07fd-4175-aa89-7774327d465a)

![Screenshot 2026-02-11 at 10 24 18](https://github.com/user-attachments/assets/dd5979d2-a27b-456f-9e7a-64640d758ab0)

@Chouffe Here is an implementation that redirect the user to the study page and show the model download progress as part of the original "import status". 

I initially tried to download and show the progress from the import screen but it surfaced an issue: 
- I select a model (non downloaded yet)
- Select files
- import UI show the download status and progress. 

At this point, with a naive implementation, if I navigate away or close the app, coming back to the import screen wouldn't show the download in progress. 
Conceptually, I don't see a reason why we should wait for a download to finish before importing another unrelated study (e.g demo dataset). This was the benefit of moving to the settings page, it made clear for the user that the import and model download were separate flows. 

That's why I went for a 3rd option where we create the study (and navigate to it) as soon as the user selected the folder since that's enough info. We then show the model download there. 
I think it makes even more sense in the specific case of 
- importing a folder
- model start processing 
- pause the import
- delete the model

At this point, resuming the import would fail without much feedback. 
With this PR, it would start downloading the model again. 

I think we trade some simplicity (users doesn't navigate between screen) at the cost of transparency (users might not notice we are downloading something big) 
