### PR TITLE
fix(media): make video class editable and keep grid/filter in sync

### DIFF
--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -154,7 +154,7 @@ export async function getMediaBboxesBatch(dbPath, mediaIDs) {
         behavior: observations.behavior
       })
       .from(observations)
-      .where(and(inArray(observations.mediaID, mediaIDs), isNotNull(observations.bboxX)))
+      .where(inArray(observations.mediaID, mediaIDs))
       .orderBy(observations.mediaID, desc(observations.detectionConfidence))
 
     // Group results by mediaID

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -670,7 +670,14 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
                   type="text"
                   value={customSpecies}
                   onChange={(e) => setCustomSpecies(e.target.value)}
-                  onKeyDown={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    // Stop Backspace/Delete from reaching the ImageModal
+                    // window shortcut that deletes the selected observation.
+                    // Let other keys (Escape, arrows) bubble as before.
+                    if (e.key === 'Backspace' || e.key === 'Delete') {
+                      e.stopPropagation()
+                    }
+                  }}
                   placeholder="Enter species name..."
                   className="flex-1 px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-lime-500 focus:border-transparent"
                 />
@@ -700,7 +707,14 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
                   type="text"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  onKeyDown={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    // Stop Backspace/Delete from reaching the ImageModal
+                    // window shortcut that deletes the selected observation.
+                    // Let other keys (Escape, arrows) bubble as before.
+                    if (e.key === 'Backspace' || e.key === 'Delete') {
+                      e.stopPropagation()
+                    }
+                  }}
                   placeholder="Search species..."
                   className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-lime-500 focus:border-transparent"
                 />

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -596,6 +596,16 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
     }
   }
 
