### PR TITLE
ci: only trigger python environment build on dependency file changes

### DIFF
--- a/.github/workflows/build_python_environments.yml
+++ b/.github/workflows/build_python_environments.yml
@@ -12,12 +12,14 @@ name: Build and Upload Python Environments
 on:
   pull_request:
     paths:
-      - 'python-environments/**'
+      - 'python-environments/**/pyproject.toml'
+      - 'python-environments/**/uv.lock'
   push:
     branches:
       - main
     paths:
-      - 'python-environments/**'
+      - 'python-environments/**/pyproject.toml'
+      - 'python-environments/**/uv.lock'
 
 jobs:
   build_and_upload_common_python_environment:


### PR DESCRIPTION
## Summary

- Narrow the path filter for the `build_python_environments` workflow to only `pyproject.toml` and `uv.lock` files
- Avoids unnecessary builds when unrelated files in `python-environments/` change (e.g. Python source code edits)

## Test plan

- [x] Verify the workflow does not trigger on changes to `.py` files under `python-environments/`
- [x] Verify the workflow triggers when `pyproject.toml` or `uv.lock` is modified