### PR TITLE
perf(activity): progressive map + SQL fast-path for heatmap

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -225,6 +225,7 @@ export {
   getSpeciesHeatmapDataByMedia,
   getSequenceAwareSpeciesCountsSQL,
   getSequenceAwareTimeseriesSQL,
+  getSequenceAwareHeatmapSQL,
   getSequenceAwareDailyActivitySQL,
   // Media
   getFilesData,

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -30,6 +30,7 @@ export {
   getSpeciesHeatmapDataByMedia,
   getSequenceAwareSpeciesCountsSQL,
   getSequenceAwareTimeseriesSQL,
+  getSequenceAwareHeatmapSQL,
   getSequenceAwareDailyActivitySQL
 } from './species.js'
 

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -701,11 +701,15 @@ export async function getSequenceAwareHeatmapSQL(
       // media are excluded from the window (LAG can't order them) and
       // contribute via null_totals when includeNullTimestamps.
       const mediaFilter = buildDateHourFilter('m.timestamp')
-      // Force m.timestamp IS NOT NULL on the window branch regardless of
-      // includeNullTimestamps — those rows go through null_totals instead.
-      const windowTsGuard = 'AND m.timestamp IS NOT NULL'
+      // Force timestamps that aren't parseable out of the window branch
+      // regardless of includeNullTimestamps — `julianday(ts) IS NULL` catches
+      // unparseable strings (e.g. "not-a-date") that would otherwise sit in
+      // the window with a NULL gap-comparison result and silently extend
+      // whichever sequence precedes them. Matches JS `hasValidTimestamp`
+      // (grouping.js:13), which also treats invalid timestamps as null-ts.
+      const windowTsGuard = 'AND m.timestamp IS NOT NULL AND julianday(m.timestamp) IS NOT NULL'
       const nullBranchFilter = includeNullTimestamps
-        ? "AND (m.timestamp IS NULL OR m.timestamp = '')"
+        ? "AND (m.timestamp IS NULL OR m.timestamp = '' OR julianday(m.timestamp) IS NULL)"
         : null
 
       const sql = `

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -587,6 +587,295 @@ export async function getSpeciesHeatmapDataByMedia(
 }
 
 /**
+ * Per-(species, lat, lng) sequence-aware heatmap counts computed entirely in
+ * SQL. Returns `[{ scientificName, latitude, longitude, locationName, count }]`
+ * rows ready to pivot into the `{sp: [{lat, lng, count, locationName}]}` shape
+ * the map expects.
+ *
+ * Replaces the previous "ship every (species, media) row, aggregate in JS"
+ * pipeline. On gmu8_leuven (2.7M obs, 2704 deployments, gap=300s) the IPC
+ * payload goes from ~400MB to <100KB and end-to-end time drops from ~19s to
+ * ~9s — the SQL is still dominated by the window-function scan but JS no
+ * longer has to re-aggregate 1.3M rows.
+ *
+ * Three internal paths keyed on gapSeconds (semantics mirror
+ * calculateSequenceAwareHeatmap → calculateSequenceAwareSpeciesCounts):
+ *  - gapSeconds > 0       → time-gap grouping via window functions.
+ *                           Sequences form at the (lat, lng) level across ALL
+ *                           selected species so an intervening obs at a
+ *                           co-located deployment still breaks a sequence
+ *                           (matches JS, which groups by location first then
+ *                           sequences within). Per (species, seq, lat, lng)
+ *                           take MAX of per-media obs count, SUM by
+ *                           (species, lat, lng).
+ *  - gapSeconds === 0     → eventID grouping, per-species. Media without
+ *                           eventID become their own event via
+ *                           COALESCE(..., 'solo:' || m.mediaID). Null-ts
+ *                           media contribute their counts directly via the
+ *                           null_totals branch.
+ *  - null / undefined / ≤ 0
+ *    (not positive)       → each media its own sequence →
+ *                           COUNT(observationID) per (species, lat, lng).
+ *
+ * Window-path ordering is (timestamp, mediaID) — deterministic. Tied
+ * timestamps at the same location can produce off-by-±1-2 counts vs the
+ * JS path (which inherits SQLite's non-deterministic tied-row order);
+ * validated against 19 local studies: all per-media and eventID paths are
+ * byte-exact, window-path maxDiff is 2 on the worst-case study.
+ *
+ * BLANK_SENTINEL in speciesNames → returns null, caller falls back to the
+ * JS path. The current heatmap JS path doesn't handle blanks either, but
+ * we keep the convention of the other fast-paths for future-proofing.
+ *
+ * @param {string} dbPath
+ * @param {Array<string>} speciesNames
+ * @param {string|null} startDate - ISO date string for range start
+ * @param {string|null} endDate - ISO date string for range end
+ * @param {number} startHour - 0-24
+ * @param {number} endHour - 0-24
+ * @param {boolean} includeNullTimestamps
+ * @param {number|null|undefined} gapSeconds
+ * @returns {Promise<Array<{scientificName: string, latitude: number, longitude: number, locationName: string, count: number}>|null>}
+ */
+export async function getSequenceAwareHeatmapSQL(
+  dbPath,
+  speciesNames = [],
+  startDate,
+  endDate,
+  startHour = 0,
+  endHour = 24,
+  includeNullTimestamps = false,
+  gapSeconds
+) {
+  if (speciesNames.includes(BLANK_SENTINEL)) return null
+  const regularSpecies = speciesNames.filter((s) => s !== BLANK_SENTINEL)
+  if (regularSpecies.length === 0) return []
+
+  const startTime = Date.now()
+  const studyId = getStudyIdFromPath(dbPath)
+  const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
+  const sqlite = manager.getSqlite()
+
+  const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
+  const useEventIDPath = gapSeconds === 0
+  const pathLabel = isPositiveGap
+    ? `time-gap-${gapSeconds}s`
+    : useEventIDPath
+      ? 'eventID'
+      : 'per-media'
+  const speciesPlaceholders = regularSpecies.map(() => '?').join(',')
+
+  // Date + hour filters. Non-window paths evaluate the predicate inline; the
+  // window path pushes it into media_info (and needs a parallel null-ts
+  // branch when includeNullTimestamps).
+  const buildDateHourFilter = (tsCol) => {
+    const conds = []
+    const params = []
+    const noDateFilter = includeNullTimestamps && (!startDate || !endDate)
+    if (!noDateFilter) {
+      if (includeNullTimestamps) {
+        conds.push(`(${tsCol} IS NULL OR (${tsCol} >= ? AND ${tsCol} <= ?))`)
+        params.push(startDate, endDate)
+      } else {
+        conds.push(`${tsCol} >= ?`)
+        conds.push(`${tsCol} <= ?`)
+        params.push(startDate, endDate)
+      }
+    }
+    const hourExpr = `CAST(strftime('%H', ${tsCol}) AS INTEGER)`
+    if (startHour < endHour) {
+      const hc = `(${hourExpr} >= ${startHour} AND ${hourExpr} < ${endHour})`
+      conds.push(includeNullTimestamps ? `(${tsCol} IS NULL OR ${hc})` : hc)
+    } else if (startHour > endHour) {
+      const hc = `(${hourExpr} >= ${startHour} OR ${hourExpr} < ${endHour})`
+      conds.push(includeNullTimestamps ? `(${tsCol} IS NULL OR ${hc})` : hc)
+    }
+    // startHour === endHour → full day, no filter
+    return { where: conds.length > 0 ? 'AND ' + conds.join(' AND ') : '', params }
+  }
+
+  try {
+    let rows
+    if (isPositiveGap) {
+      // Sequencing at (lat, lng) level across all selected species. Null-ts
+      // media are excluded from the window (LAG can't order them) and
+      // contribute via null_totals when includeNullTimestamps.
+      const mediaFilter = buildDateHourFilter('m.timestamp')
+      // Force m.timestamp IS NOT NULL on the window branch regardless of
+      // includeNullTimestamps — those rows go through null_totals instead.
+      const windowTsGuard = 'AND m.timestamp IS NOT NULL'
+      const nullBranchFilter = includeNullTimestamps
+        ? "AND (m.timestamp IS NULL OR m.timestamp = '')"
+        : null
+
+      const sql = `
+        WITH media_obs AS (
+          SELECT o.mediaID AS mediaID, o.scientificName AS scientificName,
+                 COUNT(*) AS obs_count
+            FROM observations o
+            WHERE o.scientificName IN (${speciesPlaceholders})
+            GROUP BY o.scientificName, o.mediaID
+        ),
+        media_info AS (
+          SELECT m.mediaID, m.deploymentID, m.timestamp AS ts,
+                 CASE WHEN m.fileMediatype LIKE 'video/%' THEN 1 ELSE 0 END AS is_video,
+                 d.latitude, d.longitude, d.locationName
+            FROM media m
+            INNER JOIN deployments d ON m.deploymentID = d.deploymentID
+            WHERE d.latitude IS NOT NULL AND d.longitude IS NOT NULL
+              ${windowTsGuard}
+              ${mediaFilter.where}
+              AND m.mediaID IN (SELECT DISTINCT mediaID FROM media_obs)
+        ),
+        marked AS (
+          SELECT *, CASE
+            WHEN LAG(mediaID) OVER w IS NULL THEN 1
+            WHEN is_video = 1 THEN 1
+            WHEN LAG(is_video) OVER w = 1 THEN 1
+            WHEN deploymentID IS NULL THEN 1
+            WHEN LAG(deploymentID) OVER w IS NULL THEN 1
+            WHEN deploymentID != LAG(deploymentID) OVER w THEN 1
+            WHEN (julianday(ts) - julianday(LAG(ts) OVER w)) * 86400 > ? THEN 1
+            ELSE 0
+          END AS is_new FROM media_info
+          WINDOW w AS (PARTITION BY latitude, longitude ORDER BY ts, mediaID)
+        ),
+        sequenced AS (
+          SELECT mediaID, latitude, longitude, locationName,
+                 SUM(is_new) OVER (PARTITION BY latitude, longitude ORDER BY ts, mediaID
+                                   ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS seq_id
+            FROM marked
+        ),
+        per_seq_sp_loc AS (
+          SELECT mo.scientificName, s.latitude, s.longitude, s.seq_id,
+                 MAX(mo.obs_count) AS max_count, MAX(s.locationName) AS locationName
+            FROM sequenced s INNER JOIN media_obs mo ON s.mediaID = mo.mediaID
+            GROUP BY mo.scientificName, s.latitude, s.longitude, s.seq_id
+        ),
+        valid_totals AS (
+          SELECT scientificName, latitude, longitude,
+                 MAX(locationName) AS locationName,
+                 SUM(max_count) AS count
+            FROM per_seq_sp_loc
+            GROUP BY scientificName, latitude, longitude
+        )
+        ${
+          nullBranchFilter
+            ? `,
+        null_totals AS (
+          SELECT o.scientificName,
+                 d.latitude, d.longitude, MAX(d.locationName) AS locationName,
+                 COUNT(o.observationID) AS count
+            FROM observations o
+            INNER JOIN media m ON o.mediaID = m.mediaID
+            INNER JOIN deployments d ON m.deploymentID = d.deploymentID
+            WHERE o.scientificName IN (${speciesPlaceholders})
+              AND d.latitude IS NOT NULL AND d.longitude IS NOT NULL
+              ${nullBranchFilter}
+            GROUP BY o.scientificName, d.latitude, d.longitude
+        )
+        SELECT scientificName, latitude, longitude, MAX(locationName) AS locationName,
+               SUM(count) AS count
+          FROM (SELECT * FROM valid_totals UNION ALL SELECT * FROM null_totals)
+          GROUP BY scientificName, latitude, longitude`
+            : `
+        SELECT scientificName, latitude, longitude, locationName, count FROM valid_totals`
+        }
+      `
+      const params = [
+        ...regularSpecies,
+        ...mediaFilter.params,
+        gapSeconds,
+        ...(nullBranchFilter ? regularSpecies : [])
+      ]
+      rows = sqlite.prepare(sql).all(...params)
+    } else if (useEventIDPath) {
+      const obsFilter = buildDateHourFilter('m.timestamp')
+      rows = sqlite
+        .prepare(
+          `
+          WITH per_media AS (
+            SELECT o.scientificName AS scientificName, m.mediaID AS mediaID,
+                   COALESCE(NULLIF(o.eventID, ''), 'solo:' || o.mediaID) AS event_key,
+                   m.timestamp AS ts,
+                   d.latitude, d.longitude, d.locationName,
+                   COUNT(*) AS media_count
+              FROM observations o
+              INNER JOIN media m ON o.mediaID = m.mediaID
+              INNER JOIN deployments d ON m.deploymentID = d.deploymentID
+              WHERE o.scientificName IN (${speciesPlaceholders})
+                AND d.latitude IS NOT NULL AND d.longitude IS NOT NULL
+                ${obsFilter.where}
+              GROUP BY o.scientificName, o.mediaID
+          ),
+          classified AS (
+            SELECT scientificName, event_key, mediaID, media_count,
+                   latitude, longitude, locationName,
+                   CASE
+                     WHEN ts IS NULL OR ts = '' OR julianday(ts) IS NULL
+                     THEN 1 ELSE 0
+                   END AS is_null_ts
+              FROM per_media
+          ),
+          valid_maxes AS (
+            SELECT scientificName, latitude, longitude, event_key,
+                   MAX(media_count) AS max_count,
+                   MAX(locationName) AS locationName
+              FROM classified WHERE is_null_ts = 0
+              GROUP BY scientificName, latitude, longitude, event_key
+          ),
+          valid_totals AS (
+            SELECT scientificName, latitude, longitude,
+                   MAX(locationName) AS locationName, SUM(max_count) AS count
+              FROM valid_maxes GROUP BY scientificName, latitude, longitude
+          ),
+          null_totals AS (
+            SELECT scientificName, latitude, longitude,
+                   MAX(locationName) AS locationName, SUM(media_count) AS count
+              FROM classified WHERE is_null_ts = 1
+              GROUP BY scientificName, latitude, longitude
+          )
+          SELECT scientificName, latitude, longitude,
+                 MAX(locationName) AS locationName, SUM(count) AS count
+            FROM (SELECT * FROM valid_totals UNION ALL SELECT * FROM null_totals)
+            GROUP BY scientificName, latitude, longitude
+        `
+        )
+        .all(...regularSpecies, ...obsFilter.params)
+    } else {
+      // Per-media path: each media is its own sequence, so MAX reduces to
+      // per-media count and SUM reduces to COUNT(observationID).
+      const obsFilter = buildDateHourFilter('m.timestamp')
+      rows = sqlite
+        .prepare(
+          `
+          SELECT o.scientificName AS scientificName,
+                 d.latitude, d.longitude, MAX(d.locationName) AS locationName,
+                 COUNT(o.observationID) AS count
+            FROM observations o
+            INNER JOIN media m ON o.mediaID = m.mediaID
+            INNER JOIN deployments d ON m.deploymentID = d.deploymentID
+            WHERE o.scientificName IN (${speciesPlaceholders})
+              AND d.latitude IS NOT NULL AND d.longitude IS NOT NULL
+              ${obsFilter.where}
+            GROUP BY o.scientificName, d.latitude, d.longitude
+        `
+        )
+        .all(...regularSpecies, ...obsFilter.params)
+    }
+
+    const elapsed = Date.now() - startTime
+    log.info(
+      `[SQL-agg] sequence-aware heatmap (gap=${gapSeconds}, path=${pathLabel}): ${rows.length} (species,lat,lng) rows in ${elapsed}ms`
+    )
+    return rows
+  } catch (error) {
+    log.error(`Error in getSequenceAwareHeatmapSQL: ${error.message}`)
+    throw error
+  }
+}
+
+/**
  * Hourly sequence-aware daily activity computed entirely in SQL.
  * Returns `[{ scientificName, hour, count }]`, pivoted into the radar's
  * `[{ hour, [sp1]: N, ... }]` shape by pivotPreAggregatedDailyActivity.

--- a/src/main/services/sequences/speciesCounts.js
+++ b/src/main/services/sequences/speciesCounts.js
@@ -273,6 +273,32 @@ export function pivotPreAggregatedDailyActivity(rows, selectedSpecies) {
 }
 
 /**
+ * Pivot pre-aggregated `[{ scientificName, latitude, longitude, locationName,
+ * count }]` rows (as returned by getSequenceAwareHeatmapSQL) into the
+ * `{ [scientificName]: [{ lat, lng, count, locationName }] }` shape the
+ * heatmap consumer expects. Lets the SQL fast path skip the
+ * calculateSequenceAwareHeatmap pipeline entirely.
+ *
+ * @param {Array<{scientificName: string, latitude: number, longitude: number, locationName: string, count: number}>} rows
+ * @returns {Object<string, Array<{lat: number, lng: number, count: number, locationName: string}>>}
+ */
+export function pivotPreAggregatedHeatmap(rows) {
+  if (!rows || rows.length === 0) return {}
+  const out = {}
+  for (const { scientificName, latitude, longitude, locationName, count } of rows) {
+    if (latitude == null || longitude == null) continue
+    if (!out[scientificName]) out[scientificName] = []
+    out[scientificName].push({
+      lat: parseFloat(latitude),
+      lng: parseFloat(longitude),
+      count,
+      locationName
+    })
+  }
+  return out
+}
+
+/**
  * Calculates sequence-aware species counts grouped by location for heatmap pie charts.
  *
  * @param {Array} observationsByMedia - Array of { scientificName, mediaID, timestamp, deploymentID, eventID, fileMediatype, latitude, longitude, locationName, count }

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -17,6 +17,7 @@ import {
   getSpeciesHeatmapDataByMedia,
   getSequenceAwareSpeciesCountsSQL,
   getSequenceAwareTimeseriesSQL,
+  getSequenceAwareHeatmapSQL,
   getSequenceAwareDailyActivitySQL,
   getBestMedia,
   getDeploymentsActivity
@@ -27,7 +28,8 @@ import {
   calculateSequenceAwareTimeseries,
   calculateSequenceAwareHeatmap,
   pivotPreAggregatedTimeseries,
-  pivotPreAggregatedDailyActivity
+  pivotPreAggregatedDailyActivity,
+  pivotPreAggregatedHeatmap
 } from './speciesCounts.js'
 
 async function run() {
@@ -79,6 +81,24 @@ async function run() {
       return calculateSequenceAwareTimeseries(rawData, effectiveGapSeconds)
     }
     case 'heatmap': {
+      // Fast path: SQL aggregate handles all three gap cases (per-media,
+      // eventID, time-gap) and returns pre-grouped (species, lat, lng, count)
+      // rows — on gmu8_leuven the IPC payload goes from ~400MB of raw
+      // observation rows to <100KB, with no JS-side aggregation.
+      // Returns null only when BLANK_SENTINEL is in speciesNames, in which
+      // case we fall back to the JS path (which doesn't handle blanks either
+      // — the fallback is future-proofing).
+      const fastRows = await getSequenceAwareHeatmapSQL(
+        dbPath,
+        speciesNames,
+        startDate,
+        endDate,
+        startHour,
+        endHour,
+        includeNullTimestamps,
+        effectiveGapSeconds
+      )
+      if (fastRows !== null) return pivotPreAggregatedHeatmap(fastRows)
       const rawData = await getSpeciesHeatmapDataByMedia(
         dbPath,
         speciesNames,

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -14,6 +14,26 @@ import { useImportStatus } from './hooks/import'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 
+// Inject the keyframes used by the skeleton markers once per page load.
+// Guarded by an id check so HMR / multiple SpeciesMap mounts don't re-append
+// the same <style> block.
+const skeletonMarkerStyles = `
+  @keyframes activity-skeleton-pulse {
+    0%   { opacity: 0.55; }
+    50%  { opacity: 1; }
+    100% { opacity: 0.55; }
+  }
+  .activity-skeleton-marker, .activity-skeleton-cluster {
+    animation: activity-skeleton-pulse 1.6s ease-in-out infinite;
+  }
+`
+if (typeof document !== 'undefined' && !document.getElementById('activity-skeleton-styles')) {
+  const style = document.createElement('style')
+  style.id = 'activity-skeleton-styles'
+  style.textContent = skeletonMarkerStyles
+  document.head.appendChild(style)
+}
+
 // Component to handle map layer change events for persistence
 function LayerChangeHandler({ onLayerChange }) {
   const map = useMap()
@@ -27,8 +47,32 @@ function LayerChangeHandler({ onLayerChange }) {
   return null
 }
 
-// SpeciesMap component
-const SpeciesMap = ({ heatmapData, selectedSpecies, palette, geoKey, studyId }) => {
+// SpeciesMap component.
+//
+// Renders the leaflet map in two progressive modes so the user sees something
+// at deployment locations as fast as possible:
+//   1. `heatmapData` null (still loading in the worker) → uniform gray dots
+//      clustered at the deployment coordinates. The map mounts with bounds
+//      derived from `deploymentLocations`, which comes from the lightweight
+//      getDeploymentLocations query (shared cache with Overview/Deployments,
+//      ~ms). On gmu8_leuven this paints in ~50ms instead of waiting ~8s
+//      for the heavy sequence-aware SQL.
+//   2. `heatmapData` present → swap the MarkerClusterGroup contents to the
+//      pie-chart markers. The MapContainer and LayersControl stay mounted,
+//      so the user's zoom/pan/layer selection survive the swap.
+//
+// The cluster group's `key` is still `geoKey` so filter changes rebuild the
+// clustering (same as before), plus an extra 'pies'/'dots' suffix so the
+// initial dots → pies transition forces a fresh cluster layer rather than
+// trying to reconcile pie icons onto gray markers.
+const SpeciesMap = ({
+  deploymentLocations,
+  heatmapData,
+  selectedSpecies,
+  palette,
+  geoKey,
+  studyId
+}) => {
   // Persist map layer selection per study
   const mapLayerKey = `mapLayer:${studyId}`
   const [selectedLayer, setSelectedLayer] = useState(() => {
@@ -216,26 +260,72 @@ const SpeciesMap = ({ heatmapData, selectedSpecies, palette, geoKey, studyId }) 
 
   const locationPoints = processPointData()
 
-  // Calculate bounds if we have location points
-  const bounds =
-    locationPoints.length > 0
-      ? locationPoints.reduce(
-          (bounds, point) => {
-            return [
-              [Math.min(bounds[0][0], point.lat), Math.min(bounds[0][1], point.lng)],
-              [Math.max(bounds[1][0], point.lat), Math.max(bounds[1][1], point.lng)]
-            ]
-          },
-          [
-            [90, 180],
-            [-90, -180]
-          ] // Initial bounds [min, max]
-        )
-      : null
+  // Bounds derive from deploymentLocations, not heatmapData, so the initial
+  // viewport is fixed from the moment the map mounts — it doesn't shift
+  // when the heavy heatmap query finally resolves.
+  const bounds = (() => {
+    const src = (deploymentLocations || []).filter((d) => d.latitude != null && d.longitude != null)
+    if (src.length === 0) return null
+    return src.reduce(
+      (b, d) => [
+        [Math.min(b[0][0], +d.latitude), Math.min(b[0][1], +d.longitude)],
+        [Math.max(b[1][0], +d.latitude), Math.max(b[1][1], +d.longitude)]
+      ],
+      [
+        [90, 180],
+        [-90, -180]
+      ]
+    )
+  })()
 
   // Options for bounds
   const boundsOptions = {
     padding: [20, 20]
+  }
+
+  // Skeleton mode: uniform gray dots at deployment coords while heatmap
+  // loads. Dedup by (lat, lng) so co-located deployments share a single
+  // marker — matches how the final pies are grouped.
+  const skeletonMode = !heatmapData
+  const skeletonPoints = (() => {
+    if (!skeletonMode || !deploymentLocations) return []
+    const seen = new Map()
+    for (const d of deploymentLocations) {
+      if (d.latitude == null || d.longitude == null) continue
+      const key = `${d.latitude},${d.longitude}`
+      if (!seen.has(key)) {
+        seen.set(key, { lat: parseFloat(d.latitude), lng: parseFloat(d.longitude) })
+      }
+    }
+    return Array.from(seen.values())
+  })()
+
+  // Small uniform gray dot with a soft pulse so the user reads the map as
+  // "loading" rather than "done, just sparse". Pulse comes from the
+  // `activity-skeleton-marker` keyframes injected at module load.
+  const skeletonDotIcon = useMemo(() => {
+    const size = 14
+    return L.divIcon({
+      html: `<div class="activity-skeleton-marker" style="width:${size}px;height:${size}px;background:#9ca3af;border:2px solid white;border-radius:50%;box-shadow:0 1px 2px rgba(0,0,0,0.2);"></div>`,
+      className: '',
+      iconSize: [size, size],
+      iconAnchor: [size / 2, size / 2]
+    })
+  }, [])
+
+  // Cluster icon matches the dots: same gray, same pulse, no count label
+  // (the count would overstate certainty before species data arrives).
+  // Size still scales with child count so dense areas read as bigger.
+  const createSkeletonClusterIcon = (cluster) => {
+    const count = cluster.getChildCount()
+    const size = count >= 50 ? 40 : count >= 10 ? 34 : 28
+    cluster.unbindTooltip()
+    cluster.bindTooltip('Loading species data…', { direction: 'top', offset: [0, -10] })
+    return L.divIcon({
+      html: `<div class="activity-skeleton-cluster" style="width:${size}px;height:${size}px;background:#9ca3af;border-radius:50%;border:2px solid white;box-shadow:0 1px 2px rgba(0,0,0,0.2);"></div>`,
+      className: '',
+      iconSize: L.point(size, size, true)
+    })
   }
 
   return (
@@ -260,56 +350,76 @@ const SpeciesMap = ({ heatmapData, selectedSpecies, palette, geoKey, studyId }) 
         </LayersControl.BaseLayer>
 
         <LayersControl.Overlay name="Species Distribution" checked={true}>
-          <MarkerClusterGroup
-            key={geoKey}
-            chunkedLoading
-            showCoverageOnHover={false}
-            spiderfyOnEveryZoom={false}
-            maxClusterRadius={100}
-            animateAddingMarkers={false}
-            iconCreateFunction={(cluster) => {
-              // Get all markers in this cluster
-              const markers = cluster.getAllChildMarkers()
+          {skeletonMode ? (
+            <MarkerClusterGroup
+              key={`skeleton:${skeletonPoints.length}`}
+              chunkedLoading
+              showCoverageOnHover={false}
+              spiderfyOnEveryZoom={false}
+              maxClusterRadius={100}
+              animateAddingMarkers={false}
+              iconCreateFunction={createSkeletonClusterIcon}
+            >
+              {skeletonPoints.map((point, index) => (
+                <Marker
+                  key={`skeleton-${index}`}
+                  position={[point.lat, point.lng]}
+                  icon={skeletonDotIcon}
+                />
+              ))}
+            </MarkerClusterGroup>
+          ) : (
+            <MarkerClusterGroup
+              key={`pies:${geoKey}`}
+              chunkedLoading
+              showCoverageOnHover={false}
+              spiderfyOnEveryZoom={false}
+              maxClusterRadius={100}
+              animateAddingMarkers={false}
+              iconCreateFunction={(cluster) => {
+                // Get all markers in this cluster
+                const markers = cluster.getAllChildMarkers()
 
-              // Combine counts from all markers
-              const combinedCounts = {}
+                // Combine counts from all markers
+                const combinedCounts = {}
 
-              // First, initialize counts for all selected species to ensure consistent ordering
-              selectedSpecies.forEach((species) => {
-                combinedCounts[species.scientificName] = 0
-              })
-
-              // Then add actual counts from markers
-              markers.forEach((marker) => {
-                Object.entries(marker.options.counts).forEach(([species, count]) => {
-                  // Only add species that are in our selectedSpecies list
-                  if (selectedSpecies.some((s) => s.scientificName === species)) {
-                    combinedCounts[species] += count
-                  }
+                // First, initialize counts for all selected species to ensure consistent ordering
+                selectedSpecies.forEach((species) => {
+                  combinedCounts[species.scientificName] = 0
                 })
-              })
 
-              // Filter out species with zero counts to avoid empty slices
-              const filteredCounts = Object.fromEntries(
-                Object.entries(combinedCounts).filter(([, count]) => count > 0)
-              )
+                // Then add actual counts from markers
+                markers.forEach((marker) => {
+                  Object.entries(marker.options.counts).forEach(([species, count]) => {
+                    // Only add species that are in our selectedSpecies list
+                    if (selectedSpecies.some((s) => s.scientificName === species)) {
+                      combinedCounts[species] += count
+                    }
+                  })
+                })
 
-              // Bind tooltip to cluster
-              const tooltipHtml = createTooltipContent(filteredCounts)
-              cluster.unbindTooltip()
-              cluster.bindTooltip(tooltipHtml, {
-                direction: 'top',
-                offset: [0, -10],
-                className: 'species-map-tooltip'
-              })
+                // Filter out species with zero counts to avoid empty slices
+                const filteredCounts = Object.fromEntries(
+                  Object.entries(combinedCounts).filter(([, count]) => count > 0)
+                )
 
-              return createPieChartIcon(filteredCounts)
-            }}
-          >
-            {locationPoints.map((point, index) => (
-              <PieChartMarker key={index} point={point} icon={createPieChartIcon(point.counts)} />
-            ))}
-          </MarkerClusterGroup>
+                // Bind tooltip to cluster
+                const tooltipHtml = createTooltipContent(filteredCounts)
+                cluster.unbindTooltip()
+                cluster.bindTooltip(tooltipHtml, {
+                  direction: 'top',
+                  offset: [0, -10],
+                  className: 'species-map-tooltip'
+                })
+
+                return createPieChartIcon(filteredCounts)
+              }}
+            >
+              {locationPoints.map((point, index) => (
+                <PieChartMarker key={index} point={point} icon={createPieChartIcon(point.counts)} />
+              ))}
+            </MarkerClusterGroup>
+          )}
         </LayersControl.Overlay>
 
         {/* Add a legend */}
@@ -343,11 +453,27 @@ export default function Activity({ studyData, studyId }) {
   const actualStudyId = studyId || id // Use passed studyId or from params
 
   const [selectedSpecies, setSelectedSpecies] = useState([])
+  const [speciesInitialized, setSpeciesInitialized] = useState(false)
   const [dateRange, setDateRange] = useState([null, null])
   const [fullExtent, setFullExtent] = useState([null, null])
   const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap } = useSequenceGap(actualStudyId)
+
+  // Lightweight deduped deployment-location query (shared cache with the
+  // Overview tab). Used to paint the skeleton map immediately while the
+  // heavy sequence-aware heatmap SQL runs in the worker.
+  const { data: deploymentLocations } = useQuery({
+    queryKey: ['deploymentLocations', actualStudyId],
+    queryFn: async () => {
+      const response = await window.api.getDeploymentLocations(actualStudyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!actualStudyId,
+    refetchInterval: importStatus?.isRunning ? 5000 : false,
+    staleTime: Infinity
+  })
 
   // Get taxonomic data from studyData
   const taxonomicData = studyData?.taxonomic || null
@@ -368,12 +494,17 @@ export default function Activity({ studyData, studyId }) {
   })
 
   // Initialize selectedSpecies when speciesDistributionData loads
-  // Excludes humans/vehicles from default selection
+  // Excludes humans/vehicles from default selection.
+  // `speciesInitialized` gates the bottom-row mount so TimelineChart /
+  // DailyActivityRadar / CircularTimeFilter don't fire their sequence-aware
+  // queries twice (once with [] species, once with the top-2) on large
+  // studies. Mirrors the same guard in media.jsx (PR b5c4dca).
   useEffect(() => {
-    if (speciesDistributionData && selectedSpecies.length === 0) {
+    if (speciesDistributionData && !speciesInitialized) {
       setSelectedSpecies(getTopNonHumanSpecies(speciesDistributionData, 2))
+      setSpeciesInitialized(true)
     }
-  }, [speciesDistributionData, selectedSpecies.length])
+  }, [speciesDistributionData, speciesInitialized])
 
   // Memoize speciesNames to avoid unnecessary re-renders
   const speciesNames = useMemo(
@@ -435,9 +566,24 @@ export default function Activity({ studyData, studyId }) {
     return startMatch && endMatch
   }, [hasTemporalData, fullExtent, dateRange])
 
-  // Fetch sequence-aware heatmap data
-  // Enable when: we have study + species AND (no temporal data OR valid date range)
-  // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)
+  // Fetch sequence-aware heatmap data.
+  //
+  // The `enabled` gate defers the fetch until every queryKey input has
+  // settled, so the expensive (~11s on gmu8_leuven) heatmap query fires
+  // exactly once instead of twice:
+  //
+  //   1. sequenceGap undefined → skip (useSequenceGap still resolving).
+  //   2. timeseriesQueryData undefined → skip. Without this, the heatmap
+  //      would fire once with dateRange=[null,null] (because isFullRange
+  //      defaults to true when hasTemporalData=false), and then again
+  //      when the timeseries useEffect fills in dateRange — two 11s
+  //      hits of the worker for the same semantic query.
+  //   3. Datasets WITH temporal data: require dateRange to be populated
+  //      (via the useEffect that runs one tick after timeseries resolves).
+  //   4. Datasets WITHOUT temporal data: dateRange stays [null, null] and
+  //      we fire with isFullRange=true (includeNullTimestamps semantics).
+  //
+  // Mirrors media.jsx's b5c4dca "defer mounting until inputs stable" guard.
   const { data: heatmapData, isLoading: isHeatmapLoading } = useQuery({
     queryKey: [
       'sequenceAwareHeatmap',
@@ -466,8 +612,9 @@ export default function Activity({ studyData, studyId }) {
     enabled:
       !!actualStudyId &&
       speciesNames.length > 0 &&
-      (isFullRange || (!!dateRange[0] && !!dateRange[1])) &&
-      sequenceGap !== undefined,
+      sequenceGap !== undefined &&
+      timeseriesQueryData !== undefined &&
+      (!hasTemporalData || (!!dateRange[0] && !!dateRange[1])),
     placeholderData: (prev) => prev,
     staleTime: Infinity
   })
@@ -534,17 +681,26 @@ export default function Activity({ studyData, studyId }) {
           <div className="flex flex-row gap-4 flex-1 min-h-0">
             {/* Species Distribution - left side */}
 
-            {/* Map - right side */}
+            {/* Map - right side.
+                Render SpeciesMap as soon as `deploymentLocations` arrives
+                (~ms), so the user sees clustered gray dots at the camera
+                locations while the heavy heatmap query resolves. The map
+                upgrades to pies when heatmapData lands. PlaceholderMap only
+                shows when we have deployment locations but the heatmap
+                explicitly came back empty. */}
             <div className="h-full flex-1">
-              {heatmapStatus === 'hasData' && (
-                <SpeciesMap
-                  heatmapData={heatmapData}
-                  selectedSpecies={selectedSpecies}
-                  palette={palette}
-                  studyId={actualStudyId}
-                  geoKey={geoKey}
-                />
-              )}
+              {deploymentLocations &&
+                deploymentLocations.length > 0 &&
+                heatmapStatus !== 'noData' && (
+                  <SpeciesMap
+                    deploymentLocations={deploymentLocations}
+                    heatmapData={heatmapStatus === 'hasData' ? heatmapData : null}
+                    selectedSpecies={selectedSpecies}
+                    palette={palette}
+                    studyId={actualStudyId}
+                    geoKey={geoKey}
+                  />
+                )}
               {heatmapStatus === 'noData' && !isHeatmapLoading && (
                 <PlaceholderMap
                   title="No Species Location Data"
@@ -570,31 +726,41 @@ export default function Activity({ studyData, studyId }) {
             </div>
           </div>
 
-          {/* Second row - fixed height with timeline and clock */}
-          <div className="w-full flex h-[130px] flex-shrink-0 gap-3">
-            <div className="w-[140px] h-full rounded border border-gray-200 flex items-center justify-center relative">
-              <DailyActivityRadar
-                activityData={dailyActivityData}
-                selectedSpecies={selectedSpecies}
-                palette={palette}
-              />
-              <div className="absolute w-full h-full flex items-center justify-center">
-                <CircularTimeFilter
-                  onChange={handleTimeRangeChange}
-                  startTime={timeRange.start}
-                  endTime={timeRange.end}
-                />
+          {/* Second row — always reserves 130px of layout space so the map
+              row above doesn't snap smaller when the filters finally mount.
+              The borders + children only render once inputs have settled
+              (speciesInitialized && sequenceGap !== undefined), which
+              prevents the empty bordered flash and the double-fire of
+              timeseries / daily-activity as queryKey inputs stabilize
+              (mirrors media.jsx's b5c4dca guard). */}
+          <div className="w-full h-[130px] flex-shrink-0">
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-full gap-3">
+                <div className="w-[140px] h-full rounded border border-gray-200 flex items-center justify-center relative">
+                  <DailyActivityRadar
+                    activityData={dailyActivityData}
+                    selectedSpecies={selectedSpecies}
+                    palette={palette}
+                  />
+                  <div className="absolute w-full h-full flex items-center justify-center">
+                    <CircularTimeFilter
+                      onChange={handleTimeRangeChange}
+                      startTime={timeRange.start}
+                      endTime={timeRange.end}
+                    />
+                  </div>
+                </div>
+                <div className="flex-grow rounded px-2 border border-gray-200">
+                  <TimelineChart
+                    timeseriesData={timeseriesData}
+                    selectedSpecies={selectedSpecies}
+                    dateRange={dateRange}
+                    setDateRange={setDateRange}
+                    palette={palette}
+                  />
+                </div>
               </div>
-            </div>
-            <div className="flex-grow rounded px-2 border border-gray-200">
-              <TimelineChart
-                timeseriesData={timeseriesData}
-                selectedSpecies={selectedSpecies}
-                dateRange={dateRange}
-                setDateRange={setDateRange}
-                palette={palette}
-              />
-            </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Mirrors what #427 / #431 / #432 did for the overview, media, and deployments tabs. On gmu8_leuven (2.7M obs, 2,704 deployments, gap=300s) the Activity tab used to freeze the map area for ~19s on first open, fire the heatmap worker twice, and snap the bottom row smaller when the filters finally mounted.

Three changes in one commit:

### 1. Progressive map
\`SpeciesMap\` now takes a \`deploymentLocations\` prop (served by the lightweight \`getDeploymentLocations\` query the Overview tab already uses — shared cache, ~3ms) and renders **uniform gray pulsing dots** at the deployment coords while the heavy heatmap SQL runs in the worker. When the heatmap resolves, the cluster group swaps to the pie-chart markers. The \`MapContainer\` stays mounted across the swap so zoom / pan / layer selection survive.

- Bounds derive from \`deploymentLocations\` (not heatmap), so the viewport doesn't shift when pies arrive.
- Cluster skeleton icons have **no count label** during loading (would overstate certainty before species data arrives) but still size-scale with child count so dense areas read as bigger.
- 1.6s ease-in-out opacity pulse (0.55↔1) on both dots and clusters signals "loading" rather than "done, just sparse".
- Map first paint: **~19s → ~50ms**.

### 2. SQL fast-path for the sequence-aware heatmap
New \`getSequenceAwareHeatmapSQL\` in \`queries/species.js\`, three paths keyed on \`gapSeconds\`:

- **Per-media** (null / non-positive): trivial \`COUNT\` grouped by (species, lat, lng).
- **EventID** (gap === 0): CTE with \`MAX\`-per-event, SUM per (species, lat, lng). \`event_key = COALESCE(NULLIF(eventID, ''), 'solo:' || mediaID)\`. Null-ts media UNION'd in via \`null_totals\`.
- **Time-gap** (gap > 0): window functions — \`LAG\` + cumulative \`SUM\` assigns \`seq_id\`, partitioned by **(lat, lng)** across all selected species so an intervening obs at a co-located deployment still breaks a sequence the way the JS path does. \`MAX\` per (species, seq, lat, lng), \`SUM\` per (species, lat, lng).

Pivots to the UI's \`{sp: [{lat, lng, count, locationName}]}\` shape via a new \`pivotPreAggregatedHeatmap\` helper. Date range, hour-of-day, and \`includeNullTimestamps\` filters all push into the SQL.

Validated against 19 local studies (7k–2.9M obs):
- Per-media + eventID paths: **100% byte-exact** vs JS.
- Window path: 100% exact on 17/19, max off-by-2 on 2 studies (tied-timestamp edge cases).

End-to-end on gmu8_leuven:
- SQL: 16.7s → 8.5s
- JSON payload: 417MB → 78KB (~5,300×)
- JS aggregation on worker: 1.7s → 0

### 3. Bottom-row guards (same pattern as media.jsx #b5c4dca)
- \`speciesInitialized\` state gates the timeline + clock + radar wrapper on \`speciesInitialized && sequenceGap !== undefined\` so the downstream \`timeseries\` / \`daily-activity\` queries don't fire twice as species and gap settle.
- The wrapper **always reserves its 130px** of layout space so the map above doesn't snap smaller when the filters finally mount.
- Heatmap \`useQuery\` also gates on \`timeseriesQueryData !== undefined\` and dateRange being populated from the timeseries extent — previously the heatmap fired once with \`dateRange=[null, null]\` and again after the useEffect settled it, burning two 11s worker invocations for the same semantic result.

## Test plan
- [x] Open a fresh Activity tab on gmu8_leuven: gray pulsing dots paint almost immediately, pies swap in once the heatmap resolves, no layout shift when the bottom filters appear
- [x] Map zoom / pan state survives the skeleton → pies swap
- [x] Only one \`sequence-aware heatmap\` log line per tab open, not two
- [x] Check log timings for \`[SQL-agg] sequence-aware heatmap\` on gmu8_leuven — should be ~8-11s vs previous ~17s
- [x] Change the species selection — heatmap refetches once with the new queryKey, map keeps its viewport
- [x] Drag the timeline brush — commit-on-release still works (no refetch per mousemove)
- [x] Switch to a small study (gap=0, eventID-based): pies render correctly
- [x] Switch to a study without temporal data: map renders, bottom row gate settles without spinning forever
- [x] \`npm test\` passes