### PR TITLE
fix(ci): add write permissions to Create Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the Create Release workflow
- Fixes the 403 error seen during the v1.7.2 release when `softprops/action-gh-release` tried to create a GitHub release

## Test plan

- [x] Will be verified on the next version tag push