### PR TITLE
perf(overview): cold-start ~40s → ~2s, no UI freeze

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -223,6 +223,7 @@ export {
   getSpeciesTimeseriesByMedia,
   getSpeciesHeatmapDataByMedia,
   getSpeciesDailyActivityByMedia,
+  getSequenceAwareSpeciesCountsSQL,
   // Media
   getFilesData,
   getMediaBboxes,

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -582,7 +582,10 @@ export async function getBestImagePerSpecies(dbPath) {
       studyId,
       dbPath,
       `SELECT 1 FROM observations
-         WHERE bboxX IS NOT NULL AND bboxWidth > 0 AND bboxHeight > 0
+         WHERE bboxX IS NOT NULL
+           AND bboxWidth IS NOT NULL
+           AND bboxWidth > 0
+           AND bboxHeight > 0
          LIMIT 1`,
       []
     )

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -570,6 +570,28 @@ export async function getBestImagePerSpecies(dbPath) {
   try {
     const studyId = getStudyIdFromPath(dbPath)
 
+    // Short-circuit: the scoring formula requires bbox area/visibility/padding,
+    // which only make sense when bboxWidth/bboxHeight are populated. Many
+    // datasets (e.g. CamTrap DP exports with point-only annotations) have
+    // bboxX/bboxY but no bbox size. On such datasets the big CTE below
+    // evaluates to zero rows but still scans the whole observations table
+    // (~2s on 2.7M rows). A quick EXISTS probe is cheap when bboxes are
+    // present (stops at the first match) and bounded when they are not
+    // (full scan ~200ms on gmu8_leuven, vs the query's ~2.3s).
+    const hasUsableBbox = await executeRawQuery(
+      studyId,
+      dbPath,
+      `SELECT 1 FROM observations
+         WHERE bboxX IS NOT NULL AND bboxWidth > 0 AND bboxHeight > 0
+         LIMIT 1`,
+      []
+    )
+    if (hasUsableBbox.length === 0) {
+      const elapsedTime = Date.now() - startTime
+      log.info(`Retrieved best images for 0 species in ${elapsedTime}ms (no usable bbox data)`)
+      return []
+    }
+
     // Use the same scoring formula as getBestMedia but return only one per species
     const query = `
       WITH

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -346,6 +346,32 @@ export async function getBestMedia(dbPath, options = {}) {
       return favorites
     }
 
+    // Short-circuit: the auto-scored CTE below requires observations with
+    // bbox geometry populated (area / visibility / padding feed the composite
+    // score). Datasets without usable bboxes (e.g. CamTrap DP exports with
+    // point-only annotations, or LILA/COCO sources) would otherwise scan
+    // millions of observation rows through four CTEs to return zero rows -
+    // ~28s of main-thread block on a 1.16M-row study with no bboxes. Mirror
+    // the probe pattern used in getBestImagePerSpecies.
+    const hasUsableBbox = await executeRawQuery(
+      studyId,
+      dbPath,
+      `SELECT 1 FROM observations
+         WHERE bboxX IS NOT NULL
+           AND bboxWidth IS NOT NULL
+           AND bboxWidth > 0
+           AND bboxHeight > 0
+         LIMIT 1`,
+      []
+    )
+    if (hasUsableBbox.length === 0) {
+      const elapsedTime = Date.now() - startTime
+      log.info(
+        `Retrieved ${favorites.length} best media (${favorites.length} favorites, no usable bbox data) in ${elapsedTime}ms`
+      )
+      return favorites
+    }
+
     // Step 2: Get auto-scored non-favorites to fill remaining slots
     const remainingSlots = limit - favorites.length
     const favoriteMediaIDs = favorites.map((f) => f.mediaID)

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -266,30 +266,23 @@ export async function getBestMedia(dbPath, options = {}) {
   try {
     const studyId = getStudyIdFromPath(dbPath)
 
-    // Step 1: Get user-marked favorites first
-    // Note: We need to join observations via both mediaID AND timestamp (for CamTrap DP datasets
-    // where observations.mediaID is NULL and link is via eventStart = media.timestamp)
+    // Step 1: Get user-marked favorites first.
+    // Observations link to media via mediaID for most importers, or via
+    // eventStart = media.timestamp for CamTrap DP datasets (where
+    // observations.mediaID is NULL).
+    //
+    // The favorites CTE is materialized first so the ROW_NUMBER() subqueries
+    // only partition observations belonging to the ~12 favorite media, not
+    // the entire observations table (which can be millions of rows).
     const favoritesQuery = `
-      SELECT
-        m.mediaID,
-        m.filePath,
-        m.fileName,
-        m.timestamp,
-        m.deploymentID,
-        m.fileMediatype,
-        m.favorite,
-        COALESCE(o1.observationID, o2.observationID) as observationID,
-        COALESCE(o1.scientificName, o2.scientificName) as scientificName,
-        COALESCE(o1.bboxX, o2.bboxX) as bboxX,
-        COALESCE(o1.bboxY, o2.bboxY) as bboxY,
-        COALESCE(o1.bboxWidth, o2.bboxWidth) as bboxWidth,
-        COALESCE(o1.bboxHeight, o2.bboxHeight) as bboxHeight,
-        COALESCE(o1.detectionConfidence, o2.detectionConfidence) as detectionConfidence,
-        COALESCE(o1.classificationProbability, o2.classificationProbability) as classificationProbability,
-        999.0 as compositeScore
-      FROM media m
-      -- Strategy 1: Join via mediaID (for ML runs, Wildlife Insights, Deepfaune)
-      LEFT JOIN (
+      WITH favs AS (
+        SELECT
+          mediaID, filePath, fileName, timestamp, deploymentID, fileMediatype, favorite
+        FROM media
+        WHERE favorite = 1
+      ),
+      -- Strategy 1: Join via mediaID (ML runs, Wildlife Insights, Deepfaune)
+      obs_by_mediaID AS (
         SELECT
           mediaID,
           observationID,
@@ -299,11 +292,12 @@ export async function getBestMedia(dbPath, options = {}) {
           classificationProbability,
           ROW_NUMBER() OVER (PARTITION BY mediaID ORDER BY detectionConfidence DESC) as rn
         FROM observations
-        WHERE scientificName IS NOT NULL AND scientificName != ''
+        WHERE mediaID IN (SELECT mediaID FROM favs)
           AND mediaID IS NOT NULL
-      ) o1 ON m.mediaID = o1.mediaID AND o1.rn = 1
-      -- Strategy 2: Join via timestamp (for CamTrap DP datasets where mediaID is NULL)
-      LEFT JOIN (
+          AND scientificName IS NOT NULL AND scientificName != ''
+      ),
+      -- Strategy 2: Join via timestamp (CamTrap DP datasets)
+      obs_by_ts AS (
         SELECT
           eventStart,
           observationID,
@@ -313,12 +307,32 @@ export async function getBestMedia(dbPath, options = {}) {
           classificationProbability,
           ROW_NUMBER() OVER (PARTITION BY eventStart ORDER BY detectionConfidence DESC) as rn
         FROM observations
-        WHERE scientificName IS NOT NULL AND scientificName != ''
-          AND mediaID IS NULL
-      ) o2 ON m.timestamp = o2.eventStart AND o2.rn = 1
-      WHERE m.favorite = 1
-        AND COALESCE(o1.scientificName, o2.scientificName) IS NOT NULL
-      ORDER BY m.timestamp DESC
+        WHERE mediaID IS NULL
+          AND eventStart IN (SELECT timestamp FROM favs)
+          AND scientificName IS NOT NULL AND scientificName != ''
+      )
+      SELECT
+        f.mediaID,
+        f.filePath,
+        f.fileName,
+        f.timestamp,
+        f.deploymentID,
+        f.fileMediatype,
+        f.favorite,
+        COALESCE(o1.observationID, o2.observationID) as observationID,
+        COALESCE(o1.scientificName, o2.scientificName) as scientificName,
+        COALESCE(o1.bboxX, o2.bboxX) as bboxX,
+        COALESCE(o1.bboxY, o2.bboxY) as bboxY,
+        COALESCE(o1.bboxWidth, o2.bboxWidth) as bboxWidth,
+        COALESCE(o1.bboxHeight, o2.bboxHeight) as bboxHeight,
+        COALESCE(o1.detectionConfidence, o2.detectionConfidence) as detectionConfidence,
+        COALESCE(o1.classificationProbability, o2.classificationProbability) as classificationProbability,
+        999.0 as compositeScore
+      FROM favs f
+      LEFT JOIN obs_by_mediaID o1 ON o1.mediaID = f.mediaID AND o1.rn = 1
+      LEFT JOIN obs_by_ts o2 ON o2.eventStart = f.timestamp AND o2.rn = 1
+      WHERE COALESCE(o1.scientificName, o2.scientificName) IS NOT NULL
+      ORDER BY f.timestamp DESC
       LIMIT ?
     `
 

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -27,7 +27,8 @@ export {
   getSpeciesDistributionByMedia,
   getSpeciesTimeseriesByMedia,
   getSpeciesHeatmapDataByMedia,
-  getSpeciesDailyActivityByMedia
+  getSpeciesDailyActivityByMedia,
+  getSequenceAwareSpeciesCountsSQL
 } from './species.js'
 
 // Media

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -2,7 +2,7 @@
  * Species-related database queries
  */
 
-import { getDrizzleDb, deployments, media, observations } from '../index.js'
+import { getDrizzleDb, getStudyDatabase, deployments, media, observations } from '../index.js'
 import {
   eq,
   and,
@@ -149,6 +149,132 @@ export async function getSpeciesDistributionByMedia(dbPath) {
     return result
   } catch (error) {
     log.error(`Error querying species distribution by media: ${error.message}`)
+    throw error
+  }
+}
+
+/**
+ * Compute the sequence-aware species distribution entirely in SQL for speed,
+ * producing the same aggregated result as:
+ *   getSpeciesDistributionByMedia(dbPath) + calculateSequenceAwareSpeciesCounts(rows, gapSeconds)
+ * on the happy-path gap values (null / 0). For positive gapSeconds the
+ * timestamp-gap grouping logic is non-trivial to replicate in SQL (deployment-
+ * scoped, video-aware, dual-direction gap check); this function returns null
+ * so callers fall back to the JS implementation.
+ *
+ * Semantics mirror the current JS implementation:
+ *  - gapSeconds === 0        → group by eventID per deployment-agnostic event;
+ *                              per (species, event) take MAX count, SUM by species
+ *                              (media without eventID become their own event).
+ *  - null/undefined/<= 0
+ *    (not a positive number) → "each media is its own sequence": count of
+ *                              observations per species (matches the
+ *                              null-gap short-circuit at grouping.js:59).
+ *  - gapSeconds > 0          → returns null (caller must fall back to JS).
+ *
+ * INNER JOIN on media is preserved to mirror the current behavior: observations
+ * whose mediaID has no matching media row are dropped from counts.
+ *
+ * @param {string} dbPath - Path to the SQLite database
+ * @param {number|null|undefined} gapSeconds - Sequence gap threshold
+ * @returns {Promise<Array<{scientificName: string, count: number}>|null>}
+ *   Sorted by count desc, or null if the caller must use the JS fallback.
+ */
+export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
+  const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
+  if (isPositiveGap) return null
+
+  const startTime = Date.now()
+  const studyId = getStudyIdFromPath(dbPath)
+  const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
+  const sqlite = manager.getSqlite()
+
+  const useEventIDPath = gapSeconds === 0
+
+  try {
+    let rows
+    if (useEventIDPath) {
+      // eventID path: per (species, eventID) take MAX(per-media count), SUM by species.
+      // Media without eventID contribute as their own single-media "event" via COALESCE.
+      // Null-timestamp media are separated out and contribute as individual single-media
+      // "sequences" (mirrors the nullTimestampMedia branch in speciesCounts.js:112-130),
+      // which differs from valid-ts-with-eventID grouping in the edge case where a null-ts
+      // media shares its eventID with valid-ts media.
+      rows = sqlite
+        .prepare(
+          `
+          WITH per_media AS (
+            SELECT o.scientificName AS scientificName,
+                   o.eventID AS eventID,
+                   m.mediaID AS mediaID,
+                   m.timestamp AS timestamp,
+                   COUNT(o.observationID) AS cnt
+              FROM observations o
+              INNER JOIN media m ON o.mediaID = m.mediaID
+              WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+                AND (o.observationType IS NULL OR o.observationType != 'blank')
+              GROUP BY o.scientificName, m.mediaID
+          ),
+          classified AS (
+            SELECT scientificName, eventID, mediaID, cnt,
+                   CASE
+                     WHEN timestamp IS NULL OR timestamp = '' OR julianday(timestamp) IS NULL
+                     THEN 1 ELSE 0
+                   END AS is_null_ts
+              FROM per_media
+          ),
+          valid_per_event AS (
+            SELECT scientificName,
+                   COALESCE(NULLIF(eventID, ''), 'solo:' || mediaID) AS event_key,
+                   MAX(cnt) AS max_cnt
+              FROM classified
+              WHERE is_null_ts = 0
+              GROUP BY scientificName, event_key
+          ),
+          valid_totals AS (
+            SELECT scientificName, SUM(max_cnt) AS count
+              FROM valid_per_event GROUP BY scientificName
+          ),
+          null_ts_totals AS (
+            SELECT scientificName, SUM(cnt) AS count
+              FROM classified WHERE is_null_ts = 1
+              GROUP BY scientificName
+          )
+          SELECT scientificName, SUM(count) AS count FROM (
+            SELECT scientificName, count FROM valid_totals
+            UNION ALL
+            SELECT scientificName, count FROM null_ts_totals
+          )
+          GROUP BY scientificName ORDER BY count DESC
+        `
+        )
+        .all()
+    } else {
+      // Per-media path: each media is its own sequence, so MAX == count per media,
+      // SUM over media reduces to COUNT(observationID) per species.
+      rows = sqlite
+        .prepare(
+          `
+          SELECT o.scientificName AS scientificName,
+                 COUNT(o.observationID) AS count
+            FROM observations o
+            INNER JOIN media m ON o.mediaID = m.mediaID
+            WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+              AND (o.observationType IS NULL OR o.observationType != 'blank')
+            GROUP BY o.scientificName
+            ORDER BY count DESC
+        `
+        )
+        .all()
+    }
+
+    const elapsed = Date.now() - startTime
+    log.info(
+      `[SQL-agg] sequence-aware species counts (gap=${gapSeconds}, path=${useEventIDPath ? 'eventID' : 'per-media'}): ${rows.length} species in ${elapsed}ms`
+    )
+    return rows
+  } catch (error) {
+    log.error(`Error in getSequenceAwareSpeciesCountsSQL: ${error.message}`)
     throw error
   }
 }

--- a/src/main/ipc/media.js
+++ b/src/main/ipc/media.js
@@ -11,12 +11,12 @@ import {
   getMediaBboxesBatch,
   checkMediaHaveBboxes,
   getVideoFrameDetections,
-  getBestMedia,
   updateMediaTimestamp,
   updateMediaFavorite,
   countMediaWithNullTimestamps,
   closeStudyDatabase
 } from '../database/index.js'
+import { runInWorker } from '../services/sequences/runInWorker.js'
 
 /**
  * Register all media-related IPC handlers
@@ -91,7 +91,10 @@ export function registerMediaIPCHandlers() {
     }
   })
 
-  // Get best media files scored by bbox quality heuristic
+  // Get best media files scored by bbox quality heuristic.
+  // Runs in the sequences worker so the favorites CTE and (potentially heavy)
+  // auto-scored CTE don't block the renderer's UI on cold-cache runs. The
+  // bbox short-circuit inside getBestMedia keeps the no-bbox case cheap too.
   ipcMain.handle('media:get-best', async (_, studyId, options = {}) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
@@ -100,7 +103,12 @@ export function registerMediaIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      const bestMedia = await getBestMedia(dbPath, options)
+      const bestMedia = await runInWorker({
+        type: 'best-media',
+        dbPath,
+        studyId,
+        options
+      })
       return { data: bestMedia }
     } catch (error) {
       log.error('Error getting best media:', error)

--- a/src/main/ipc/sequences.js
+++ b/src/main/ipc/sequences.js
@@ -14,7 +14,6 @@ import { join } from 'path'
 import { Worker } from 'worker_threads'
 import { getStudyDatabasePath } from '../services/paths.js'
 import { getPaginatedSequences } from '../services/sequences/index.js'
-import { getDrizzleDb, getMetadata, getSequenceAwareSpeciesCountsSQL } from '../database/index.js'
 
 /**
  * Run a sequence computation in a worker thread.
@@ -64,27 +63,16 @@ export function registerSequencesIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      // Resolve gap from metadata if the caller didn't pass one.
-      let effectiveGap = gapSeconds
-      if (effectiveGap === undefined) {
-        const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
-        const meta = await getMetadata(db)
-        effectiveGap = meta?.sequenceGap ?? null
-      }
-
-      // Fast path: SQL aggregate runs on main (no Worker spawn). ~2s of SQLite
-      // blocks the main-process event loop — acceptable since other single-SQL
-      // handlers (e.g. getDeploymentsActivity) already run on main.
-      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGap)
-      if (fast !== null) return { data: fast }
-
-      // Slow path (positive gap): fall back to the Worker so ~3s of JS
-      // sequence grouping doesn't block the main thread.
+      // Always dispatch through the Worker. The Worker tries the SQL aggregate
+      // first (null/0 gap) and falls back to row-dump + JS grouping on null
+      // return (positive gap). Running off-thread is required because the SQL
+      // scan itself can take ~8s on cold FS cache on large studies, which
+      // would freeze the renderer's UI if it ran on main.
       const data = await runInWorker({
         type: 'species-distribution',
         dbPath,
         studyId,
-        gapSeconds: effectiveGap
+        gapSeconds
       })
       return { data }
     } catch (error) {

--- a/src/main/ipc/sequences.js
+++ b/src/main/ipc/sequences.js
@@ -10,41 +10,9 @@
 import { app, ipcMain } from 'electron'
 import log from 'electron-log'
 import { existsSync } from 'fs'
-import { join } from 'path'
-import { Worker } from 'worker_threads'
 import { getStudyDatabasePath } from '../services/paths.js'
 import { getPaginatedSequences } from '../services/sequences/index.js'
-
-/**
- * Run a sequence computation in a worker thread.
- * Each worker opens its own readonly DB connection, runs the query + grouping,
- * returns the result, then exits.
- *
- * @param {Object} workerData - Task parameters passed to the worker
- * @returns {Promise<*>} Computed result
- */
-function runInWorker(workerData) {
-  return new Promise((resolve, reject) => {
-    const workerPath = join(__dirname, 'sequences-worker.js')
-    const worker = new Worker(workerPath, { workerData })
-
-    worker.on('message', (result) => {
-      if (result.error) {
-        reject(new Error(result.error))
-      } else {
-        resolve(result.data)
-      }
-    })
-
-    worker.on('error', reject)
-
-    worker.on('exit', (code) => {
-      if (code !== 0) {
-        reject(new Error(`Sequence worker exited with code ${code}`))
-      }
-    })
-  })
-}
+import { runInWorker } from '../services/sequences/runInWorker.js'
 
 /**
  * Register all sequence-related IPC handlers

--- a/src/main/ipc/sequences.js
+++ b/src/main/ipc/sequences.js
@@ -14,6 +14,7 @@ import { join } from 'path'
 import { Worker } from 'worker_threads'
 import { getStudyDatabasePath } from '../services/paths.js'
 import { getPaginatedSequences } from '../services/sequences/index.js'
+import { getDrizzleDb, getMetadata, getSequenceAwareSpeciesCountsSQL } from '../database/index.js'
 
 /**
  * Run a sequence computation in a worker thread.
@@ -63,11 +64,27 @@ export function registerSequencesIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
+      // Resolve gap from metadata if the caller didn't pass one.
+      let effectiveGap = gapSeconds
+      if (effectiveGap === undefined) {
+        const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
+        const meta = await getMetadata(db)
+        effectiveGap = meta?.sequenceGap ?? null
+      }
+
+      // Fast path: SQL aggregate runs on main (no Worker spawn). ~2s of SQLite
+      // blocks the main-process event loop — acceptable since other single-SQL
+      // handlers (e.g. getDeploymentsActivity) already run on main.
+      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGap)
+      if (fast !== null) return { data: fast }
+
+      // Slow path (positive gap): fall back to the Worker so ~3s of JS
+      // sequence grouping doesn't block the main thread.
       const data = await runInWorker({
         type: 'species-distribution',
         dbPath,
         studyId,
-        gapSeconds
+        gapSeconds: effectiveGap
       })
       return { data }
     } catch (error) {

--- a/src/main/services/sequences/runInWorker.js
+++ b/src/main/services/sequences/runInWorker.js
@@ -10,9 +10,11 @@ import { join } from 'path'
 import { Worker } from 'worker_threads'
 
 /**
- * @param {Object} workerData - Task parameters passed to the worker (must
- *   include at least { type, dbPath, studyId }; other fields are forwarded
- *   verbatim to the switch in worker.js).
+ * @param {Object} workerData - Task parameters passed to the worker. Must
+ *   include at minimum `{ type, dbPath }`. `studyId` is only read by tasks
+ *   that resolve sequenceGap from metadata (species-distribution, timeseries,
+ *   heatmap, daily-activity); best-media ignores it. Any other fields are
+ *   forwarded verbatim to the switch in worker.js.
  * @returns {Promise<*>} The worker's posted result, or rejects with the
  *   worker's error.
  */

--- a/src/main/services/sequences/runInWorker.js
+++ b/src/main/services/sequences/runInWorker.js
@@ -1,0 +1,44 @@
+/**
+ * Shared helper to run a task on the sequences worker thread.
+ *
+ * Each call spawns a fresh worker that opens its own readonly DB connection,
+ * executes the task, posts the result, and exits. Used by IPC handlers that
+ * would otherwise block the main event loop on heavy SQLite work.
+ */
+
+import { join } from 'path'
+import { Worker } from 'worker_threads'
+
+/**
+ * @param {Object} workerData - Task parameters passed to the worker (must
+ *   include at least { type, dbPath, studyId }; other fields are forwarded
+ *   verbatim to the switch in worker.js).
+ * @returns {Promise<*>} The worker's posted result, or rejects with the
+ *   worker's error.
+ */
+export function runInWorker(workerData) {
+  return new Promise((resolve, reject) => {
+    // __dirname here resolves to `out/main/` at runtime because the main
+    // bundle flattens all of src/main/**/* into that directory. The worker
+    // is a separate rollup input (see electron.vite.config.mjs) and lands
+    // at out/main/sequences-worker.js.
+    const workerPath = join(__dirname, 'sequences-worker.js')
+    const worker = new Worker(workerPath, { workerData })
+
+    worker.on('message', (result) => {
+      if (result.error) {
+        reject(new Error(result.error))
+      } else {
+        resolve(result.data)
+      }
+    })
+
+    worker.on('error', reject)
+
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`Sequence worker exited with code ${code}`))
+      }
+    })
+  })
+}

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -1,8 +1,11 @@
 /**
- * Worker thread for sequence-aware computations.
+ * Worker thread for heavy DB computations.
  *
- * Runs DB queries and sequence grouping off the main thread so the UI stays
- * responsive. Each worker instance handles a single task then exits.
+ * Dispatches on `workerData.type`: sequence-aware species-distribution,
+ * timeseries, heatmap, daily-activity, and the best-media scoring pipeline.
+ * Runs off the main thread so the renderer UI stays responsive during
+ * multi-second SQLite scans. Each worker instance handles a single task
+ * then exits.
  */
 
 import { parentPort, workerData } from 'worker_threads'

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -13,7 +13,8 @@ import {
   getSpeciesTimeseriesByMedia,
   getSpeciesHeatmapDataByMedia,
   getSpeciesDailyActivityByMedia,
-  getSequenceAwareSpeciesCountsSQL
+  getSequenceAwareSpeciesCountsSQL,
+  getBestMedia
 } from '../../database/index.js'
 import {
   calculateSequenceAwareSpeciesCounts,
@@ -74,6 +75,12 @@ async function run() {
     case 'daily-activity': {
       const rawData = await getSpeciesDailyActivityByMedia(dbPath, speciesNames, startDate, endDate)
       return calculateSequenceAwareDailyActivity(rawData, effectiveGapSeconds, speciesNames)
+    }
+    case 'best-media': {
+      // Off-main-thread path for the best-captures carousel. Covers both the
+      // favorites CTE and the (potentially heavy) auto-scored CTE. See
+      // src/main/database/queries/best-media.js for the query pipeline.
+      return getBestMedia(dbPath, workerData.options || {})
     }
     default:
       throw new Error(`Unknown worker task type: ${type}`)

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -12,7 +12,8 @@ import {
   getSpeciesDistributionByMedia,
   getSpeciesTimeseriesByMedia,
   getSpeciesHeatmapDataByMedia,
-  getSpeciesDailyActivityByMedia
+  getSpeciesDailyActivityByMedia,
+  getSequenceAwareSpeciesCountsSQL
 } from '../../database/index.js'
 import {
   calculateSequenceAwareSpeciesCounts,
@@ -45,6 +46,12 @@ async function run() {
 
   switch (type) {
     case 'species-distribution': {
+      // Fast path: SQL aggregate handles gapSeconds === null and === 0, returns
+      // the final [{scientificName, count}] directly (83 rows, not 1.65M).
+      // Returns null for positive gapSeconds, in which case we fall back to the
+      // row-dump + JS sequence grouping below.
+      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds)
+      if (fast !== null) return fast
       const rawData = await getSpeciesDistributionByMedia(dbPath)
       return calculateSequenceAwareSpeciesCounts(rawData, effectiveGapSeconds)
     }

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1583,6 +1583,7 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareHeatmap', studyId] })
       queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['bestMedia', studyId] })
     }
   })
 
@@ -1681,6 +1682,8 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['mediaBboxes', studyId, media?.mediaID] })
       // Also update thumbnail grid
       queryClient.invalidateQueries({ queryKey: ['thumbnailBboxesBatch'] })
+      // Bbox geometry feeds the best-media composite score (area / visibility / padding)
+      queryClient.invalidateQueries({ queryKey: ['bestMedia', studyId] })
     }
   })
 
@@ -1731,6 +1734,8 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['mediaBboxes', studyId, media?.mediaID] })
       // Also update thumbnail grid
       queryClient.invalidateQueries({ queryKey: ['thumbnailBboxesBatch'] })
+      // Deleting an observation can remove a media from the best-media candidate set
+      queryClient.invalidateQueries({ queryKey: ['bestMedia', studyId] })
     }
   })
 
@@ -1761,6 +1766,7 @@ function ImageModal({
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareDailyActivity', studyId] })
       queryClient.invalidateQueries({ queryKey: ['sequenceAwareHeatmap', studyId] })
       queryClient.invalidateQueries({ queryKey: ['blankMediaCount', studyId] })
+      queryClient.invalidateQueries({ queryKey: ['bestMedia', studyId] })
       // Exit draw mode and select the new observation
       setIsDrawMode(false)
       setSelectedBboxId(data.observationID)

--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -320,11 +320,14 @@ export default function Overview({ data, studyId, studyName }) {
   const { importStatus } = useImportStatus(studyId)
   const { sequenceGap } = useSequenceGap(studyId)
 
-  // Use useQuery for deployments data - use same query as Deployments tab
-  const { data: deploymentsActivityData, error: deploymentsError } = useQuery({
-    queryKey: ['deploymentsActivity', studyId],
+  // Lightweight deployments query for the Overview map — server-side deduped
+  // by (latitude, longitude), no activity period aggregation. The Deployments
+  // tab keeps its own heavier ['deploymentsActivity', studyId] query for the
+  // observation-count-per-period visualization.
+  const { data: deploymentsData, error: deploymentsError } = useQuery({
+    queryKey: ['deployments', studyId],
     queryFn: async () => {
-      const response = await window.api.getDeploymentsActivity(studyId)
+      const response = await window.api.getDeployments(studyId)
       if (response.error) {
         throw new Error(response.error)
       }
@@ -333,20 +336,6 @@ export default function Overview({ data, studyId, studyName }) {
     enabled: !!studyId,
     refetchInterval: importStatus?.isRunning ? 5000 : false
   })
-
-  // De-duplicate deployments by coordinates for map (one marker per location)
-  const deploymentsData = useMemo(() => {
-    if (!deploymentsActivityData?.deployments) return []
-    const seen = new Map()
-    for (const d of deploymentsActivityData.deployments) {
-      const key = `${d.latitude},${d.longitude}`
-      // Keep the first deployment (or could pick by most recent date)
-      if (!seen.has(key)) {
-        seen.set(key, d)
-      }
-    }
-    return Array.from(seen.values())
-  }, [deploymentsActivityData])
 
   // Use sequence-aware species distribution
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -677,7 +677,13 @@ export default function BestMediaCarousel({ studyId, isRunning }) {
       return response.data
     },
     enabled: !!studyId,
-    staleTime: 60000, // Cache for 1 minute
+    // Study data is immutable outside of explicit user actions, so keep the
+    // cache indefinitely. Invalidation is covered by:
+    //   - favorite toggle (lines 788, 801 below)
+    //   - species re-classification (media.jsx:1608)
+    //   - import status transitions (hooks/import.js:24)
+    // so navigating away and back never triggers a refetch in the steady state.
+    staleTime: Infinity,
     refetchInterval: isRunning ? 5000 : false // Poll every 5s during ML run
   })
 

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -679,9 +679,12 @@ export default function BestMediaCarousel({ studyId, isRunning }) {
     enabled: !!studyId,
     // Study data is immutable outside of explicit user actions, so keep the
     // cache indefinitely. Invalidation is covered by:
-    //   - favorite toggle (lines 788, 801 below)
-    //   - species re-classification (media.jsx:1608)
-    //   - import status transitions (hooks/import.js:24)
+    //   - favorite toggle: onClose handlers in this file + favoriteMutation
+    //     onSettled in media.jsx
+    //   - observation create / update / delete / bbox edit in media.jsx
+    //     (each mutation's onSuccess/onSettled invalidates ['bestMedia', studyId])
+    //   - import completion: useImportStatus hook invalidates on
+    //     isRunning true -> false with done === total
     // so navigating away and back never triggers a refetch in the steady state.
     staleTime: Infinity,
     refetchInterval: isRunning ? 5000 : false // Poll every 5s during ML run

--- a/test/main/database/queries/bestMedia.test.js
+++ b/test/main/database/queries/bestMedia.test.js
@@ -1,0 +1,379 @@
+/**
+ * Tests for the favorites CTE rewrite in getBestMedia and the bbox
+ * short-circuit in getBestImagePerSpecies.
+ *
+ * insertMedia/insertObservations don't expose favorite or bbox columns, so
+ * we seed those via raw SQL on the underlying better-sqlite3 handle.
+ */
+
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+
+import {
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations,
+  getBestMedia,
+  getBestImagePerSpecies
+} from '../../../../src/main/database/index.js'
+
+let testDbPath
+let testStudyId
+let testBiowatchDataPath
+
+beforeEach(async () => {
+  // Silence electron-log during tests
+  try {
+    const electronLog = await import('electron-log')
+    const log = electronLog.default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    // not available, fine
+  }
+
+  testStudyId = `test-best-media-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-best-media-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+function deployment(id) {
+  return {
+    deploymentID: id,
+    locationID: `loc-${id}`,
+    locationName: `Site ${id}`,
+    deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+    deploymentEnd: DateTime.fromISO('2024-01-31T00:00:00Z'),
+    latitude: 0,
+    longitude: 0
+  }
+}
+
+function mediaEntry(id, ts) {
+  return {
+    mediaID: id,
+    deploymentID: 'd1',
+    timestamp: DateTime.fromISO(ts),
+    filePath: `p/${id}.jpg`,
+    fileName: `${id}.jpg`,
+    importFolder: 'p',
+    folderName: 'f'
+  }
+}
+
+async function seed({ deployments = { d1: deployment('d1') }, media, observations }) {
+  const manager = await createImageDirectoryDatabase(testDbPath)
+  await insertDeployments(manager, deployments)
+  await insertMedia(manager, media)
+  await insertObservations(manager, observations)
+  return manager
+}
+
+/** Raw-SQL helper to mark specific mediaIDs as favorite = 1. */
+function markFavorites(manager, mediaIDs) {
+  const sqlite = manager.getSqlite()
+  const stmt = sqlite.prepare('UPDATE media SET favorite = 1 WHERE mediaID = ?')
+  for (const id of mediaIDs) stmt.run(id)
+}
+
+/** Raw-SQL helper to populate bbox geometry on an observation. */
+function setBbox(manager, observationID, { x, y, width, height, detectionConfidence = 0.9 }) {
+  const sqlite = manager.getSqlite()
+  sqlite
+    .prepare(
+      `UPDATE observations
+         SET bboxX = ?, bboxY = ?, bboxWidth = ?, bboxHeight = ?, detectionConfidence = ?
+       WHERE observationID = ?`
+    )
+    .run(x, y, width, height, detectionConfidence, observationID)
+}
+
+describe('getBestMedia favorites CTE', () => {
+  test('returns all favorites that have observations, capped at limit', async () => {
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z'),
+        'c.jpg': mediaEntry('m-c', '2024-01-07T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-b',
+          mediaID: 'm-b',
+          deploymentID: 'd1',
+          eventID: 'e-b',
+          scientificName: 'Deer',
+          count: 1
+        },
+        {
+          observationID: 'o-c',
+          mediaID: 'm-c',
+          deploymentID: 'd1',
+          eventID: 'e-c',
+          scientificName: 'Badger',
+          count: 1
+        }
+      ]
+    })
+    markFavorites(manager, ['m-a', 'm-b', 'm-c'])
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    assert.equal(result.length, 3)
+    // Ordered by timestamp DESC
+    assert.deepEqual(
+      result.map((r) => r.mediaID),
+      ['m-c', 'm-b', 'm-a']
+    )
+    // All flagged as favorites
+    for (const r of result) assert.equal(r.favorite, 1)
+    // scientificName decorated from the favorite's observation
+    assert.deepEqual(
+      result.map((r) => r.scientificName),
+      ['Badger', 'Deer', 'Fox']
+    )
+  })
+
+  test('favorites without observations are excluded (do not consume limit)', async () => {
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z'), // no observation
+        'c.jpg': mediaEntry('m-c', '2024-01-07T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-c',
+          mediaID: 'm-c',
+          deploymentID: 'd1',
+          eventID: 'e-c',
+          scientificName: 'Badger',
+          count: 1
+        }
+      ]
+    })
+    markFavorites(manager, ['m-a', 'm-b', 'm-c'])
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    // m-b has no observation so it is filtered out; the other two remain.
+    assert.equal(result.length, 2)
+    assert.deepEqual(result.map((r) => r.mediaID).sort(), ['m-a', 'm-c'])
+  })
+
+  test('LIMIT is applied after the observation-null filter, not before', async () => {
+    // Three favorites (timestamps in DESC order: c, b, a). m-b has no obs.
+    // With LIMIT 2 this should return [m-c, m-a] — the two favorites that
+    // have observations — rather than [m-c, m-b] which would be wrong.
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z'),
+        'c.jpg': mediaEntry('m-c', '2024-01-07T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-c',
+          mediaID: 'm-c',
+          deploymentID: 'd1',
+          eventID: 'e-c',
+          scientificName: 'Badger',
+          count: 1
+        }
+      ]
+    })
+    markFavorites(manager, ['m-a', 'm-b', 'm-c'])
+
+    const result = await getBestMedia(testDbPath, { limit: 2 })
+
+    assert.equal(result.length, 2)
+    assert.deepEqual(
+      result.map((r) => r.mediaID),
+      ['m-c', 'm-a']
+    )
+  })
+
+  test('picks highest-detectionConfidence observation per (media, species) via ROW_NUMBER', async () => {
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z')
+      },
+      observations: [
+        // Two Fox observations on the same media with different confidences.
+        // The CTE's ROW_NUMBER ... ORDER BY detectionConfidence DESC picks the
+        // higher-confidence one (0.9), which must be the observationID returned.
+        {
+          observationID: 'o-low',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1,
+          classificationProbability: 0.3
+        },
+        {
+          observationID: 'o-high',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1,
+          classificationProbability: 0.9
+        }
+      ]
+    })
+    markFavorites(manager, ['m-a'])
+    setBbox(manager, 'o-low', { x: 0.1, y: 0.1, width: 0.2, height: 0.2, detectionConfidence: 0.1 })
+    setBbox(manager, 'o-high', {
+      x: 0.3,
+      y: 0.3,
+      width: 0.4,
+      height: 0.4,
+      detectionConfidence: 0.9
+    })
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    assert.equal(result.length, 1)
+    assert.equal(result[0].observationID, 'o-high')
+    assert.equal(result[0].detectionConfidence, 0.9)
+  })
+})
+
+describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
+  test('returns [] when no observations have bboxWidth/bboxHeight', async () => {
+    await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-b',
+          mediaID: 'm-b',
+          deploymentID: 'd1',
+          eventID: 'e-b',
+          scientificName: 'Deer',
+          count: 1
+        }
+      ]
+    })
+
+    const result = await getBestImagePerSpecies(testDbPath)
+
+    assert.deepEqual(result, [])
+  })
+
+  test('returns [] when observations have bboxX but no bboxWidth (point-only CamTrap DP pattern)', async () => {
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        }
+      ]
+    })
+    // Populate bboxX/bboxY but leave width/height NULL (matches the CamTrap DP
+    // pattern we observed on gmu8_leuven).
+    manager
+      .getSqlite()
+      .prepare('UPDATE observations SET bboxX = 0.5, bboxY = 0.5 WHERE observationID = ?')
+      .run('o-a')
+
+    const result = await getBestImagePerSpecies(testDbPath)
+
+    assert.deepEqual(result, [])
+  })
+
+  test('runs the scoring pipeline and returns one row per species when bbox data exists', async () => {
+    const manager = await seed({
+      media: {
+        'fox.jpg': mediaEntry('m-fox', '2024-01-05T10:00:00Z'),
+        'deer.jpg': mediaEntry('m-deer', '2024-01-06T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-fox',
+          mediaID: 'm-fox',
+          deploymentID: 'd1',
+          eventID: 'e-fox',
+          scientificName: 'Fox',
+          count: 1,
+          classificationProbability: 0.8
+        },
+        {
+          observationID: 'o-deer',
+          mediaID: 'm-deer',
+          deploymentID: 'd1',
+          eventID: 'e-deer',
+          scientificName: 'Deer',
+          count: 1,
+          classificationProbability: 0.9
+        }
+      ]
+    })
+    setBbox(manager, 'o-fox', { x: 0.2, y: 0.2, width: 0.3, height: 0.3 })
+    setBbox(manager, 'o-deer', { x: 0.1, y: 0.1, width: 0.4, height: 0.4 })
+
+    const result = await getBestImagePerSpecies(testDbPath)
+
+    // One row per species, each pointing to the correct media.
+    const byName = Object.fromEntries(result.map((r) => [r.scientificName, r]))
+    assert.ok(byName.Fox, 'Fox row present')
+    assert.equal(byName.Fox.mediaID, 'm-fox')
+    assert.ok(byName.Deer, 'Deer row present')
+    assert.equal(byName.Deer.mediaID, 'm-deer')
+    assert.equal(result.length, 2)
+  })
+})

