### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to Biowatch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.1] - 2026-03-19
+
+### Added
+
+- Unit tests for detection_utils functions
+
+### Changed
+
+- Register local-file as a privileged scheme with startup helper
+- Bump python common environment to 0.1.4
+- Bump torch from 2.6.0 to 2.7.0
+- Bump speciesnet from 5.0.0 to 5.0.3
+- Extract shared detection functions into detection_utils module
+- Rename video_utils.py to utils.py and use safe_imread in all servers
+- Remove importer after completion
+
+### Fixed
+
+- Unpack ffmpeg-static in electron app package
+- Skip duplicate media on re-import to prevent UNIQUE constraint errors
+- Stream local-file responses and support suffix byte ranges
+- Fallback to a free port when preferred port is occupied
+- Handle error predictions in speciesnet parseScientificName
+- Skip macOS resource fork files and handle corrupt images gracefully
+
 ## [1.7.0] - 2026-02-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biowatch",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Analyse and visualise camera trap datasets",
   "main": "./out/main/index.js",
   "author": "earthtoolsmaker.org",

--- a/src/shared/mlmodels.js
+++ b/src/shared/mlmodels.js
@@ -118,6 +118,33 @@ export const pythonEnvironments = [
         files: 53286
       }
     }
+  },
+  {
+    type: 'conda',
+    reference: { id: 'common', version: '0.1.4' },
+    platform: {
+      mac: {
+        downloadURL:
+          'https://pub-5a51774bae6b4020a4948aaf91b72172.r2.dev/conda-environments/common-0.1.4-macOS.tar.gz',
+        size_in_MB: 428,
+        size_in_MB_installed: 1300,
+        files: 55470
+      },
+      linux: {
+        downloadURL:
+          'https://pub-5a51774bae6b4020a4948aaf91b72172.r2.dev/conda-environments/common-0.1.4-Linux.tar.gz',
+        size_in_MB: 4388,
+        size_in_MB_installed: 6200,
+        files: 55869
+      },
+      windows: {
+        downloadURL:
+          'https://pub-5a51774bae6b4020a4948aaf91b72172.r2.dev/conda-environments/common-0.1.4-Windows.tar.gz',
+        size_in_MB: 3062,
+        size_in_MB_installed: 6200,
+        files: 53286
+      }
+    }
   }
 ]
 
@@ -130,7 +157,7 @@ export const modelZoo = [
    */
   {
     reference: { id: 'speciesnet', version: '4.0.1a' },
-    pythonEnvironment: { id: 'common', version: '0.1.3' },
+    pythonEnvironment: { id: 'common', version: '0.1.4' },
     name: 'SpeciesNet',
     size_in_MB: 468,
     files: 6,
@@ -144,7 +171,7 @@ export const modelZoo = [
   },
   {
     reference: { id: 'deepfaune', version: '1.3' },
-    pythonEnvironment: { id: 'common', version: '0.1.3' },
+    pythonEnvironment: { id: 'common', version: '0.1.4' },
     name: 'DeepFaune',
     size_in_MB: 1200,
     files: 2,
@@ -158,7 +185,7 @@ export const modelZoo = [
   },
   {
     reference: { id: 'manas', version: '1.0' },
-    pythonEnvironment: { id: 'common', version: '0.1.3' },
+    pythonEnvironment: { id: 'common', version: '0.1.4' },
     name: 'Manas',
     size_in_MB: 502,
     files: 3,


### PR DESCRIPTION
## Summary

- Bump version to 1.7.1
- Add python common environment 0.1.4 (torch 2.7.0, speciesnet 5.0.3, security dep bumps)
- Update all 3 model zoo entries (speciesnet, deepfaune, manas) to use common 0.1.4

## Changelog

See [CHANGELOG.md](CHANGELOG.md) for the full list of changes since 1.7.0.

## Test plan

- [x] All 750 tests pass (`npm test`)
- [ ] After merge: `git tag v1.7.1 && git push origin v1.7.1`