### PR TITLE
Always show files tab to prepare for osi camtrap dp export/import

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -217,6 +217,7 @@ export {
   getSpeciesDailyActivityByMedia,
   // Media
   getFilesData,
+  getFirstMediaFilePath,
   getMediaBboxes,
   getMediaBboxesBatch,
   checkMediaHaveBboxes,

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -33,6 +33,7 @@ export {
 // Media
 export {
   getFilesData,
+  getFirstMediaFilePath,
   getMediaBboxes,
   getMediaBboxesBatch,
   checkMediaHaveBboxes,

--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -64,6 +64,19 @@ export async function getFilesData(dbPath) {
 }
 
 /**
+ * Get the filePath of the first media record for a study
+ * Used to detect whether media is stored remotely (http) or locally
+ * @param {string} dbPath - Path to the SQLite database
+ * @returns {Promise<string|null>} - The filePath string or null if no media exists
+ */
+export async function getFirstMediaFilePath(dbPath) {
+  const studyId = getStudyIdFromPath(dbPath)
+  const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
+  const rows = await db.select({ filePath: media.filePath }).from(media).limit(1)
+  return rows.length > 0 ? rows[0].filePath : null
+}
+
+/**
  * Get all bounding boxes for a specific media file with model provenance
  * @param {string} dbPath - Path to the SQLite database
  * @param {string} mediaID - The media ID to get bboxes for

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -93,10 +93,16 @@ export async function getMediaForSequencePagination(dbPath, options = {}) {
     }
 
     // Correlated subquery for blank detection
+    // Excludes observationType='blank' so media with only blank observations are still considered blank
     const matchingObservations = db
       .select({ one: sql`1` })
       .from(observations)
-      .where(eq(observations.mediaID, media.mediaID))
+      .where(
+        and(
+          eq(observations.mediaID, media.mediaID),
+          or(isNull(observations.observationType), ne(observations.observationType, 'blank'))
+        )
+      )
 
     // Phase 1: Timestamped media
     if (phase === 'timestamped') {
@@ -406,10 +412,16 @@ export async function hasTimestampedMedia(dbPath, options = {}) {
     }
 
     // Correlated subquery for blank detection
+    // Excludes observationType='blank' so media with only blank observations are still considered blank
     const matchingObservations = db
       .select({ one: sql`1` })
       .from(observations)
-      .where(eq(observations.mediaID, media.mediaID))
+      .where(
+        and(
+          eq(observations.mediaID, media.mediaID),
+          or(isNull(observations.observationType), ne(observations.observationType, 'blank'))
+        )
+      )
 
     let result
 

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -76,11 +76,17 @@ export async function getBlankMediaCount(dbPath) {
     const studyId = getStudyIdFromPath(dbPath)
     const db = await getDrizzleDb(studyId, dbPath)
 
-    // Count media with no linked observations
+    // Count media with no linked non-blank observations
+    // Media with only observationType='blank' observations are considered blank
     const matchingObservations = db
       .select({ one: sql`1` })
       .from(observations)
-      .where(eq(observations.mediaID, media.mediaID))
+      .where(
+        and(
+          eq(observations.mediaID, media.mediaID),
+          or(isNull(observations.observationType), ne(observations.observationType, 'blank'))
+        )
+      )
 
     const result = await db
       .select({ count: count().as('count') })

--- a/src/main/ipc/media.js
+++ b/src/main/ipc/media.js
@@ -14,6 +14,7 @@ import {
   updateMediaTimestamp,
   updateMediaFavorite,
   countMediaWithNullTimestamps,
+  getFirstMediaFilePath,
   closeStudyDatabase
 } from '../database/index.js'
 
@@ -136,6 +137,22 @@ export function registerMediaIPCHandlers() {
       return { data: count }
     } catch (error) {
       log.error('Error counting media with null timestamps:', error)
+      return { error: error.message }
+    }
+  })
+
+  // Check whether the study's media files are stored remotely (http URLs)
+  ipcMain.handle('media:has-remote-paths', async (_, studyId) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        return { data: false }
+      }
+      const filePath = await getFirstMediaFilePath(dbPath)
+      console.error('First media file path:', filePath)
+      return { data: filePath != null && filePath.startsWith('http') }
+    } catch (error) {
+      log.error('Error checking remote media paths:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -68,6 +68,9 @@ const api = {
   getBestMedia: async (studyId, options = {}) => {
     return await electronAPI.ipcRenderer.invoke('media:get-best', studyId, options)
   },
+  hasRemoteMediaPaths: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('media:has-remote-paths', studyId)
+  },
   getBestImagePerSpecies: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('species:get-best-images', studyId)
   },
@@ -183,8 +186,16 @@ const api = {
   resumeImport: async (id) => {
     return await electronAPI.ipcRenderer.invoke('importer:resume', id)
   },
-  selectMoreImagesDirectory: async (id) => {
-    return await electronAPI.ipcRenderer.invoke('importer:select-more-images-directory', id)
+  selectMoreImagesDirectory: async (id, modelReference, country) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'importer:select-more-images-directory',
+      id,
+      modelReference,
+      country
+    )
+  },
+  getLatestModelRun: async (id) => {
+    return await electronAPI.ipcRenderer.invoke('importer:get-latest-model-run', id)
   },
   setDeploymentLatitude: async (studyId, deploymentID, latitude) => {
     return await electronAPI.ipcRenderer.invoke(

--- a/src/renderer/src/files.jsx
+++ b/src/renderer/src/files.jsx
@@ -1,13 +1,111 @@
+import { useState, useEffect, useCallback } from 'react'
 import { useParams } from 'react-router'
 import { FolderIcon } from 'lucide-react'
 import { useQueryClient, useQuery } from '@tanstack/react-query'
 import { useImportStatus } from '@renderer/hooks/import'
+import { modelZoo } from '../../shared/mlmodels.js'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select.jsx'
+import CountryPickerModal from './CountryPickerModal.jsx'
 
 export default function Files({ studyId }) {
   const { id } = useParams()
   const actualStudyId = studyId || id
   const queryClient = useQueryClient()
   const { importStatus } = useImportStatus(actualStudyId)
+
+  // Model picker state
+  const [showModelPicker, setShowModelPicker] = useState(false)
+  const [selectedModel, setSelectedModel] = useState(null)
+  const [installedModels, setInstalledModels] = useState([])
+  const [installedEnvironments, setInstalledEnvironments] = useState([])
+  const [showCountryPicker, setShowCountryPicker] = useState(false)
+
+  const isModelInstalled = useCallback(
+    (modelReference) =>
+      installedModels.some(
+        (inst) => inst.id === modelReference.id && inst.version === modelReference.version
+      ),
+    [installedModels]
+  )
+
+  const isEnvironmentInstalled = useCallback(
+    (envReference) =>
+      installedEnvironments.some(
+        (inst) => inst.id === envReference.id && inst.version === envReference.version
+      ),
+    [installedEnvironments]
+  )
+
+  const isModelCompletelyInstalled = useCallback(
+    (modelReference) => {
+      const model = modelZoo.find(
+        (m) =>
+          m.reference.id === modelReference.id && m.reference.version === modelReference.version
+      )
+      if (!model) return false
+      return isModelInstalled(model.reference) && isEnvironmentInstalled(model.pythonEnvironment)
+    },
+    [isModelInstalled, isEnvironmentInstalled]
+  )
+
+  // Fetch installed models/environments on mount
+  useEffect(() => {
+    const fetchInstalled = async () => {
+      try {
+        const [models, environments] = await Promise.all([
+          window.api.listInstalledMLModels(),
+          window.api.listInstalledMLModelEnvironments()
+        ])
+        setInstalledModels(models)
+        setInstalledEnvironments(environments)
+      } catch (error) {
+        console.error('Failed to fetch installed models:', error)
+      }
+    }
+    fetchInstalled()
+  }, [])
+
+  const handleAddFolder = async () => {
+    // Fetch latest model run for pre-selection
+    const latestRunResult = await window.api.getLatestModelRun(id)
+    const latestData = latestRunResult?.data
+
+    if (latestData?.modelReference && isModelCompletelyInstalled(latestData.modelReference)) {
+      setSelectedModel(latestData.modelReference)
+    } else {
+      // Default to first completely installed model
+      const firstInstalled = modelZoo.find(
+        (m) => isModelInstalled(m.reference) && isEnvironmentInstalled(m.pythonEnvironment)
+      )
+      setSelectedModel(firstInstalled?.reference || null)
+    }
+
+    setShowModelPicker(true)
+  }
+
+  const handleModelPickerConfirm = async () => {
+    setShowModelPicker(false)
+
+    if (!selectedModel) return
+
+    const isSpeciesNet = selectedModel.id === 'speciesnet'
+    if (isSpeciesNet) {
+      setShowCountryPicker(true)
+    } else {
+      await startImport(selectedModel, null)
+    }
+  }
+
+  const handleCountrySelected = async (countryCode) => {
+    setShowCountryPicker(false)
+    await startImport(selectedModel, countryCode)
+  }
+
+  const startImport = async (modelReference, country) => {
+    await window.api.selectMoreImagesDirectory(id, modelReference, country)
+    queryClient.invalidateQueries({ queryKey: ['importStatus', id] })
+    queryClient.invalidateQueries({ queryKey: ['filesData', actualStudyId] })
+  }
 
   const {
     data: filesData,
@@ -66,16 +164,110 @@ export default function Files({ studyId }) {
     <div className="px-8 py-3 h-full overflow-y-auto space-y-6">
       <header>
         <button
-          onClick={async () => {
-            await window.api.selectMoreImagesDirectory(id)
-            queryClient.invalidateQueries({ queryKey: ['importStatus', id] })
-            queryClient.invalidateQueries({ queryKey: ['filesData', actualStudyId] })
-          }}
+          onClick={handleAddFolder}
           className={`cursor-pointer transition-colors flex justify-center flex-row gap-2 items-center border border-gray-200 px-2 h-10 text-sm shadow-sm rounded-md hover:bg-gray-50`}
         >
           Add Folder
         </button>
       </header>
+
+      {/* Model Picker Modal */}
+      {showModelPicker && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+          onClick={() => setShowModelPicker(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4 flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Select Model</h2>
+              <p className="text-sm text-gray-500 mt-1">
+                Choose a model to classify images in the new folder.
+              </p>
+            </div>
+
+            <div className="px-6 py-4">
+              <Select
+                value={selectedModel ? `${selectedModel.id}-${selectedModel.version}` : ''}
+                onValueChange={(value) => {
+                  const [modelId, version] = value.split('-')
+                  const model = modelZoo.find(
+                    (m) => m.reference.id === modelId && m.reference.version === version
+                  )
+                  if (model && isModelCompletelyInstalled(model.reference)) {
+                    setSelectedModel(model.reference)
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full bg-white border-gray-200 h-11">
+                  <SelectValue>
+                    {selectedModel
+                      ? (() => {
+                          const model = modelZoo.find(
+                            (m) =>
+                              m.reference.id === selectedModel.id &&
+                              m.reference.version === selectedModel.version
+                          )
+                          return model ? `${model.name} v${model.reference.version}` : ''
+                        })()
+                      : 'Select a model'}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {modelZoo.map((model) => {
+                    const completelyInstalled =
+                      isModelInstalled(model.reference) &&
+                      isEnvironmentInstalled(model.pythonEnvironment)
+
+                    let statusText = ''
+                    if (!isModelInstalled(model.reference)) {
+                      statusText = ' (not installed)'
+                    } else if (!isEnvironmentInstalled(model.pythonEnvironment)) {
+                      statusText = ' (environment missing)'
+                    }
+
+                    return (
+                      <SelectItem
+                        key={`${model.reference.id}-${model.reference.version}`}
+                        value={`${model.reference.id}-${model.reference.version}`}
+                        disabled={!completelyInstalled}
+                        className={!completelyInstalled ? 'opacity-50 cursor-not-allowed' : ''}
+                      >
+                        {model.name} v{model.reference.version}
+                        {statusText}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">
+              <button
+                onClick={() => setShowModelPicker(false)}
+                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleModelPickerConfirm}
+                disabled={!selectedModel}
+                className="px-4 py-2 text-sm text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              >
+                Select Folder
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <CountryPickerModal
+        isOpen={showCountryPicker}
+        onConfirm={handleCountrySelected}
+        onCancel={() => setShowCountryPicker(false)}
+      />
       <div className="space-y-6">
         {Object.entries(importFolders).map(([importFolder, directories]) => (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200" key={importFolder}>

--- a/src/renderer/src/study.jsx
+++ b/src/renderer/src/study.jsx
@@ -67,7 +67,7 @@ function ErrorFallback({ error, resetErrorBoundary }) {
 }
 
 // Import status component to prevent unnecessary re-renders
-function ImportStatus({ studyId, importerName }) {
+function ImportStatus({ studyId }) {
   const { importStatus, resumeImport, pauseImport } = useImportStatus(studyId)
 
   console.log('ImportStatus', importStatus)
@@ -76,10 +76,7 @@ function ImportStatus({ studyId, importerName }) {
   const progress =
     importStatus && importStatus.total > 0 ? (importStatus.done / importStatus.total) * 100 : 0
   const showImportStatus =
-    importerName?.startsWith('local/') &&
-    importStatus &&
-    importStatus.total > 0 &&
-    importStatus.total > importStatus.done
+    importStatus && importStatus.total > 0 && importStatus.total > importStatus.done
 
   if (!showImportStatus) {
     return null
@@ -149,6 +146,15 @@ export default function Study() {
     enabled: !!id
   })
 
+  const { data: hasRemoteMedia } = useQuery({
+    queryKey: ['study', id, 'hasRemoteMedia'],
+    queryFn: async () => {
+      const result = await window.api.hasRemoteMediaPaths(id)
+      return result?.data ?? false
+    },
+    enabled: !!id
+  })
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -178,7 +184,7 @@ export default function Study() {
             <Tab to={`/study/${id}/deployments`} icon={Cctv}>
               Deployments
             </Tab>
-            {study?.importerName?.startsWith('local/') && (
+            {!hasRemoteMedia && (
               <Tab to={`/study/${id}/files`} icon={FolderOpen}>
                 Files
               </Tab>
@@ -224,16 +230,14 @@ export default function Study() {
               </ErrorBoundary>
             }
           />
-          {study?.importerName?.startsWith('local/') && (
-            <Route
-              path="files"
-              element={
-                <ErrorBoundary FallbackComponent={ErrorFallback} key={'files'}>
-                  <Files studyId={id} />
-                </ErrorBoundary>
-              }
-            />
-          )}
+          <Route
+            path="files"
+            element={
+              <ErrorBoundary FallbackComponent={ErrorFallback} key={'files'}>
+                <Files studyId={id} />
+              </ErrorBoundary>
+            }
+          />
           <Route
             path="settings"
             element={

--- a/test/integration/import/camtrapDP-null-fks.test.js
+++ b/test/integration/import/camtrapDP-null-fks.test.js
@@ -97,9 +97,14 @@ describe('CamTrapDP NULL Foreign Keys Tests', () => {
 
       const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
 
-      // Should import all 4 observation records including those with NULL mediaID
+      // Should import all 4 original observations + 2 blank observations for unlinked media
+      // (media002 and media004 have NULL deploymentID so can't be matched via expansion)
       const observationCount = countRecords(dbPath, 'observations')
-      assert.equal(observationCount, 4, 'Should import all observations including standalone ones')
+      assert.equal(
+        observationCount,
+        6,
+        'Should import all observations including standalone and blank ones'
+      )
 
       // Check for standalone observations (NULL mediaID)
       const standaloneObs = queryDatabase(
@@ -132,12 +137,16 @@ describe('CamTrapDP NULL Foreign Keys Tests', () => {
 
       const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
 
-      // Check for observations with NULL deploymentID
+      // Check for observations with NULL deploymentID (2 original + 2 blank for orphaned media)
       const noDeploymentObs = queryDatabase(
         dbPath,
         'SELECT * FROM observations WHERE deploymentID IS NULL'
       )
-      assert.equal(noDeploymentObs.length, 2, 'Should have 2 observations without deploymentID')
+      assert.equal(
+        noDeploymentObs.length,
+        4,
+        'Should have 4 observations without deploymentID (2 original + 2 blank)'
+      )
 
       // Verify observation without deploymentID
       const noDeployment = noDeploymentObs.find((o) => o.observationID === 'obs003')
@@ -183,7 +192,7 @@ describe('CamTrapDP NULL Foreign Keys Tests', () => {
       // Media with non-NULL deploymentID should reference existing deployments
       const mediaWithValidDeployment = queryDatabase(
         dbPath,
-        `SELECT m.* FROM media m 
+        `SELECT m.* FROM media m
          INNER JOIN deployments d ON m.deploymentID = d.deploymentID`
       )
       assert.equal(
@@ -193,17 +202,22 @@ describe('CamTrapDP NULL Foreign Keys Tests', () => {
       )
 
       // Observations with non-NULL mediaID should reference existing media
+      // (2 original with mediaID + 2 blank observations for unlinked media)
       const obsWithValidMedia = queryDatabase(
         dbPath,
-        `SELECT o.* FROM observations o 
+        `SELECT o.* FROM observations o
          INNER JOIN media m ON o.mediaID = m.mediaID`
       )
-      assert.equal(obsWithValidMedia.length, 2, 'Should have 2 observations with valid media refs')
+      assert.equal(
+        obsWithValidMedia.length,
+        4,
+        'Should have 4 observations with valid media refs (2 original + 2 blank)'
+      )
 
       // Observations with non-NULL deploymentID should reference existing deployments
       const obsWithValidDeployment = queryDatabase(
         dbPath,
-        `SELECT o.* FROM observations o 
+        `SELECT o.* FROM observations o
          INNER JOIN deployments d ON o.deploymentID = d.deploymentID`
       )
       assert.equal(


### PR DESCRIPTION
Preparing for a "Change Root" feature that allow any study (local model or camtrapdp) to update the path to the media directory. Few issues appears after enabling the "Files" tab on every study type.

---

When importing a CamtrapDP dataset (or re-importing a previously exported one), several issues appeared in the Files tab and Media tab:

"null" directory name in Files tab: Added folderName and importFolder fields to transformMediaRow in the CamtrapDP parser, deriving the folder name from the resolved file path relative to the import directory.

"Add Folder" button not working for CamtrapDP studies: Moved model selection from the main process (which relied on an existing model run) to the renderer via a new modal picker, so users can choose a model and country before adding folders to any study type.

Import progress bar not shown: Removed the importerName?.startsWith('local/') guard in ImportStatus, allowing the progress bar to display for all study types including CamtrapDP.

"0 media files" displayed: CamtrapDP datasets don't always include fileMediatype in the CSV. Added inferMediatype() to derive it from the file extension so media counts render correctly.

Most media shown as "unprocessed": Event-based CamtrapDP observations only match a subset of media via timestamp windows. Added createBlankObservationsForUnlinkedMedia() to generate synthetic blank observations for any media without a linked observation, so all media appear as processed.

Blank filter broken after synthetic observations: The blank detection query used NOT EXISTS (matching observations), which no longer worked because every media now has at least one observation. Updated the subqueries in species.js and sequences.js to exclude observationType = 'blank' when checking for real observations.