### PR TITLE
fix: skip code signing for fork PRs in build preview

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      CSC_FOR_PULL_REQUEST: true
+      CSC_FOR_PULL_REQUEST: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
 
     strategy:
       matrix:
@@ -47,11 +47,11 @@ jobs:
 
       - name: Build application
         env:
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_CERTIFICATE_BASE64 || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD || '' }}
-          APPLE_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && secrets.APPLE_TEAM_ID || '' }}
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_SIGNING_CERTIFICATE_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_TEAM_ID || '' }}
         run: npm run ${{ matrix.build_script }}
 
       - name: Upload build artifacts


### PR DESCRIPTION
## Summary

- Fork PRs don't have access to repository secrets, causing the macOS build to fail when electron-builder attempts code signing with empty credentials
- `CSC_FOR_PULL_REQUEST` is now only `true` for internal PRs (where the head repo matches the base repo)
- Apple signing env vars are similarly gated, so fork PRs produce unsigned but functional build artifacts

Fixes the CI failure seen in #360.