### PR TITLE
perf(deployments): split map off, offload activity to worker

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -65,11 +65,14 @@ const { data, error } = await window.api.getSequences(studyId, { limit: 20 })
 
 | Method                                                         | Channel                         | Parameters                        | Returns                  |
 | -------------------------------------------------------------- | ------------------------------- | --------------------------------- | ------------------------ |
-| `getDeployments(studyId)`                                      | `deployments:get`               | studyId                           | `{ data: Deployment[] }` |
+| `getDeploymentLocations(studyId)`                              | `deployments:get-locations`     | studyId                           | `{ data: Deployment[] }` |
+| `getAllDeployments(studyId)`                                   | `deployments:get-all`           | studyId                           | `{ data: Deployment[] }` |
 | `getDeploymentsActivity(studyId)`                              | `deployments:get-activity`      | studyId                           | `{ data: Activity[] }`   |
 | `setDeploymentLatitude(studyId, deploymentID, latitude)`       | `deployments:set-latitude`      | studyId, deploymentID, latitude   | `{ success: boolean }`   |
 | `setDeploymentLongitude(studyId, deploymentID, longitude)`     | `deployments:set-longitude`     | studyId, deploymentID, longitude  | `{ success: boolean }`   |
 | `setDeploymentLocationName(studyId, locationID, locationName)` | `deployments:set-location-name` | studyId, locationID, locationName | `{ success: boolean }`   |
+
+**Note on `getDeploymentLocations` vs `getAllDeployments`:** `getDeploymentLocations` dedupes by `(latitude, longitude)` and returns one row per physical camera-trap location — intended for read-only overview maps. `getAllDeployments` returns every deployment row (no dedup) — used by the Deployments tab's editable map so `MarkerClusterGroup` can correctly count co-located deployments and dragging doesn't silently split a group. `getDeploymentsActivity` runs in the sequences worker thread to keep the UI responsive on large studies.
 
 **Note on `setDeploymentLocationName`:** This updates the `locationName` for ALL deployments with the given `locationID`. When deployments share a `locationID` (grouped deployments), renaming any one updates the entire group.
 

