### PR TITLE
fix: skip duplicate media on re-import to prevent UNIQUE constraint errors

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -178,8 +178,8 @@ export async function insertModelOutput(db, data) {
     }
   }
 
-  const result = await db.insert(modelOutputs).values(data).returning()
-  return result[0]
+  const result = await db.insert(modelOutputs).values(data).onConflictDoNothing().returning()
+  return result[0] || null
 }
 
 /**

--- a/src/main/services/import/importer.js
+++ b/src/main/services/import/importer.js
@@ -257,6 +257,13 @@ export async function* getPredictions(mediaPaths, port, signal = null, sampleFps
 }
 
 async function insertMedia(db, fullPath, importFolder) {
+  // Check if media with this filePath already exists (dedup on re-import)
+  const existing = await db.select().from(media).where(eq(media.filePath, fullPath)).limit(1)
+  if (existing.length > 0) {
+    log.info(`Media already exists for path: ${fullPath}, skipping`)
+    return existing[0]
+  }
+
   const folderName =
     importFolder === path.dirname(fullPath)
       ? path.basename(importFolder)
@@ -278,7 +285,6 @@ async function insertMedia(db, fullPath, importFolder) {
 }
 
 async function getMedia(db, filepath) {
-  console.log('getMedia', filepath)
   try {
     const result = await db.select().from(media).where(eq(media.filePath, filepath)).limit(1)
     return result[0] || null
@@ -517,12 +523,17 @@ async function insertVideoPredictions(db, predictions, mediaRecord, modelInfo = 
 
   // 2. Store ALL frame predictions in modelOutputs.rawOutput (full provenance)
   const modelOutputID = crypto.randomUUID()
-  await insertModelOutput(db, {
+  const modelOutput = await insertModelOutput(db, {
     id: modelOutputID,
     mediaID: mediaRecord.mediaID,
     runID: modelInfo.runID,
     rawOutput: { frames: predictions } // Complete frame-by-frame data
   })
+
+  if (!modelOutput) {
+    log.info(`Model output already exists for video ${mediaRecord.filePath}, skipping`)
+    return
+  }
 
   // 3. Aggregate species across all frames (skip blanks)
   const modelType = modelInfo.modelID || 'speciesnet'
@@ -1077,12 +1088,17 @@ export class Importer {
 
               // Create model_output record for this media (with validated rawOutput)
               const modelOutputID = crypto.randomUUID()
-              await insertModelOutput(this.db, {
+              const modelOutput = await insertModelOutput(this.db, {
                 id: modelOutputID,
                 mediaID: mediaRecord.mediaID,
                 runID: runID,
                 rawOutput: prediction // Store full prediction as JSON
               })
+
+              if (!modelOutput) {
+                log.info(`Model output already exists for media ${mediaRecord.mediaID}, skipping`)
+                continue
+              }
 
               // Insert prediction with model provenance
               await insertPrediction(this.db, prediction, {


### PR DESCRIPTION
## Summary
- Skip existing files during re-import ("Add More Images") by checking if a media record with the same `filePath` already exists before inserting, preventing duplicate records
- Add `onConflictDoNothing()` safety net to `insertModelOutput` so duplicate `(mediaID, runID)` pairs are silently skipped instead of throwing UNIQUE constraint errors
- Handle `null` return from `insertModelOutput` in both image and video processing paths, skipping already-processed media gracefully

Fixes #361

## Test plan
- [x] Import a folder of images/videos
- [x] Import the same folder again via "Add More Images" — should complete without errors and not create duplicate media records
- [x] Verify ML processing runs without UNIQUE constraint errors on re-imported studies
- [x] `npm test` passes (750/750)