### PR TITLE
fix: skip R2 upload on PRs in build_python_environments workflow

### DIFF
--- a/.github/workflows/build_python_environments.yml
+++ b/.github/workflows/build_python_environments.yml
@@ -94,6 +94,7 @@ jobs:
           tar -czf dist/common-"${ENVIRONMENT_VERSION}"-${{ runner.os }}.tar.gz -C "${CONDA_BASE}"/envs common
 
       - name: Upload to Cloudflare R2
+        if: github.event_name == 'push'
         uses: shallwefootball/s3-upload-action@master
         with:
           aws_key_id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- Skip the "Upload to Cloudflare R2" step on pull requests in the `build_python_environments` workflow, since PR builds (especially from Dependabot) don't have access to repo secrets
- Build and compress steps still run on PRs to validate changes; upload only runs on push to main

Follows the same pattern as #364 for the build preview workflow.

## Verification

1. After merging, comment `@dependabot rebase` on PR #363 so it picks up the fix
2. Verify the python env build jobs pass (build succeeds, upload step is skipped)