### PR TITLE
fix: skip R2 upload and code signing for Dependabot PRs

### DIFF
--- a/.github/workflows/build_preview.yml
+++ b/.github/workflows/build_preview.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-      CSC_FOR_PULL_REQUEST: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      CSC_FOR_PULL_REQUEST: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
 
     strategy:
       matrix:
@@ -47,11 +47,11 @@ jobs:
 
       - name: Build application
         env:
-          CSC_LINK: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_SIGNING_CERTIFICATE_BASE64 || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD || '' }}
-          APPLE_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_ID || '' }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && secrets.APPLE_TEAM_ID || '' }}
+          CSC_LINK: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.APPLE_SIGNING_CERTIFICATE_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.APPLE_SIGNING_CERTIFICATE_PASSWORD || '' }}
+          APPLE_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.APPLE_ID || '' }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.APPLE_APP_SPECIFIC_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ matrix.os == 'macos-latest' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' && secrets.APPLE_TEAM_ID || '' }}
         run: npm run ${{ matrix.build_script }}
 
       - name: Upload build artifacts


### PR DESCRIPTION
## Summary

- Skip the "Upload to Cloudflare R2" step on PRs in the `build_python_environments` workflow, since Dependabot PRs don't have access to repo secrets
- Skip code signing for Dependabot PRs in the `build_preview` workflow — Dependabot branches live in the same repo (not a fork), so the existing fork check passed but secrets were still unavailable, causing the macOS build to fail

## Details

Dependabot PRs create branches in the same repository, so the existing condition `github.event.pull_request.head.repo.full_name == github.repository` evaluates to `true`. This caused electron-builder to attempt code signing with empty secrets, failing the build. Adding `github.actor != 'dependabot[bot]'` to the condition fixes this.

Follows the same pattern as #364.

## Verification

1. After merging, comment `@dependabot rebase` on PR #363 so it picks up the fix
2. Verify both workflows pass (build succeeds, upload and code signing steps are skipped)