### PR TITLE
fix(ui/overview): truncate species rows to one line, drop parens

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -199,16 +199,14 @@ function SpeciesRow({
           className="cursor-pointer hover:bg-gray-50 transition-colors rounded py-1"
           onClick={() => onRowClick(species)}
         >
-          <div className="flex justify-between mb-1 items-center">
-            <div>
+          <div className="flex justify-between mb-1 items-center gap-2">
+            <div className="min-w-0 truncate">
               <span className="capitalize text-sm">{displayName}</span>
               {showScientific && (
-                <span className="text-gray-500 text-sm italic ml-2">
-                  ({species.scientificName})
-                </span>
+                <span className="text-gray-500 text-sm italic ml-2">{species.scientificName}</span>
               )}
             </div>
-            <span className="text-xs text-gray-500">{species.count}</span>
+            <span className="text-xs text-gray-500 shrink-0">{species.count}</span>
           </div>
           <div className="w-full bg-gray-200 rounded-full h-2">
             <div


### PR DESCRIPTION
## Summary
- Species distribution rows in the Overview tab now render as a single line with ellipsis truncation, matching the pattern used in the Media tab species list.
- Dropped the parentheses around the scientific name so the format is `CommonName ScientificName` (italic, gray).
- Added `min-w-0 truncate` on the name wrapper, `gap-2` on the row, and `shrink-0` on the count so the count stays pinned right while long names ellipsize.

## Test plan
- [x] Visually inspected long common + scientific name combos — now truncate on a single line instead of wrapping to two.
- [x] Count column stays aligned right and does not get squished.
- [x] `prettier --write` and `eslint --fix` run clean on the modified file.