### PR TITLE
fix(overview): show common names alongside scientific names

### DIFF
--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -1,6 +1,46 @@
 import { useState, useRef, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ChevronLeft, ChevronRight, CameraOff, X, Heart, Play, Loader2 } from 'lucide-react'
+import { useCommonName } from '../utils/commonNames'
+
+function toTitleCase(str) {
+  return str.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+// Binomial nomenclature: only the genus (first letter) is capitalized.
+function capitalizeGenus(str) {
+  if (!str) return str
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
+
+/**
+ * Renders the common name (title-cased) for a carousel thumbnail label.
+ * Falls back to the scientific name when no common name resolves.
+ */
+function SpeciesThumbnailLabel({ scientificName }) {
+  const common = useCommonName(scientificName)
+  if (!scientificName) return <>Unknown species</>
+  if (common && common !== scientificName) return <>{toTitleCase(common)}</>
+  return <>{capitalizeGenus(scientificName)}</>
+}
+
+/**
+ * Renders "Common name (Scientific name)" when a common name resolves,
+ * otherwise just the scientific name. Empty input renders "No species".
+ */
+function SpeciesHeading({ scientificName }) {
+  const common = useCommonName(scientificName)
+  if (!scientificName) return <>No species</>
+  if (common && common !== scientificName) {
+    return (
+      <>
+        {toTitleCase(common)}{' '}
+        <span className="italic text-white/80">({capitalizeGenus(scientificName)})</span>
+      </>
+    )
+  }
+  return <>{capitalizeGenus(scientificName)}</>
+}
 
 /**
  * Constructs a file URL for the local file or cached-image protocol
@@ -185,7 +225,9 @@ function ImageViewerModal({
 
         {/* Species info overlay */}
         <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 rounded-b-lg">
-          <p className="text-white text-lg font-medium">{media.scientificName || 'No species'}</p>
+          <p className="text-white text-lg font-medium">
+            <SpeciesHeading scientificName={media.scientificName} />
+          </p>
           {media.timestamp && (
             <p className="text-white/70 text-sm">{new Date(media.timestamp).toLocaleString()}</p>
           )}
@@ -469,7 +511,9 @@ function VideoViewerModal({
 
         {/* Species info overlay */}
         <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 rounded-b-lg">
-          <p className="text-white text-lg font-medium">{media.scientificName || 'No species'}</p>
+          <p className="text-white text-lg font-medium">
+            <SpeciesHeading scientificName={media.scientificName} />
+          </p>
           {media.timestamp && (
             <p className="text-white/70 text-sm">{new Date(media.timestamp).toLocaleString()}</p>
           )}
@@ -599,7 +643,7 @@ function MediaCard({ media, onClick, studyId }) {
       {/* Species label */}
       <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-2 z-20">
         <p className="text-white text-xs font-medium truncate">
-          {media.scientificName || 'Unknown species'}
+          <SpeciesThumbnailLabel scientificName={media.scientificName} />
         </p>
       </div>
     </div>

--- a/src/renderer/src/ui/SpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/SpeciesTooltipContent.jsx
@@ -1,5 +1,15 @@
 import { useState, useEffect } from 'react'
 import { CameraOff, Loader2 } from 'lucide-react'
+import { useCommonName } from '../utils/commonNames'
+
+function toTitleCase(str) {
+  return str.replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function capitalizeGenus(str) {
+  if (!str) return str
+  return str.charAt(0).toUpperCase() + str.slice(1)
+}
 
 /**
  * Construct image URL for local files (same pattern as BestMediaCarousel.jsx)
@@ -29,6 +39,7 @@ function isRemoteUrl(filePath) {
 export default function SpeciesTooltipContent({ imageData, studyId }) {
   const [imageError, setImageError] = useState(false)
   const [imageLoaded, setImageLoaded] = useState(false)
+  const common = useCommonName(imageData?.scientificName)
 
   // Reset state when imageData changes
   useEffect(() => {
@@ -39,6 +50,9 @@ export default function SpeciesTooltipContent({ imageData, studyId }) {
   if (!imageData?.filePath) {
     return null
   }
+
+  const sciName = imageData.scientificName
+  const hasCommon = common && common !== sciName
 
   return (
     <div className="w-[280px] bg-white rounded-lg shadow-xl border border-gray-200 overflow-hidden">
@@ -72,7 +86,16 @@ export default function SpeciesTooltipContent({ imageData, studyId }) {
 
       {/* Species name footer */}
       <div className="px-2 py-1.5 bg-gray-50 border-t border-gray-100">
-        <p className="text-xs text-gray-600 truncate italic">{imageData.scientificName}</p>
+        <p className="text-xs text-gray-600 truncate">
+          {hasCommon ? (
+            <>
+              {toTitleCase(common)}{' '}
+              <span className="italic text-gray-500">({capitalizeGenus(sciName)})</span>
+            </>
+          ) : (
+            <span className="italic">{capitalizeGenus(sciName)}</span>
+          )}
+        </p>
       </div>
     </div>
   )

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -33,20 +33,24 @@ function SpeciesRow({
 
   const rowContent = (
     <div className="cursor-pointer group" onClick={() => onToggle(species)}>
-      <div className="flex justify-between mb-1 items-center cursor-pointer">
-        <div className="flex items-center cursor-pointer">
+      <div className="flex justify-between mb-1 items-center cursor-pointer gap-2">
+        <div className="flex items-center cursor-pointer min-w-0 flex-1">
           <div
-            className={`w-2 h-2 rounded-full mr-2 border cursor-pointer ${isSelected ? `border-transparent bg-[${color}]` : 'border-gray-300'} group-hover:bg-gray-800 `}
+            className={`w-2 h-2 rounded-full mr-2 flex-shrink-0 border cursor-pointer ${isSelected ? `border-transparent bg-[${color}]` : 'border-gray-300'} group-hover:bg-gray-800 `}
             style={{ backgroundColor: isSelected ? color : null }}
           ></div>
-          <span className={`text-sm ${isBlankEntry ? 'text-gray-500 italic' : 'capitalize'}`}>
+          <span
+            className={`text-sm truncate ${isBlankEntry ? 'text-gray-500 italic' : 'capitalize'}`}
+          >
             {displayName}
+            {showScientificInItalic && (
+              <span className="text-gray-500 italic ml-2 normal-case">
+                {species.scientificName}
+              </span>
+            )}
           </span>
-          {showScientificInItalic && (
-            <span className="text-gray-500 text-sm italic ml-2">{species.scientificName}</span>
-          )}
         </div>
-        <span className="text-xs text-gray-500">{species.count}</span>
+        <span className="text-xs text-gray-500 flex-shrink-0">{species.count}</span>
       </div>
       <div className="w-full bg-gray-200 rounded-full h-2">
         <div


### PR DESCRIPTION
## Summary
- **Best Captures carousel**: thumbnails show the common name (title-cased, falls back to scientific); image/video modals show \`Common Name (Scientific name)\`.
- **Species hover tooltip** (overview/activity/media): footer now shows \`Common Name (Scientific name)\` instead of only the scientific name.
- **Species list rows** (activity, media): long \`common name (scientific name)\` labels now truncate with an ellipsis instead of wrapping to a second line in narrow sidebars.

Scientific names are normalized so the genus is capitalized (per binomial nomenclature).

## Test plan
- [x] Open a study in the overview tab and confirm the Best Captures thumbnails display common names; click a thumbnail and verify the modal shows \`Common Name (Scientific name)\`.
- [x] Click a video thumbnail and verify the video modal shows the same format.
- [x] Hover a species row in the overview and confirm the tooltip footer reads \`Common Name (Scientific name)\`.
- [x] Open the activity/media tabs at a narrow width and confirm long species labels truncate with ellipsis on a single line (dot and count stay visible).
- [x] Species with no resolvable common name fall back to the scientific name, genus-capitalized.