### PR TITLE
chore: install Python dev dependencies in local setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fix": "eslint --cache --fix .",
     "start": "electron-vite preview",
     "dev": "electron-vite dev --watch",
-    "build:python-env-common": "cd python-environments/common && uv sync",
+    "build:python-env-common": "cd python-environments/common && uv sync --extra dev",
     "build": "electron-vite build",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:win": "npm run build && electron-builder --win --publish always",


### PR DESCRIPTION
## Summary

- Add `--extra dev` to the `uv sync` command in the `build:python-env-common` npm script so that `make install` also installs dev tools (ruff, pytest, etc.)
- CI is unaffected since the production build pipeline uses its own `uv pip compile` flow which only includes main dependencies

## Test plan

- [x] Run `make install` and verify ruff/pytest are installed in the Python venv
- [x] Verify CI build pipeline still produces correct production environments