### PR TITLE
fix: replace dynamic import of ffmpeg.js with static import

### DIFF
--- a/src/main/services/ffmpeg.js
+++ b/src/main/services/ffmpeg.js
@@ -5,10 +5,12 @@
  * ffmpeg-static, handling the app.asar → app.asar.unpacked rewrite
  * required in packaged Electron apps.
  *
+ * Intentionally free of Electron imports so the module can be loaded
+ * in plain Node.js (e.g. tests) without crashing.
+ *
  * @module ffmpeg
  */
 
-import { app } from 'electron'
 import ffmpegPath from 'ffmpeg-static'
 
 /**
@@ -22,7 +24,10 @@ export function getFFmpegBinaryPath() {
   }
 
   // Packaged Electron apps cannot execute binaries from app.asar.
-  return app.isPackaged && ffmpegPath.includes('app.asar')
+  // ffmpeg-static uses __dirname to resolve the binary path; inside an asar
+  // archive this yields a path containing "app.asar" which must be rewritten
+  // to "app.asar.unpacked" where electron-builder places the real binary.
+  return ffmpegPath.includes('app.asar')
     ? ffmpegPath.replace('app.asar', 'app.asar.unpacked')
     : ffmpegPath
 }

--- a/src/main/services/import/timestamp.js
+++ b/src/main/services/import/timestamp.js
@@ -14,6 +14,7 @@ import { spawn } from 'child_process'
 import fs from 'fs'
 import path from 'path'
 
+import { getFFmpegBinaryPath } from '../ffmpeg.js'
 import log from '../logger.js'
 
 /**
@@ -62,14 +63,13 @@ export function parseFFmpegCreationTime(stderr) {
 
 /**
  * Lazily resolve the FFmpeg binary path once.
- * Avoids top-level Electron imports (which break tests) and repeated
- * resolution during batch imports. The promise is cached after first call.
- * @returns {() => Promise<string>}
+ * Caches the result to avoid repeated resolution during batch imports.
+ * @returns {string}
  */
 const resolveFFmpegPath = (() => {
   let cached
   return () => {
-    if (!cached) cached = import('../ffmpeg.js').then((m) => m.getFFmpegBinaryPath())
+    if (!cached) cached = getFFmpegBinaryPath()
     return cached
   }
 })()
@@ -85,7 +85,7 @@ const resolveFFmpegPath = (() => {
 export async function extractTimestampFromFFmpeg(filePath) {
   let ffmpegBinary
   try {
-    ffmpegBinary = await resolveFFmpegPath()
+    ffmpegBinary = resolveFFmpegPath()
   } catch {
     log.warn('[Timestamp] FFmpeg binary not available, skipping container metadata extraction')
     return { timestamp: null, source: 'ffmpeg' }


### PR DESCRIPTION
## Summary

- Removed the `electron` dependency from `ffmpeg.js` — the `app.isPackaged` guard was redundant since `ffmpegPath.includes('app.asar')` alone correctly distinguishes packaged from non-packaged environments
- Converted `timestamp.js` from dynamic `import()` to static import, eliminating the Vite warning about mixed dynamic/static imports of the same module

## Test plan

- [x] All 25 existing timestamp tests pass
- [x] `npm run build` completes without the Vite warning
- [x] `npm run build:unpack` packaged build succeeds, ffmpeg binary correctly resolved at `app.asar.unpacked`
- [x] `extractTimestampFromFFmpeg` and `resolveVideoTimestamp` verified working end-to-end with a test video