--- a/test/main/database/queries/bestMedia.test.js
+++ b/test/main/database/queries/bestMedia.test.js
@@ -276,6 +276,126 @@ describe('getBestMedia favorites CTE', () => {
   })
 })
 
+describe('getBestMedia short-circuit on missing bbox data', () => {
+  test('no favorites + no bbox data: returns [] without running auto-scored CTE', async () => {
+    await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-b',
+          mediaID: 'm-b',
+          deploymentID: 'd1',
+          eventID: 'e-b',
+          scientificName: 'Deer',
+          count: 1
+        }
+      ]
+      // No favorites marked, no bboxes populated.
+    })
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    assert.deepEqual(result, [])
+  })
+
+  test('some favorites + no bbox data: returns only the favorites, skipping auto-scored', async () => {
+    const manager = await seed({
+      media: {
+        'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
+        'b.jpg': mediaEntry('m-b', '2024-01-06T10:00:00Z'),
+        'c.jpg': mediaEntry('m-c', '2024-01-07T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-a',
+          mediaID: 'm-a',
+          deploymentID: 'd1',
+          eventID: 'e-a',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-b',
+          mediaID: 'm-b',
+          deploymentID: 'd1',
+          eventID: 'e-b',
+          scientificName: 'Deer',
+          count: 1
+        },
+        {
+          observationID: 'o-c',
+          mediaID: 'm-c',
+          deploymentID: 'd1',
+          eventID: 'e-c',
+          scientificName: 'Badger',
+          count: 1
+        }
+      ]
+    })
+    // Mark only two of three as favorites; limit is larger than favorite count.
+    markFavorites(manager, ['m-a', 'm-b'])
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    // Must return exactly the two favorites (no auto-scored fill-in on a
+    // no-bbox dataset), ordered by timestamp DESC.
+    assert.equal(result.length, 2)
+    assert.deepEqual(
+      result.map((r) => r.mediaID),
+      ['m-b', 'm-a']
+    )
+  })
+
+  test('bbox data exists + 0 favorites: auto-scored path runs and returns per-species candidates', async () => {
+    const manager = await seed({
+      media: {
+        'fox.jpg': mediaEntry('m-fox', '2024-01-05T10:00:00Z'),
+        'deer.jpg': mediaEntry('m-deer', '2024-01-06T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-fox',
+          mediaID: 'm-fox',
+          deploymentID: 'd1',
+          eventID: 'e-fox',
+          scientificName: 'Fox',
+          count: 1,
+          classificationProbability: 0.8
+        },
+        {
+          observationID: 'o-deer',
+          mediaID: 'm-deer',
+          deploymentID: 'd1',
+          eventID: 'e-deer',
+          scientificName: 'Deer',
+          count: 1,
+          classificationProbability: 0.9
+        }
+      ]
+    })
+    setBbox(manager, 'o-fox', { x: 0.2, y: 0.2, width: 0.3, height: 0.3 })
+    setBbox(manager, 'o-deer', { x: 0.1, y: 0.1, width: 0.4, height: 0.4 })
+    // No favorites marked; auto-scored branch must run.
+
+    const result = await getBestMedia(testDbPath, { limit: 12 })
+
+    // Both species' media should be selected via the scoring/diversity pipeline.
+    const mediaIDs = result.map((r) => r.mediaID).sort()
+    assert.deepEqual(mediaIDs, ['m-deer', 'm-fox'])
+  })
+})
+
 describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
   test('returns [] when no observations have bboxWidth/bboxHeight', async () => {
     await seed({

--- a/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
+++ b/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
@@ -1,0 +1,497 @@
+/**
+ * Parity tests for the SQL-aggregate path vs the JS pipeline.
+ *
+ * For each fixture + gap value, assert that:
+ *   getSequenceAwareSpeciesCountsSQL(dbPath, gap)
+ *   ==
+ *   calculateSequenceAwareSpeciesCounts(getSpeciesDistributionByMedia(dbPath), gap)
+ *
+ * The SQL path is allowed to return null for gap values it does not handle
+ * (currently: any positive number), in which case we skip the comparison.
+ */
+
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+
+import {
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations,
+  getSpeciesDistributionByMedia,
+  getSequenceAwareSpeciesCountsSQL
+} from '../../../../src/main/database/index.js'
+import { calculateSequenceAwareSpeciesCounts } from '../../../../src/main/services/sequences/speciesCounts.js'
+
+let testDbPath
+let testStudyId
+let testBiowatchDataPath
+
+beforeEach(async () => {
+  // Silence electron-log during tests
+  try {
+    const electronLog = await import('electron-log')
+    const log = electronLog.default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    // not available, fine
+  }
+
+  testStudyId = `test-sql-agg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-sql-agg-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+/**
+ * Run the old JS pipeline and the new SQL aggregate, normalize both to
+ * `[{scientificName, count}]` sorted by (count desc, name asc for stability),
+ * and assert equality. If SQL returns null (unsupported gap), returns early.
+ */
+async function assertParity(dbPath, gapSeconds, label) {
+  const rawRows = await getSpeciesDistributionByMedia(dbPath)
+  const jsResult = calculateSequenceAwareSpeciesCounts(rawRows, gapSeconds)
+
+  const sqlResult = await getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds)
+  if (sqlResult === null) {
+    return { skipped: true, gapSeconds, label }
+  }
+
+  const norm = (arr) =>
+    [...arr]
+      .map((r) => ({ scientificName: r.scientificName, count: Number(r.count) }))
+      .sort(
+        (a, b) =>
+          b.count - a.count || (a.scientificName || '').localeCompare(b.scientificName || '')
+      )
+
+  assert.deepEqual(
+    norm(sqlResult),
+    norm(jsResult),
+    `SQL vs JS parity mismatch for gap=${gapSeconds} (${label})`
+  )
+  return { skipped: false, gapSeconds, label, count: sqlResult.length }
+}
+
+async function seed(dbPath, { deployments, media, observations }) {
+  const manager = await createImageDirectoryDatabase(dbPath)
+  await insertDeployments(manager, deployments)
+  await insertMedia(manager, media)
+  await insertObservations(manager, observations)
+  return manager
+}
+
+describe('getSequenceAwareSpeciesCountsSQL — parity with JS pipeline', () => {
+  test('basic: three species across deployments, null + 0 gap parity', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'loc1',
+          locationName: 'Site A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-31T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        },
+        d2: {
+          deploymentID: 'd2',
+          locationID: 'loc2',
+          locationName: 'Site B',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-31T00:00:00Z'),
+          latitude: 1,
+          longitude: 1
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-05T10:00:00Z'),
+          filePath: 'p/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'p',
+          folderName: 'f'
+        },
+        'm2.jpg': {
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-05T10:00:30Z'),
+          filePath: 'p/m2.jpg',
+          fileName: 'm2.jpg',
+          importFolder: 'p',
+          folderName: 'f'
+        },
+        'm3.jpg': {
+          mediaID: 'm3',
+          deploymentID: 'd2',
+          timestamp: DateTime.fromISO('2024-01-06T10:00:00Z'),
+          filePath: 'p/m3.jpg',
+          fileName: 'm3.jpg',
+          importFolder: 'p',
+          folderName: 'f'
+        }
+      },
+      observations: [
+        // Two observations on m1 → cnt=2 for (Deer, m1)
+        {
+          observationID: 'o1',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 3
+        },
+        {
+          observationID: 'o2',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 3
+        },
+        // m2 in same event e1
+        {
+          observationID: 'o3',
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 5
+        },
+        // m3 in its own event
+        {
+          observationID: 'o4',
+          mediaID: 'm3',
+          deploymentID: 'd2',
+          eventID: 'e2',
+          scientificName: 'Fox',
+          count: 1
+        }
+      ]
+    })
+    await assertParity(testDbPath, null, 'null-gap')
+    await assertParity(testDbPath, 0, 'eventID-gap')
+  })
+
+  test('excludes blank observationType and null/empty scientificName', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'l1',
+          locationName: 'A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
+          filePath: 'x/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        },
+        'm2.jpg': {
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:01:00Z'),
+          filePath: 'x/m2.jpg',
+          fileName: 'm2.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        }
+      },
+      observations: [
+        // Normal species observation
+        {
+          observationID: 'o1',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Badger',
+          count: 1
+        },
+        // Blank observation (should be excluded) — same schema pattern as queries.test.js
+        {
+          observationID: 'o2',
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: null,
+          observationType: 'blank',
+          count: 0
+        }
+      ]
+    })
+    await assertParity(testDbPath, null, 'null-gap')
+    await assertParity(testDbPath, 0, 'eventID-gap')
+  })
+
+  test('eventID-gap: multiple media share an eventID — MAX per (species,event) then SUM', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'l1',
+          locationName: 'A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
+          filePath: 'x/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        },
+        'm2.jpg': {
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:30Z'),
+          filePath: 'x/m2.jpg',
+          fileName: 'm2.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        },
+        'm3.jpg': {
+          mediaID: 'm3',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-02T10:00:00Z'),
+          filePath: 'x/m3.jpg',
+          fileName: 'm3.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        }
+      },
+      // Note: the per-(species, media) "count" used by the sequence logic is
+      // COUNT(observationID) over the group, NOT observations.count. To control
+      // it we insert N rows per (species, media).
+      observations: [
+        // e1 / m1: 2 rows for Deer → cnt=2
+        ...Array.from({ length: 2 }, (_, i) => ({
+          observationID: `m1-Deer-${i}`,
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 1
+        })),
+        // e1 / m2: 5 rows for Deer → cnt=5
+        ...Array.from({ length: 5 }, (_, i) => ({
+          observationID: `m2-Deer-${i}`,
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 1
+        })),
+        // e2 / m3: 3 rows for Deer → cnt=3
+        ...Array.from({ length: 3 }, (_, i) => ({
+          observationID: `m3-Deer-${i}`,
+          mediaID: 'm3',
+          deploymentID: 'd1',
+          eventID: 'e2',
+          scientificName: 'Deer',
+          count: 1
+        }))
+      ]
+    })
+    // For gap=0: Deer total should be 5 + 3 = 8 (MAX per event, SUM).
+    // For gap=null: Deer total should be 2 + 5 + 3 = 10 (each media own seq).
+    const rawRows = await getSpeciesDistributionByMedia(testDbPath)
+    const jsEventID = calculateSequenceAwareSpeciesCounts(rawRows, 0)
+    assert.equal(jsEventID.find((r) => r.scientificName === 'Deer').count, 8)
+    const jsNull = calculateSequenceAwareSpeciesCounts(rawRows, null)
+    assert.equal(jsNull.find((r) => r.scientificName === 'Deer').count, 10)
+
+    await assertParity(testDbPath, null, 'null-gap')
+    await assertParity(testDbPath, 0, 'eventID-gap')
+  })
+
+  test('null-timestamp media still contribute to counts', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'l1',
+          locationName: 'A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
+          filePath: 'x/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        },
+        'm2.jpg': {
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          timestamp: null, // null-ts
+          filePath: 'x/m2.jpg',
+          fileName: 'm2.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        }
+      },
+      observations: [
+        {
+          observationID: 'o1',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Fox',
+          count: 1
+        },
+        // Null-ts media with same eventID as valid-ts — current JS treats this as a
+        // separate per-media sequence, my SQL must match.
+        {
+          observationID: 'o2',
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Fox',
+          count: 4
+        }
+      ]
+    })
+    await assertParity(testDbPath, null, 'null-gap with null-ts')
+    await assertParity(testDbPath, 0, 'eventID-gap with null-ts')
+  })
+
+  test('positive gapSeconds: SQL path returns null (JS fallback)', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'l1',
+          locationName: 'A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
+          filePath: 'x/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        }
+      },
+      observations: [
+        {
+          observationID: 'o1',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: 'e1',
+          scientificName: 'Deer',
+          count: 1
+        }
+      ]
+    })
+    const sql = await getSequenceAwareSpeciesCountsSQL(testDbPath, 120)
+    assert.equal(sql, null, 'positive gap should return null so caller falls back to JS')
+  })
+
+  test('empty DB returns empty array (gap=null and gap=0)', async () => {
+    await createImageDirectoryDatabase(testDbPath)
+    const sqlNull = await getSequenceAwareSpeciesCountsSQL(testDbPath, null)
+    const sqlZero = await getSequenceAwareSpeciesCountsSQL(testDbPath, 0)
+    assert.deepEqual(sqlNull, [])
+    assert.deepEqual(sqlZero, [])
+  })
+
+  test('media with empty-string eventID becomes its own event (COALESCE NULLIF path)', async () => {
+    await seed(testDbPath, {
+      deployments: {
+        d1: {
+          deploymentID: 'd1',
+          locationID: 'l1',
+          locationName: 'A',
+          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
+          latitude: 0,
+          longitude: 0
+        }
+      },
+      media: {
+        'm1.jpg': {
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
+          filePath: 'x/m1.jpg',
+          fileName: 'm1.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        },
+        'm2.jpg': {
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          timestamp: DateTime.fromISO('2024-01-01T10:00:30Z'),
+          filePath: 'x/m2.jpg',
+          fileName: 'm2.jpg',
+          importFolder: 'x',
+          folderName: 'f'
+        }
+      },
+      observations: [
+        // m1 has empty-string eventID → its own "event"
+        {
+          observationID: 'o1',
+          mediaID: 'm1',
+          deploymentID: 'd1',
+          eventID: '',
+          scientificName: 'Badger',
+          count: 2
+        },
+        // m2 has null eventID → also its own "event"
+        {
+          observationID: 'o2',
+          mediaID: 'm2',
+          deploymentID: 'd1',
+          eventID: null,
+          scientificName: 'Badger',
+          count: 3
+        }
+      ]
+    })
+    await assertParity(testDbPath, null, 'null-gap, no-eventID')
+    await assertParity(testDbPath, 0, 'eventID-gap, no-eventID')
+  })
+})


### PR DESCRIPTION
## Summary

Overview tab was slow on large-dataset studies and, on a fresh biowatch boot, **freezing the renderer UI for tens of seconds** during first load. Ten commits in this branch make Overview's first-load fast **and** non-blocking on cold FS cache.

Measured end-to-end on the two test fixtures:

| Study | Shape | Before | After |
|---|---|---|---|
| **gmu8_leuven** (CamTrap DP) | 2704 deployments, 2.7M obs, 83 species, 12 favorites | first-load ~10s warm / ~18s cold (8.4s **main-thread freeze** from species SQL) | ~2s warm / ~3s cold, map pannable throughout |
| **California Small Animals** (`lila/coco`) | 1.16M obs, 0 favorites, **no usable bboxes** | `getBestMedia` **28s main-thread freeze**, empty result | ~1–1.5s via Worker + short-circuit, empty result |

## Per-query results on gmu8_leuven

| Query | Before | After |
|---|---|---|
| `getSequenceAwareSpeciesDistribution` | ~9.9s warm / ~8.4s cold (main) | ~1.8s warm / ~2.5s cold, **in Worker** |
| `getDeployments` (was `getDeploymentsActivity` via Overview) | ~1.5s | ~0.04s |
| `getBestMedia` (favorites branch) | ~5.0s | ~0.2s |
| `getBestImagePerSpecies` | ~2.3s | ~0.18s |
| Carousel on re-entry within session | SQL round-trip | cache (staleTime: Infinity) |

## Commits, by theme

**SQL-level perf wins**

- `9bb1341` **species SQL-aggregate** — `getSequenceAwareSpeciesDistribution` was dumping 1.65M rows across the process boundary and grouping in JS. Moved aggregation into SQL for `sequenceGap === null` and `=== 0` (the vast majority of CamTrap DP / slider-off cases); positive-gap falls back to the existing JS pipeline. Payload shrinks from 1.65M rows to 83. **9.9s → 1.8s.**
- `d86f05b` **lightweight deployments query** — Overview map was using `getDeploymentsActivity` and computing 20 `SUM(CASE WHEN …)` buckets per deployment that the Overview never reads. Switched to `getDeployments` (server-side deduped by lat/lng). Deployments tab keeps its own query. **1.5s → 0.04s.**
- `51579ea` **best-media favorites filter-first** — the favorites SQL was materializing two `ROW_NUMBER() OVER (PARTITION BY …)` subqueries over the entire observations table (2.7M rows) and only filtering to favorites at the outer `WHERE`. Move the favorites filter into a CTE first; scope the `ROW_NUMBER` work to observations belonging to those favorites. **5.0s → 0.2s.** LIMIT semantics preserved (applied after the observation-null filter).
- `ec4551f` **short-circuit `getBestImagePerSpecies`** — the scoring formula needs `bboxWidth/bboxHeight > 0`, but many datasets (CamTrap DP point-only annotations, etc.) populate `bboxX/Y` without size. A `LIMIT 1` probe returns `[]` immediately instead of paying ~2s scanning observations to produce zero rows. **2.3s → 0.18s** on affected datasets; near-zero cost on bbox-having datasets.
- `722ac80` **short-circuit `getBestMedia`** — same fix applied to the parent function. On the California Small Animals dataset this eliminates a **28-second** scan for auto-scored candidates that don't exist. ~28s → ~200ms.

**Caching + correctness**

- `146ae0c` **best-media `staleTime: Infinity`** — subsequent visits to Overview within a session serve the carousel instantly from cache instead of paying the SQL round-trip.
- `5a1fc52` **plug cache invalidation gaps** — code review caught that `updateMutation`, `createMutation`, `deleteMutation`, `updateBboxMutation` in `media.jsx` all fed the best-media score but left the cache stale. Added `invalidateQueries(['bestMedia', studyId])` to each. Fixed a misleading doc comment and aligned a redundant NULL check for audit readability.

**Main-thread unblocking (cold-start)**

- `4277693` **move SQL-agg species path into the Worker** — fresh-boot testing showed the SQL aggregate runs in ~1.8s warm but **~8.4s cold**, and we'd placed it on main — freezing the UI. The Worker already resolves `gapSeconds` from metadata, so we just teach the worker's `species-distribution` case to try SQL first and fall back to row-dump+JS on `null` return (positive gap). Handler reverts to dispatching straight to `runInWorker`.
- `bce777e` **move `getBestMedia` into the Worker** — defense-in-depth: same risk shape as above. Factored `runInWorker` into `src/main/services/sequences/runInWorker.js` so `media.js` and `sequences.js` share the helper; added a `best-media` task type to the worker; `media:get-best` now dispatches through it. Adds ~1s Worker-spawn per call, paid once per study per session thanks to `staleTime: Infinity`.
- `b49ec27` **docs** — tightened the worker/runInWorker JSDoc headers after the two moves (the worker now handles more than "sequence-aware computations"; `studyId` is no longer universally required).

## Test plan

- [x] `npm run test:rebuild && node --test 'test/**/*.test.js'` — **920/920 pass** (10 new: 7 parity tests for the sequence-aware SQL aggregate; 3 for the `getBestMedia` short-circuit)
- [x] Prettier + ESLint clean on all changed files
- [x] **Fresh-boot manual on gmu8_leuven** (CamTrap DP, 2.7M obs): species list + map + carousel render in ~2–3s; map pan remains responsive throughout the load
- [x] **Fresh-boot manual on California Small Animals** (`lila/coco`, 1.16M obs, no bboxes): empty carousel arrives in ~1–1.5s instead of freezing for ~28s; UI responsive
- [x] Smoke-test on an ML-run study with populated bboxes — exercises the `getBestImagePerSpecies` + `getBestMedia` auto-scored CTE paths through the Worker
- [x] Smoke-test species reclassification in the Media tab → navigate back to Overview → verify the Best Captures carousel reflects the new label (exercises commit `5a1fc52`'s added invalidations)
- [x] Smoke-test on a Wildlife Insights dataset (positive `sequenceGap`) to exercise the JS-fallback path inside the worker

## Worker concurrency (no new infrastructure)

Workers are spawned per task and exit on completion — no pool. On Overview first-load this means **at most 2 concurrent Workers** (species-distribution + best-media). Each allocates its own v8 isolate and readonly SQLite connection. Typical session peaks at 3–5 total spawns; no backpressure but also no observed pressure. A pool (`piscina` or hand-rolled) is an easy follow-up if pooling ever pays off — left out of this branch.

## Not included / explicit follow-ups

- **CamTrap DP auto-scored fallback**: `getBestMedia`'s auto-scored branch only joins observations via `mediaID` (no `eventStart` fallback). For CamTrap DP datasets with populated bboxes + populated `mediaID`, this works; for the odd dataset where observations link via timestamp it returns nothing. Pre-existing, unrelated to this branch.
- **Timestamp-gap window function**: positive `sequenceGap` still uses the JS fallback inside the Worker. A SQL window-function rewrite measured at ~9s total (only marginally faster than the JS pipeline) + correctness risk; deferred until a user on the slider path reports it.
- **Partial index on bbox columns**: would drop the bbox-existence probe from ~200ms to ~1ms on no-bbox datasets. Deferred — 200ms inside a Worker doesn't block anything meaningfully.
- **Worker pool**: deferred as above.