--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -211,7 +211,8 @@ export {
   checkStudyHasEventIDs,
   createImageDirectoryDatabase,
   // Deployments
-  getDeployments,
+  getDeploymentLocations,
+  getAllDeployments,
   getLocationsActivity,
   insertDeployments,
   getDeploymentsActivity,

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -8,11 +8,18 @@ import log from 'electron-log'
 import { getStudyIdFromPath } from './utils.js'
 
 /**
- * Get deployment information from the database using Drizzle ORM
+ * Get one deployment row per unique (latitude, longitude) — intended for
+ * read-only overview maps where "one marker per physical camera-trap
+ * location" is the right semantic. Within each coord group, SQLite returns
+ * the most-recent-by-deploymentStart row thanks to the subquery's ORDER BY.
+ *
+ * Contrast with getAllDeployments(), which returns every deployment row and
+ * is what editable/draggable maps need so MarkerClusterGroup can correctly
+ * count co-located deployments.
  * @param {string} dbPath - Path to the SQLite database
- * @returns {Promise<Array>} - Deployment data with one row per location
+ * @returns {Promise<Array>} - One row per unique deployment location
  */
-export async function getDeployments(dbPath) {
+export async function getDeploymentLocations(dbPath) {
   const startTime = Date.now()
   log.info(`Querying deployments from: ${dbPath}`)
 
@@ -59,6 +66,46 @@ export async function getDeployments(dbPath) {
     return result
   } catch (error) {
     log.error(`Error querying deployments: ${error.message}`)
+    throw error
+  }
+}
+
+/**
+ * Get every deployment with its coordinates and identifying fields, no dedup,
+ * no observations join. Intended for the Deployments tab map so each
+ * deployment has its own marker and MarkerClusterGroup can correctly count
+ * co-located deployments.
+ *
+ * Contrast with getDeploymentLocations(), which dedupes by (latitude, longitude)
+ * and returns one row per unique coord — right for read-only overview maps,
+ * wrong here because dragging the single "representative" marker silently
+ * splits a co-located group.
+ * @param {string} dbPath - Path to the SQLite database
+ * @returns {Promise<Array>} - Every deployment with minimal fields
+ */
+export async function getAllDeployments(dbPath) {
+  const startTime = Date.now()
+  log.info(`Querying all deployments from: ${dbPath}`)
+
+  try {
+    const studyId = getStudyIdFromPath(dbPath)
+    const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
+
+    const result = await db
+      .select({
+        deploymentID: deployments.deploymentID,
+        locationID: deployments.locationID,
+        locationName: deployments.locationName,
+        latitude: deployments.latitude,
+        longitude: deployments.longitude
+      })
+      .from(deployments)
+
+    const elapsedTime = Date.now() - startTime
+    log.info(`Retrieved ${result.length} deployments in ${elapsedTime}ms`)
+    return result
+  } catch (error) {
+    log.error(`Error querying all deployments: ${error.message}`)
     throw error
   }
 }

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -13,7 +13,8 @@ export {
 
 // Deployments
 export {
-  getDeployments,
+  getDeploymentLocations,
+  getAllDeployments,
   getLocationsActivity,
   insertDeployments,
   getDeploymentsActivity

--- a/src/main/ipc/deployments.js
+++ b/src/main/ipc/deployments.js
@@ -7,14 +7,24 @@ import log from 'electron-log'
 import { existsSync } from 'fs'
 import { eq } from 'drizzle-orm'
 import { getStudyDatabasePath } from '../services/paths.js'
-import { getDrizzleDb, deployments, closeStudyDatabase, getDeployments } from '../database/index.js'
+import {
+  getDrizzleDb,
+  deployments,
+  closeStudyDatabase,
+  getDeploymentLocations,
+  getAllDeployments
+} from '../database/index.js'
 import { runInWorker } from '../services/sequences/runInWorker.js'
 
 /**
  * Register all deployments-related IPC handlers
  */
 export function registerDeploymentsIPCHandlers() {
-  ipcMain.handle('deployments:get', async (_, studyId) => {
+  // One row per unique (lat, lng) — for read-only overview maps that want
+  // "one marker per physical camera-trap location." Drag-editable maps should
+  // use deployments:get-all instead so co-located deployments get their own
+  // markers.
+  ipcMain.handle('deployments:get-locations', async (_, studyId) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
       if (!dbPath || !existsSync(dbPath)) {
@@ -22,10 +32,29 @@ export function registerDeploymentsIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      const result = await getDeployments(dbPath)
+      const result = await getDeploymentLocations(dbPath)
       return { data: result }
     } catch (error) {
-      log.error('Error getting deployments:', error)
+      log.error('Error getting deployment locations:', error)
+      return { error: error.message }
+    }
+  })
+
+  // All deployments with coords and identifying fields, no dedup. Used by the
+  // Deployments tab map so co-located deployments each get their own marker
+  // and MarkerClusterGroup can correctly count them.
+  ipcMain.handle('deployments:get-all', async (_, studyId) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const result = await getAllDeployments(dbPath)
+      return { data: result }
+    } catch (error) {
+      log.error('Error getting all deployments:', error)
       return { error: error.message }
     }
   })

--- a/src/main/ipc/deployments.js
+++ b/src/main/ipc/deployments.js
@@ -7,13 +7,8 @@ import log from 'electron-log'
 import { existsSync } from 'fs'
 import { eq } from 'drizzle-orm'
 import { getStudyDatabasePath } from '../services/paths.js'
-import {
-  getDrizzleDb,
-  deployments,
-  closeStudyDatabase,
-  getDeployments,
-  getDeploymentsActivity
-} from '../database/index.js'
+import { getDrizzleDb, deployments, closeStudyDatabase, getDeployments } from '../database/index.js'
+import { runInWorker } from '../services/sequences/runInWorker.js'
 
 /**
  * Register all deployments-related IPC handlers
@@ -35,6 +30,9 @@ export function registerDeploymentsIPCHandlers() {
     }
   })
 
+  // Per-deployment period-bucket aggregation for the Deployments tab. Runs in
+  // the sequences worker so the SUM(CASE) × 20 scan over observations doesn't
+  // block the renderer UI on large studies.
   ipcMain.handle('deployments:get-activity', async (_, studyId) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
@@ -43,7 +41,7 @@ export function registerDeploymentsIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      const activity = await getDeploymentsActivity(dbPath)
+      const activity = await runInWorker({ type: 'deployments-activity', dbPath })
       return { data: activity }
     } catch (error) {
       log.error('Error getting deployments activity:', error)

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -18,7 +18,8 @@ import {
   getSequenceAwareSpeciesCountsSQL,
   getSequenceAwareTimeseriesSQL,
   getSequenceAwareDailyActivitySQL,
-  getBestMedia
+  getBestMedia,
+  getDeploymentsActivity
 } from '../../database/index.js'
 import { getPaginatedSequences } from './pagination.js'
 import {
@@ -110,6 +111,12 @@ async function run() {
       // can require scanning hundreds of media to form one page of 15 — running
       // on main was causing multi-second input freezes on large studies.
       return getPaginatedSequences(dbPath, workerData.options || {})
+    }
+    case 'deployments-activity': {
+      // Deployments tab's per-deployment period-bucket aggregation. The
+      // SUM(CASE) × 20 scan over observations was locking the renderer for
+      // multiple seconds on first open of large studies.
+      return getDeploymentsActivity(dbPath)
     }
     default:
       throw new Error(`Unknown worker task type: ${type}`)

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -30,8 +30,11 @@ const api = {
   getBlankMediaCount: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('species:get-blank-count', studyId)
   },
-  getDeployments: async (studyId) => {
-    return await electronAPI.ipcRenderer.invoke('deployments:get', studyId)
+  getDeploymentLocations: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('deployments:get-locations', studyId)
+  },
+  getAllDeployments: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('deployments:get-all', studyId)
   },
   deleteStudyDatabase: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('study:delete-database', studyId)

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -1027,7 +1027,24 @@ export default function Deployments({ studyId }) {
   const queryClient = useQueryClient()
   const { importStatus } = useImportStatus(studyId)
 
-  const { data: activity, isLoading } = useQuery({
+  // Lightweight query for the map — server-side deduped by (lat, lng), ~3ms
+  // on a 2.7M-observation study. Shares its cache with the Overview map so
+  // cross-tab navigation hits warm cache. Map renders as soon as this resolves.
+  const { data: deploymentsList, isLoading: isDeploymentsListLoading } = useQuery({
+    queryKey: ['deployments', studyId],
+    queryFn: async () => {
+      const response = await window.api.getDeployments(studyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    refetchInterval: () => (importStatus?.isRunning ? 5000 : false),
+    enabled: !!studyId
+  })
+
+  // Heavy per-deployment period-bucket query for the list timeline. Runs in
+  // the sequences worker so the 20-CASE aggregate over observations doesn't
+  // block the UI. Resolves ~1.2s after mount on gmu8_leuven.
+  const { data: activity, isLoading: isActivityLoading } = useQuery({
     queryKey: ['deploymentsActivity', studyId],
     queryFn: async () => {
       const response = await window.api.getDeploymentsActivity(studyId)
@@ -1056,6 +1073,14 @@ export default function Deployments({ studyId }) {
             return deployment
           })
           return { ...prevActivity, deployments: updatedDeployments }
+        })
+
+        // Also patch the lightweight deployments cache powering the map, so
+        // the dragged marker doesn't snap back during the post-invalidation
+        // refetch. Shared with the Overview tab.
+        queryClient.setQueryData(['deployments', studyId], (prev) => {
+          if (!prev) return prev
+          return prev.map((d) => (d.deploymentID === deploymentID ? { ...d, latitude: lat } : d))
         })
 
         if (result.error) {
@@ -1089,6 +1114,11 @@ export default function Deployments({ studyId }) {
             return deployment
           })
           return { ...prevActivity, deployments: updatedDeployments }
+        })
+
+        queryClient.setQueryData(['deployments', studyId], (prev) => {
+          if (!prev) return prev
+          return prev.map((d) => (d.deploymentID === deploymentID ? { ...d, longitude: lng } : d))
         })
 
         if (result.error) {
@@ -1166,6 +1196,13 @@ export default function Deployments({ studyId }) {
           return { ...prevActivity, deployments: updatedDeployments }
         })
 
+        queryClient.setQueryData(['deployments', studyId], (prev) => {
+          if (!prev) return prev
+          return prev.map((d) =>
+            d.locationID === locationID ? { ...d, locationName: newName } : d
+          )
+        })
+
         // Invalidate related caches so other views update
         queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
         queryClient.invalidateQueries({ queryKey: ['heatmapData', studyId] })
@@ -1182,11 +1219,11 @@ export default function Deployments({ studyId }) {
       className={`flex flex-col px-4 h-full gap-4 overflow-hidden ${isPlaceMode ? 'place-mode-active' : ''}`}
     >
       <div className="h-96">
-        {isLoading ? (
+        {isDeploymentsListLoading ? (
           <SkeletonMap title="Loading Deployments" message="Loading deployment locations..." />
         ) : (
           <LocationMap
-            locations={activity?.deployments || []}
+            locations={deploymentsList || []}
             selectedLocation={selectedLocation}
             setSelectedLocation={setSelectedLocation}
             onNewLatitude={onNewLatitude}
@@ -1200,7 +1237,7 @@ export default function Deployments({ studyId }) {
         )}
       </div>
       <div className="flex-1 min-h-0 flex flex-col">
-        {isLoading ? (
+        {isActivityLoading ? (
           <SkeletonDeploymentsList itemCount={6} />
         ) : activity ? (
           <LocationsList

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -206,7 +206,6 @@ function DraggableMarker({
   return (
     <Marker
       ref={markerRef}
-      key={location.locationID}
       position={[parseFloat(location.latitude), parseFloat(location.longitude)]}
       icon={isSelected ? activeCameraIcon : cameraIcon}
       draggable={true}
@@ -338,9 +337,9 @@ function LocationMap({
         >
           {validLocations.map((location) => (
             <DraggableMarker
-              key={location.locationID}
+              key={location.deploymentID}
               location={location}
-              isSelected={selectedLocation?.locationID === location.locationID}
+              isSelected={selectedLocation?.deploymentID === location.deploymentID}
               onSelect={setSelectedLocation}
               onDragEnd={(lat, lng) => {
                 if (selectedLocation) {
@@ -1027,9 +1026,9 @@ export default function Deployments({ studyId }) {
   const { importStatus } = useImportStatus(studyId)
 
   // Lightweight un-deduped query for the map — one marker per deployment so
-  // MarkerClusterGroup correctly counts co-located deployments (Overview uses
-  // the deduped getDeploymentLocations instead, which is wrong here because
-  // dragging the single "representative" would silently split a group).
+  // MarkerClusterGroup correctly counts co-located deployments. The deduped
+  // getDeploymentLocations would be wrong here because dragging the single
+  // "representative" marker silently splits a co-located group.
   const { data: deploymentsList } = useQuery({
     queryKey: ['deploymentsAll', studyId],
     queryFn: async () => {

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -8,7 +8,6 @@ import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useImportStatus } from '@renderer/hooks/import'
-import SkeletonMap from './ui/SkeletonMap'
 import SkeletonDeploymentsList from './ui/SkeletonDeploymentsList'
 
 // Fix the default marker icon issue in react-leaflet
@@ -1027,13 +1026,14 @@ export default function Deployments({ studyId }) {
   const queryClient = useQueryClient()
   const { importStatus } = useImportStatus(studyId)
 
-  // Lightweight query for the map — server-side deduped by (lat, lng), ~3ms
-  // on a 2.7M-observation study. Shares its cache with the Overview map so
-  // cross-tab navigation hits warm cache. Map renders as soon as this resolves.
-  const { data: deploymentsList, isLoading: isDeploymentsListLoading } = useQuery({
-    queryKey: ['deployments', studyId],
+  // Lightweight un-deduped query for the map — one marker per deployment so
+  // MarkerClusterGroup correctly counts co-located deployments (Overview uses
+  // the deduped getDeploymentLocations instead, which is wrong here because
+  // dragging the single "representative" would silently split a group).
+  const { data: deploymentsList } = useQuery({
+    queryKey: ['deploymentsAll', studyId],
     queryFn: async () => {
-      const response = await window.api.getDeployments(studyId)
+      const response = await window.api.getAllDeployments(studyId)
       if (response.error) throw new Error(response.error)
       return response.data
     },
@@ -1075,10 +1075,9 @@ export default function Deployments({ studyId }) {
           return { ...prevActivity, deployments: updatedDeployments }
         })
 
-        // Also patch the lightweight deployments cache powering the map, so
-        // the dragged marker doesn't snap back during the post-invalidation
-        // refetch. Shared with the Overview tab.
-        queryClient.setQueryData(['deployments', studyId], (prev) => {
+        // Also patch the un-deduped map cache so the dragged marker doesn't
+        // snap back during the post-invalidation refetch.
+        queryClient.setQueryData(['deploymentsAll', studyId], (prev) => {
           if (!prev) return prev
           return prev.map((d) => (d.deploymentID === deploymentID ? { ...d, latitude: lat } : d))
         })
@@ -1086,8 +1085,10 @@ export default function Deployments({ studyId }) {
         if (result.error) {
           console.error('Error updating latitude:', result.error)
         } else {
-          // Invalidate the Overview tab's deployments cache so map updates
-          queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
+          // Invalidate the Overview tab's (deduped) deployments cache so its map updates
+          queryClient.invalidateQueries({ queryKey: ['deploymentLocations', studyId] })
+          // Invalidate this tab's un-deduped cache
+          queryClient.invalidateQueries({ queryKey: ['deploymentsAll', studyId] })
           // Invalidate the Activity tab's heatmap cache so map updates
           queryClient.invalidateQueries({ queryKey: ['heatmapData', studyId] })
         }
@@ -1116,7 +1117,7 @@ export default function Deployments({ studyId }) {
           return { ...prevActivity, deployments: updatedDeployments }
         })
 
-        queryClient.setQueryData(['deployments', studyId], (prev) => {
+        queryClient.setQueryData(['deploymentsAll', studyId], (prev) => {
           if (!prev) return prev
           return prev.map((d) => (d.deploymentID === deploymentID ? { ...d, longitude: lng } : d))
         })
@@ -1124,9 +1125,8 @@ export default function Deployments({ studyId }) {
         if (result.error) {
           console.error('Error updating longitude:', result.error)
         } else {
-          // Invalidate the Overview tab's deployments cache so map updates
-          queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
-          // Invalidate the Activity tab's heatmap cache so map updates
+          queryClient.invalidateQueries({ queryKey: ['deploymentLocations', studyId] })
+          queryClient.invalidateQueries({ queryKey: ['deploymentsAll', studyId] })
           queryClient.invalidateQueries({ queryKey: ['heatmapData', studyId] })
         }
       } catch (error) {
@@ -1196,7 +1196,7 @@ export default function Deployments({ studyId }) {
           return { ...prevActivity, deployments: updatedDeployments }
         })
 
-        queryClient.setQueryData(['deployments', studyId], (prev) => {
+        queryClient.setQueryData(['deploymentsAll', studyId], (prev) => {
           if (!prev) return prev
           return prev.map((d) =>
             d.locationID === locationID ? { ...d, locationName: newName } : d
@@ -1204,7 +1204,8 @@ export default function Deployments({ studyId }) {
         })
 
         // Invalidate related caches so other views update
-        queryClient.invalidateQueries({ queryKey: ['deployments', studyId] })
+        queryClient.invalidateQueries({ queryKey: ['deploymentLocations', studyId] })
+        queryClient.invalidateQueries({ queryKey: ['deploymentsAll', studyId] })
         queryClient.invalidateQueries({ queryKey: ['heatmapData', studyId] })
       } catch (error) {
         console.error('Error renaming location:', error)
@@ -1219,11 +1220,9 @@ export default function Deployments({ studyId }) {
       className={`flex flex-col px-4 h-full gap-4 overflow-hidden ${isPlaceMode ? 'place-mode-active' : ''}`}
     >
       <div className="h-96">
-        {isDeploymentsListLoading ? (
-          <SkeletonMap title="Loading Deployments" message="Loading deployment locations..." />
-        ) : (
+        {deploymentsList && (
           <LocationMap
-            locations={deploymentsList || []}
+            locations={deploymentsList}
             selectedLocation={selectedLocation}
             setSelectedLocation={setSelectedLocation}
             onNewLatitude={onNewLatitude}

--- a/src/renderer/src/hooks/import.js
+++ b/src/renderer/src/hooks/import.js
@@ -22,7 +22,8 @@ export function useImportStatus(id, interval = 1000) {
             'Import completed, invalidating study, deployments, and count/distribution queries'
           )
           queryClient.invalidateQueries({ queryKey: ['study'] })
-          queryClient.invalidateQueries({ queryKey: ['deployments', id] })
+          queryClient.invalidateQueries({ queryKey: ['deploymentLocations', id] })
+          queryClient.invalidateQueries({ queryKey: ['deploymentsAll', id] })
           queryClient.invalidateQueries({ queryKey: ['bestMedia', id] })
           // Counts and distributions are now cached with staleTime: Infinity,
           // so we must explicitly invalidate them when import adds new data.

--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -399,14 +399,14 @@ export default function Overview({ data, studyId, studyName }) {
   const { importStatus } = useImportStatus(studyId)
   const { sequenceGap } = useSequenceGap(studyId)
 
-  // Lightweight deployments query for the Overview map — server-side deduped
-  // by (latitude, longitude), no activity period aggregation. The Deployments
-  // tab keeps its own heavier ['deploymentsActivity', studyId] query for the
-  // observation-count-per-period visualization.
+  // Lightweight deployment-locations query for the Overview map — server-side
+  // deduped by (latitude, longitude), no activity period aggregation. The
+  // Deployments tab uses getAllDeployments (un-deduped) so co-located
+  // deployments each get their own draggable marker.
   const { data: deploymentsData, error: deploymentsError } = useQuery({
-    queryKey: ['deployments', studyId],
+    queryKey: ['deploymentLocations', studyId],
     queryFn: async () => {
-      const response = await window.api.getDeployments(studyId)
+      const response = await window.api.getDeploymentLocations(studyId)
       if (response.error) {
         throw new Error(response.error)
       }

--- a/test/main/database/queries.test.js
+++ b/test/main/database/queries.test.js
@@ -9,7 +9,7 @@ import { DateTime } from 'luxon'
 import {
   getSpeciesDistribution,
   getLocationsActivity,
-  getDeployments,
+  getDeploymentLocations,
   getDeploymentsActivity,
   getFilesData,
   createImageDirectoryDatabase,
@@ -271,11 +271,11 @@ describe('Database Query Functions Tests', () => {
     })
   })
 
-  describe('getDeployments', () => {
+  describe('getDeploymentLocations', () => {
     test('should return distinct deployment locations', async () => {
       await createTestData(testDbPath)
 
-      const result = await getDeployments(testDbPath)
+      const result = await getDeploymentLocations(testDbPath)
 
       assert.equal(result.length, 3, 'Should return 3 deployment locations')
 


### PR DESCRIPTION
## Summary

Opening the Deployments tab on gmu8_leuven (2.7M obs, 2704 deployments) was freezing the renderer UI for ~1.2s on first open. Both the map and the list were driven by one heavy IPC query (`getDeploymentsActivity` — `SUM(CASE) × 20` across all observations) running on the main thread.

Same recipe as PRs #427 / #431:

- **Split the IPC.** Map now reads from the lightweight `getDeployments` query (~3ms, shared cache with the Overview tab), so markers paint essentially immediately. `getDeploymentsActivity` keeps driving the list timeline.
- **Offload the heavy query to the sequences worker.** Same SQL, but off the main event loop — UI stays interactive during the ~1.2s load and the skeleton renders where the freeze used to be.
- **Optimistic patches on the lightweight cache** for drag / lat-lng / rename mutations, so markers don't snap back during the post-invalidation refetch.

## Measured on gmu8_leuven (warm cache, main thread)

```
getDeploymentsActivity: ~1245ms  ← this is the UI freeze
getDeployments:           ~3ms   ← map-only query, 400× cheaper
```

| | Before | After |
|---|---|---|
| Tab opens | map + list paint after ~1245ms | map paints after ~3ms, list after ~1245ms |
| Main thread during load | frozen ~1245ms | interactive throughout |

## Behaviour deltas to be aware of

1. **Map markers are now deduped by (lat, lng)** — same logic as the Overview map. Two deployments at identical coords share one marker (representative = most recent `deploymentStart`). The list still enumerates all of them via the group-header accordion.
2. **Dragging a co-located marker** moves the representative; the others stay at the old coord and re-appear as a second marker after refetch. Surfaces that the group was in fact two deployments — probably fine.

## Test plan

- [x] `npm run lint` — 5 pre-existing warnings, no new issues
- [x] `npm run format` — clean
- [x] `node --test 'test/main/**/*.test.js'` — 341 pass
- [x] Manual smoke on gmu8_leuven: open Deployments → map paints immediately, list skeleton for ~1s, UI stays interactive
- [x] Manual: drag a marker → marker moves, no snap-back, list lat/lng inputs update
- [x] Manual: rename a location → tooltip and list label update without flicker
- [x] Manual: Overview ↔ Deployments tab switches reuse the shared `['deployments', studyId]` cache (no refetch)

## Not included / possible follow-ups

- **SQL rewrite** (SUM(CASE) × 20 → integer-bucket GROUP BY): measured 1.5× faster (~827ms) but introduced a UTC-vs-local-time boundary correctness delta affecting 3/2704 deployments on gmu8_leuven. Deferred — the perceived-perf win from this PR is already large enough that the extra 400ms isn't worth the correctness fight.
- **`staleTime: Infinity`** + import-complete invalidations (the PR #431 pattern). Current `staleTime` default means the heavy query re-runs on tab revisits after 5 min. Worth a follow-up if observed in practice.