+  const handleMarkAsBlank = () => {
+    onUpdate({
+      observationID: bbox.observationID,
+      scientificName: null,
+      commonName: null,
+      observationType: 'blank'
+    })
+    onClose()
+  }
+
   const handleSexChange = (sex) => {
     onUpdate({
       observationID: bbox.observationID,
@@ -660,6 +670,7 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
                   type="text"
                   value={customSpecies}
                   onChange={(e) => setCustomSpecies(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
                   placeholder="Enter species name..."
                   className="flex-1 px-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-lime-500 focus:border-transparent"
                 />
@@ -689,6 +700,7 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
                   type="text"
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
                   placeholder="Search species..."
                   className="w-full pl-8 pr-3 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-lime-500 focus:border-transparent"
                 />
@@ -707,6 +719,18 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
                 <span className="text-sm">+ Add custom species</span>
               </button>
             )}
+
+            {/* Mark-as-blank option (only when there is a species to clear) */}
+            {!showCustomInput &&
+              bbox.observationID !== 'new-observation' &&
+              bbox.scientificName && (
+                <button
+                  onClick={handleMarkAsBlank}
+                  className="w-full px-3 py-2 text-left hover:bg-red-50 flex items-center gap-2 text-red-600 border-b border-gray-100"
+                >
+                  <span className="text-sm">✕ Mark as blank (no species)</span>
+                </button>
+              )}
 
             {/* Filtered species list */}
             {filteredSpecies.map((species) => (
@@ -1509,9 +1533,13 @@ function ImageModal({
     onSuccess: () => {
       // Invalidate related queries to refresh data
       queryClient.invalidateQueries({ queryKey: ['mediaBboxes', studyId, media?.mediaID] })
-      queryClient.invalidateQueries({ queryKey: ['speciesDistribution'] })
       queryClient.invalidateQueries({ queryKey: ['distinctSpecies', studyId] })
       queryClient.invalidateQueries({ queryKey: ['thumbnailBboxesBatch'] })
+      queryClient.invalidateQueries({ queryKey: ['sequences', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareSpeciesDistribution', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareTimeseries', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
     }
   })
 
@@ -1683,9 +1711,12 @@ function ImageModal({
       // Invalidate related queries to refresh data
       queryClient.invalidateQueries({ queryKey: ['mediaBboxes', studyId, media?.mediaID] })
       queryClient.invalidateQueries({ queryKey: ['distinctSpecies', studyId] })
-      queryClient.invalidateQueries({ queryKey: ['speciesDistribution'] })
-      // Also update thumbnail grid
       queryClient.invalidateQueries({ queryKey: ['thumbnailBboxesBatch'] })
+      queryClient.invalidateQueries({ queryKey: ['sequences', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareSpeciesDistribution', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareTimeseries', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
       // Exit draw mode and select the new observation
       setIsDrawMode(false)
       setSelectedBboxId(data.observationID)
@@ -2366,20 +2397,27 @@ function ImageModal({
           {/* Footer with metadata */}
           <div className="px-4 py-3 bg-white flex-shrink-0 border-t border-gray-100">
             <div className="flex items-center justify-between">
-              {/* For videos with observations, show editable species */}
-              {isVideoMedia(media) && bboxes.length > 0 ? (
+              {/* Videos are always editable. If a video-level observation
+                  exists, edit it; otherwise fall into the create-on-pick
+                  path used for images without bboxes. */}
+              {isVideoMedia(media) ? (
                 <button
                   ref={videoSpeciesLabelRef}
                   onClick={() => {
-                    // Select the video's observation (first/only one)
-                    setSelectedBboxId(bboxes[0].observationID)
-                    setShowObservationEditor(true)
+                    if (bboxes.length > 0) {
+                      setSelectedBboxId(bboxes[0].observationID)
+                      setShowObservationEditor(true)
+                    } else {
+                      handleImageWithoutBboxClick()
+                    }
                   }}
                   className="text-lg font-semibold text-left hover:text-lime-600 cursor-pointer flex items-center gap-2 group"
                   title="Click to edit species"
                 >
                   <span>
-                    <SpeciesLabel names={media.scientificName ? [media.scientificName] : []} />
+                    <SpeciesLabel
+                      names={bboxes[0]?.scientificName ? [bboxes[0].scientificName] : []}
+                    />
                   </span>
                   <Pencil
                     size={16}
@@ -3636,6 +3674,17 @@ export default function Activity({ studyData, studyId }) {
       setSelectedSpecies(getTopNonHumanSpecies(speciesDistributionData, 2))
     }
   }, [speciesDistributionData, searchParams, setSearchParams, selectedSpecies.length])
+
+  // Drop filter entries whose species no longer exists (e.g. after a rename
+  // or mark-as-blank). Preserve identity when nothing changes.
+  useEffect(() => {
+    if (!speciesDistributionData) return
+    const validNames = new Set(speciesDistributionData.map((s) => s.scientificName))
+    setSelectedSpecies((prev) => {
+      const filtered = prev.filter((s) => validNames.has(s.scientificName))
+      return filtered.length === prev.length ? prev : filtered
+    })
+  }, [speciesDistributionData])
 
   // Memoize speciesNames to avoid unnecessary re-renders
   const speciesNames = useMemo(

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1553,6 +1553,7 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareSpeciesDistribution', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareTimeseries', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareHeatmap', studyId] })
       queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
     }
   })
@@ -1730,6 +1731,7 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareSpeciesDistribution', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareTimeseries', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['sequenceAwareHeatmap', studyId] })
       queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
       // Exit draw mode and select the new observation
       setIsDrawMode(false)

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -2718,13 +2718,16 @@ function ThumbnailBboxOverlay({ bboxes, imageRef, containerRef }) {
     }
   }, [imageRef, containerRef])
 
-  if (!bboxes?.length || !imageBounds) return null
+  // Drop class-only observations (no bbox coordinates); getMediaBboxesBatch
+  // returns them for species-label lookup but they have no geometry to draw.
+  const drawableBboxes = bboxes?.filter((b) => b.bboxX != null) ?? []
+  if (!drawableBboxes.length || !imageBounds) return null
 
   const { offsetX, offsetY, renderedWidth, renderedHeight } = imageBounds
 
   return (
     <svg className="absolute inset-0 w-full h-full pointer-events-none z-10">
-      {bboxes.map((bbox, index) => (
+      {drawableBboxes.map((bbox, index) => (
         <rect
           key={bbox.observationID || index}
           x={offsetX + bbox.bboxX * renderedWidth}


### PR DESCRIPTION
## Summary

Editing the class of a video observation in the media tab frequently left the UI stuck on "No species" with the pencil icon gone, and renaming a species left the grid empty and the right-hand panel showing stale counts. This PR tracks down the chain of bugs behind the reported flow and fixes them:

- **Backspace silently deleted the observation being edited.** The `ImageModal` window-level `keydown` listener interprets Delete/Backspace as "delete the selected bbox"; the species editor's inputs didn't `stopPropagation`, so typing a correction in the search box deleted the video's observation row. Fixed by stopping propagation on both editor inputs.
- **A video with no observation row had no pencil.** With SpeciesNet frame detections present, `hasBboxes` is true, so the code fell through to the read-only `<h3>` branch. Widened the video footer branch to always render an editable button; when `bboxes.length === 0` it reuses `handleImageWithoutBboxClick` → `createMutation` (which already handles null bbox).
- **No UI path to mark an observation as blank.** Added a "✕ Mark as blank (no species)" option in the species picker, shown only when the current observation has a species to clear. Uses the existing three-case write logic in `updateObservationClassification`.
- **Grid tile showed "No species" for videos that had class-only observations.** `getMediaBboxesBatch` filtered by `isNotNull(observations.bboxX)`, which excluded video class-only rows. Dropped that predicate; `getSpeciesListFromSequence` already handles bbox-less rows correctly.
- **Modal footer read the stale `media.scientificName` prop.** Switched the video branch to read `bboxes[0]?.scientificName` (fresh via `mediaBboxes` invalidation).
- **Wrong cache keys invalidated on class-edit.** `updateMutation` / `createMutation` were invalidating a dead `['speciesDistribution']` key. Replaced with the keys actually used by the right panel and charts: `sequenceAwareSpeciesDistribution`, `sequenceAwareTimeseries`, `sequenceAwareDailyActivity`, `blankMediaCount`, and `sequences`.
- **Renaming a species left an unmatched filter chip.** Added an effect in `Activity` that reconciles `selectedSpecies` against the refreshed distribution, dropping entries whose `scientificName` no longer exists.

All fixes are in `src/renderer/src/media.jsx` except the one-line relaxation in `src/main/database/queries/media.js`.

Out of scope, noted while tracing: `src/main/services/prediction.js:482,506` writes to a non-existent `confidence` column when inserting video observations, so `classificationProbability` is always NULL for videos. Worth a small separate follow-up.

## Test plan

- [x] Open the `videos test` study (or run SpeciesNet on a folder with one video).
- [x] Open the video in the fullscreen modal, click the species pencil, type a filter and hit Backspace — the observation is **not** deleted; the editor stays open.
- [x] Rename the class (e.g. `sciurus vulgaris` → `sciurus custom`). Close the modal.
  - Grid shows the video (not "No media files match").
  - Right-hand panel shows `sciurus custom` with count 1 (the old `sciurus vulgaris` chip is gone).
- [x] Click the pencil again → "✕ Mark as blank (no species)" — footer flips to "No species", pencil still visible, "Blank" count on the right panel goes up.
- [x] Re-classify the blank video via the picker — observation is (re-)created, footer updates, grid label updates.
- [x] Regression: open an image with bboxes and edit species — the existing image flow still works.