### PR TITLE
fix(media): anchor species dropdown over media to prevent clipping

### DIFF
--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -31,7 +31,11 @@ import TimelineChart from './ui/timeseries'
 import DateTimePicker from './ui/DateTimePicker'
 import EditableBbox from './ui/EditableBbox'
 import VideoBboxOverlay from './ui/VideoBboxOverlay.jsx'
-import { computeBboxLabelPosition, computeSelectorPosition } from './utils/positioning'
+import {
+  computeBboxLabelPosition,
+  computeSelectorPosition,
+  computeFooterTriggeredSelectorPosition
+} from './utils/positioning'
 import {
   getImageBounds,
   screenToNormalized,
@@ -524,7 +528,14 @@ function BehaviorSelector({ value = [], onChange }) {
 /**
  * Observation editor with tabs for species selection and attributes
  */
-function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'species' }) {
+function ObservationEditor({
+  bbox,
+  studyId,
+  onClose,
+  onUpdate,
+  initialTab = 'species',
+  maxHeight
+}) {
   const [activeTab, setActiveTab] = useState(initialTab)
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
@@ -644,15 +655,32 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
     })
   }
 
+  // Cap the dropdown at a comfortable size so it doesn't stretch to fill
+  // every pixel of available height; the list scrolls inside this cap.
+  const MAX_DROPDOWN_HEIGHT = 400
+  const effectiveMaxHeight =
+    maxHeight != null ? Math.min(maxHeight, MAX_DROPDOWN_HEIGHT) : undefined
+
+  // Once the user has started searching, lock the editor height at the cap so
+  // switching between Species and Attributes tabs doesn't reshuffle the dropdown.
+  const isSearchActive = debouncedSearch.trim().length > 0
+  const rootStyle =
+    effectiveMaxHeight != null
+      ? isSearchActive
+        ? { maxHeight: `${effectiveMaxHeight}px`, height: `${effectiveMaxHeight}px` }
+        : { maxHeight: `${effectiveMaxHeight}px` }
+      : undefined
+
   return (
     <div
-      className={`absolute z-20 bg-white rounded-lg shadow-xl border border-gray-200 w-72 ${
+      className={`bg-white rounded-lg shadow-xl border border-gray-200 w-72 flex flex-col ${
         activeTab === 'species' ? 'overflow-hidden' : 'overflow-visible'
       }`}
+      style={rootStyle}
       onClick={(e) => e.stopPropagation()}
     >
       {/* Tab bar */}
-      <div className="flex border-b border-gray-200">
+      <div className="flex border-b border-gray-200 shrink-0">
         <button
           className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === 'species'
@@ -680,7 +708,7 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
         <>
           {/* Current classification chip */}
           {bbox.scientificName && (
-            <div className="p-2 border-b border-gray-100 flex items-center gap-2">
+            <div className="p-2 border-b border-gray-100 flex items-center gap-2 shrink-0">
               <div
                 className="flex-1 min-w-0 inline-flex items-center gap-1 px-2 py-1 rounded bg-lime-50 text-lime-700 text-sm"
                 title={
@@ -709,7 +737,7 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
           )}
 
           {/* Search input */}
-          <div className="p-2 border-b border-gray-100">
+          <div className="p-2 border-b border-gray-100 shrink-0">
             <div className="relative">
               <Search
                 size={16}
@@ -759,7 +787,7 @@ function ObservationEditor({ bbox, studyId, onClose, onUpdate, initialTab = 'spe
           </div>
 
           {/* Species list */}
-          <div className="max-h-52 overflow-y-auto">
+          <div className={`overflow-y-auto ${maxHeight != null ? 'flex-1 min-h-0' : 'max-h-52'}`}>
             {/* Ranked species list */}
             {results.map((species, index) => (
               <button
@@ -1309,37 +1337,16 @@ function ImageModal({
       return
     }
 
-    // For videos, use the footer species label ref
-    if (isVideoMedia(media) && videoSpeciesLabelRef.current) {
-      const labelRect = videoSpeciesLabelRef.current.getBoundingClientRect()
-      const containerRect = imageContainerRef.current?.getBoundingClientRect() || {
-        top: 0,
-        bottom: window.innerHeight,
-        left: 0,
-        right: window.innerWidth,
-        height: window.innerHeight,
-        width: window.innerWidth
-      }
-      const position = computeSelectorPosition(labelRect, containerRect)
-      setSelectorPosition(position)
-      return
-    }
-
-    // For images without bboxes (using footer species label), use imageSpeciesLabelRef
-    if (
-      (selectedBboxId === 'new-observation' || !bboxLabelRefs.current[selectedBboxId]) &&
-      imageSpeciesLabelRef.current
-    ) {
-      const labelRect = imageSpeciesLabelRef.current.getBoundingClientRect()
-      const containerRect = imageContainerRef.current?.getBoundingClientRect() || {
-        top: 0,
-        bottom: window.innerHeight,
-        left: 0,
-        right: window.innerWidth,
-        height: window.innerHeight,
-        width: window.innerWidth
-      }
-      const position = computeSelectorPosition(labelRect, containerRect)
+    // Footer-triggered: anchor dropdown over the media area (above the footer)
+    // so it stays fully visible regardless of screen height. Applies to videos
+    // and to images without bboxes.
+    const footerTriggered =
+      (isVideoMedia(media) && videoSpeciesLabelRef.current) ||
+      ((selectedBboxId === 'new-observation' || !bboxLabelRefs.current[selectedBboxId]) &&
+        imageSpeciesLabelRef.current)
+    if (footerTriggered && imageContainerRef.current) {
+      const mediaAreaRect = imageContainerRef.current.getBoundingClientRect()
+      const position = computeFooterTriggeredSelectorPosition(mediaAreaRect)
       setSelectorPosition(position)
       return
     }
@@ -1363,37 +1370,14 @@ function ImageModal({
     if (!selectedBboxId || !showObservationEditor) return
 
     const handleResize = () => {
-      // For videos, use footer label ref
-      if (isVideoMedia(media) && videoSpeciesLabelRef.current) {
-        const labelRect = videoSpeciesLabelRef.current.getBoundingClientRect()
-        const containerRect = imageContainerRef.current?.getBoundingClientRect() || {
-          top: 0,
-          bottom: window.innerHeight,
-          left: 0,
-          right: window.innerWidth,
-          height: window.innerHeight,
-          width: window.innerWidth
-        }
-        const position = computeSelectorPosition(labelRect, containerRect)
-        setSelectorPosition(position)
-        return
-      }
-
-      // For images without bboxes, use footer label ref
-      if (
-        (selectedBboxId === 'new-observation' || !bboxLabelRefs.current[selectedBboxId]) &&
-        imageSpeciesLabelRef.current
-      ) {
-        const labelRect = imageSpeciesLabelRef.current.getBoundingClientRect()
-        const containerRect = imageContainerRef.current?.getBoundingClientRect() || {
-          top: 0,
-          bottom: window.innerHeight,
-          left: 0,
-          right: window.innerWidth,
-          height: window.innerHeight,
-          width: window.innerWidth
-        }
-        const position = computeSelectorPosition(labelRect, containerRect)
+      // Footer-triggered: recompute using the media area (excludes footer).
+      const footerTriggered =
+        (isVideoMedia(media) && videoSpeciesLabelRef.current) ||
+        ((selectedBboxId === 'new-observation' || !bboxLabelRefs.current[selectedBboxId]) &&
+          imageSpeciesLabelRef.current)
+      if (footerTriggered && imageContainerRef.current) {
+        const mediaAreaRect = imageContainerRef.current.getBoundingClientRect()
+        const position = computeFooterTriggeredSelectorPosition(mediaAreaRect)
         setSelectorPosition(position)
         return
       }
@@ -2624,6 +2608,7 @@ function ImageModal({
                 bbox={selectedBbox}
                 studyId={studyId}
                 initialTab={editorInitialTab}
+                maxHeight={selectorPosition.maxHeight}
                 onClose={() => {
                   setShowObservationEditor(false)
                   setSelectedBboxId(null)

--- a/src/renderer/src/utils/positioning.js
+++ b/src/renderer/src/utils/positioning.js
@@ -109,3 +109,67 @@ export function computeSelectorPosition(
 
   return { x, y, transform }
 }
+
+/**
+ * Compute dropdown position for a footer-triggered species selector.
+ *
+ * The dropdown's bottom edge is pinned just above the footer (at the media
+ * area's bottom edge) and it grows upward. The caller applies the returned
+ * `maxHeight` to the dropdown so it never extends past the top of the
+ * viewport; content inside the dropdown scrolls when it exceeds that height.
+ *
+ * @param {Object} mediaAreaRect - Rect of the media-only container (excludes the footer)
+ * @param {number} mediaAreaRect.top
+ * @param {number} mediaAreaRect.bottom
+ * @param {number} mediaAreaRect.left
+ * @param {number} mediaAreaRect.right
+ * @param {number} mediaAreaRect.height
+ * @param {number} mediaAreaRect.width
+ * @param {Object} [selectorSize]
+ * @param {number} [selectorSize.width=288]
+ * @param {Object} [viewport] - Viewport size (defaults to window)
+ * @param {number} [viewport.width]
+ * @param {number} [viewport.height]
+ * @returns {Object} Position values { x, y, transform, maxHeight }
+ */
+export function computeFooterTriggeredSelectorPosition(
+  mediaAreaRect,
+  selectorSize = { width: 288 },
+  viewport = {
+    width: typeof window !== 'undefined' ? window.innerWidth : 1920,
+    height: typeof window !== 'undefined' ? window.innerHeight : 1080
+  }
+) {
+  const PADDING = 16
+  const MARGIN = 8
+
+  // Bottom edge: pinned just above the footer. Also keep it inside the viewport
+  // bottom so a partially-off-screen media area can't push the anchor offscreen.
+  const bottomY = Math.min(mediaAreaRect.bottom - MARGIN, viewport.height - PADDING)
+
+  // Available height: from the bottom anchor upward to the viewport top
+  // (minus padding). Kept non-negative to stay safe for style consumers.
+  const maxHeight = Math.max(0, bottomY - PADDING)
+
+  // Horizontal: left-align inside the media area, clamped to viewport.
+  let x = mediaAreaRect.left + PADDING
+  if (x + selectorSize.width > mediaAreaRect.right - PADDING) {
+    x = mediaAreaRect.right - PADDING - selectorSize.width
+  }
+  if (x < mediaAreaRect.left + PADDING) {
+    x = mediaAreaRect.left + PADDING
+  }
+  if (x + selectorSize.width > viewport.width - PADDING) {
+    x = viewport.width - PADDING - selectorSize.width
+  }
+  if (x < PADDING) {
+    x = PADDING
+  }
+
+  return {
+    x,
+    y: bottomY,
+    transform: 'translateY(-100%)',
+    maxHeight
+  }
+}

--- a/test/renderer/positioning.test.js
+++ b/test/renderer/positioning.test.js
@@ -2,7 +2,8 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   computeBboxLabelPosition,
-  computeSelectorPosition
+  computeSelectorPosition,
+  computeFooterTriggeredSelectorPosition
 } from '../../src/renderer/src/utils/positioning.js'
 
 // Helper to extract numeric percentage value from string like "30%"
@@ -188,5 +189,133 @@ describe('computeSelectorPosition', () => {
     // Should use the custom size for calculations
     assert.equal(result.y, 332) // bottom + MARGIN
     assert.equal(result.transform, 'none')
+  })
+})
+
+describe('computeFooterTriggeredSelectorPosition', () => {
+  const viewport = { width: 1920, height: 1080 }
+  const selectorSize = { width: 288 }
+
+  test('tall media area - bottom pinned above footer, grows upward', () => {
+    const mediaAreaRect = {
+      top: 80,
+      bottom: 880,
+      left: 400,
+      right: 1500,
+      height: 800,
+      width: 1100
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, viewport)
+
+    // x: media-area left + PADDING
+    assert.equal(result.x, 416)
+    // y: media-area bottom - MARGIN
+    assert.equal(result.y, 872)
+    assert.equal(result.transform, 'translateY(-100%)')
+    // maxHeight: bottomY - PADDING
+    assert.equal(result.maxHeight, 856)
+  })
+
+  test('short media area - dropdown still bottom-pinned, maxHeight bounded', () => {
+    const mediaAreaRect = {
+      top: 100,
+      bottom: 400,
+      left: 200,
+      right: 1200,
+      height: 300,
+      width: 1000
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, viewport)
+
+    // bottomY = 392, maxHeight = 392 - 16 = 376
+    assert.equal(result.y, 392)
+    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.maxHeight, 376)
+    assert.equal(result.x, 216)
+  })
+
+  test('narrow media area - x clamp leaves room for width', () => {
+    const mediaAreaRect = {
+      top: 80,
+      bottom: 880,
+      left: 900,
+      right: 1100,
+      height: 800,
+      width: 200
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, viewport)
+
+    // x = left + PADDING = 916; right-clamp: 796; left-clamp reinstates 916.
+    assert.equal(result.x, 916)
+  })
+
+  test('media area extends past viewport bottom - bottomY clamped to viewport', () => {
+    const mediaAreaRect = {
+      top: 400,
+      bottom: 1200, // past viewport.height = 1080
+      left: 300,
+      right: 1400,
+      height: 800,
+      width: 1100
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, viewport)
+
+    // bottomY = min(1192, 1064) = 1064; maxHeight = 1064 - 16 = 1048
+    assert.equal(result.y, 1064)
+    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.maxHeight, 1048)
+  })
+
+  test('media area above viewport - maxHeight still positive and rendered area bounded', () => {
+    const mediaAreaRect = {
+      top: -200,
+      bottom: 100,
+      left: 300,
+      right: 1400,
+      height: 300,
+      width: 1100
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, viewport)
+
+    // bottomY = min(92, 1064) = 92; maxHeight = 92 - 16 = 76
+    assert.equal(result.y, 92)
+    assert.equal(result.transform, 'translateY(-100%)')
+    assert.equal(result.maxHeight, 76)
+  })
+
+  test('narrow viewport - horizontal viewport clamp wins', () => {
+    const narrowViewport = { width: 300, height: 1080 }
+    const mediaAreaRect = {
+      top: 80,
+      bottom: 880,
+      left: 10,
+      right: 290,
+      height: 800,
+      width: 280
+    }
+    const result = computeFooterTriggeredSelectorPosition(
+      mediaAreaRect,
+      selectorSize,
+      narrowViewport
+    )
+
+    // viewport-x clamp: 300 - 16 - 288 = -4, then min-x clamp: 16.
+    assert.equal(result.x, 16)
+  })
+
+  test('maxHeight never negative when bottomY is at/above top of viewport', () => {
+    const tallViewport = { width: 1920, height: 1080 }
+    const mediaAreaRect = {
+      top: -500,
+      bottom: -100, // fully above the viewport
+      left: 300,
+      right: 1400,
+      height: 400,
+      width: 1100
+    }
+    const result = computeFooterTriggeredSelectorPosition(mediaAreaRect, selectorSize, tallViewport)
+
+    // bottomY = min(-108, 1064) = -108; maxHeight = max(0, -108 - 16) = 0
+    assert.equal(result.maxHeight, 0)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #411. The species/attributes dropdown was partially cut off at the bottom of the viewport when opened from the footer button — reproducible on videos (always) and on images without bboxes (also triggered from the footer). Root causes were two-fold: the dropdown anchored *below* its trigger button (which sat below the media), and `ObservationEditor` was `position: absolute`, which escaped the positioning wrapper so `maxHeight` never applied.

- New `computeFooterTriggeredSelectorPosition` in `utils/positioning.js` pins the dropdown's bottom edge just above the footer (clamped to the viewport) and returns a `maxHeight` up to the viewport top.
- Both footer-triggered branches in `media.jsx` (video, image-without-bbox) go through the new function; the image-with-bbox path is unchanged.
- `ObservationEditor` is now a flex column in normal flow with `maxHeight` on its root, the species list takes remaining height via `flex-1 min-h-0`, and sibling rows are `shrink-0`.
- Dropdown is capped at 400px so it doesn't stretch to fill the viewport.
- While a search is active, the height is locked at the cap so switching between Species and Attributes tabs doesn't reshuffle the dropdown.

## Test plan

- [x] Unit tests for `computeFooterTriggeredSelectorPosition` (7 cases) — pass
- [x] Full suite `make test` — 903/903 pass
- [x] Manual: video + long search result list → dropdown bottom pinned above footer, list scrolls internally
- [x] Manual: image without bboxes → same behavior
- [x] Manual: shrunk window height → dropdown stays fully visible
- [x] Manual: image *with* bboxes (regression) → dropdown still anchors to the bbox label, unchanged
- [x] Manual: Species ↔ Attributes tab switching with populated search → dropdown height is stable