### PR TITLE
chore: release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to Biowatch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-04-28
+
+### Added
+
+- Species tooltip with blurb, IUCN Red List badge, Wikipedia fallback image, and Wikipedia link
+- Species-info module with GBIF and Wikipedia response parsers, species-candidate pre-filter, pure synchronous resolver, and build script CLI; ships initial `data.json` covering 2054 species
+- Inline IUCN Red List badge in species list rows
+- "Show more" toggle on tooltip blurb (default 5 lines)
+- Species hover tooltip shown whenever any image (study or Wikipedia) is available
+
+### Changed
+
+- Species hover migrated from Tooltip to HoverCard
+- Wikipedia fallback images letterboxed on black to avoid awkward crops
+- Inline IUCN badge aligned to the right of the row, left of the count
+
+### Fixed
+
+- HoverCard closes on scroll instead of riding with the row
+- Inline IUCN badge hidden on media and activity sidebars
+- Species-info build flushes progress every 25 entries and on SIGTERM; atomic `data.json` writes (temp + rename) so SIGKILL can't corrupt the file
+- Species-info rejects unknown IUCN codes, maps verbose IUCN strings to codes, and hardens rate-limit handling
+- Wikipedia thumbnail cache shared app-wide instead of per-study
+
 ## [1.8.0] - 2026-04-27
 
 ### Added
@@ -371,6 +395,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Activity heatmaps
 - Overview statistics
 
+[1.8.1]: https://github.com/earthtoolsmaker/biowatch/compare/v1.8.0...v1.8.1
 [1.8.0]: https://github.com/earthtoolsmaker/biowatch/compare/v1.7.2...v1.8.0
 [1.7.2]: https://github.com/earthtoolsmaker/biowatch/compare/v1.7.1...v1.7.2
 [1.7.1]: https://github.com/earthtoolsmaker/biowatch/compare/v1.7.0...v1.7.1

--- a/docs/development.md
+++ b/docs/development.md
@@ -384,30 +384,43 @@ Biowatch uses an automated CI/CD pipeline that builds and publishes releases for
 
 ### Step-by-Step Release
 
-1. **Update version** in `package.json`:
+Releases go through a pull request rather than a direct push to `main`, so the version bump gets the same review and CI checks as any other change.
+
+1. **Create a release branch** off `main`:
+   ```bash
+   git checkout main
+   git pull
+   git checkout -b <yourname>/release-new-version-1.5.0
+   ```
+
+2. **Update version** in `package.json`:
    ```json
    "version": "1.5.0"
    ```
 
-2. **Update `CHANGELOG.md`** with the new version's changes:
+3. **Update `CHANGELOG.md`** with the new version's changes:
    - Add a new section for the version with the release date
    - Document all notable changes under: Added, Changed, Fixed, Removed
    - Update the comparison links at the bottom of the file
 
-3. **Commit the version bump**:
+4. **Commit and push the release branch**:
    ```bash
    git add package.json CHANGELOG.md
    git commit -m "chore: bump version to 1.5.0"
-   git push origin main
+   git push -u origin HEAD
    ```
 
-4. **Create and push a version tag**:
+5. **Open a pull request** targeting `main` and get it reviewed/merged. Do **not** push the bump commit straight to `main` — the tag in step 6 must point at the merge commit on `main`.
+
+6. **Create and push a version tag** from `main` after the PR merges:
    ```bash
+   git checkout main
+   git pull
    git tag v1.5.0
    git push origin v1.5.0
    ```
 
-5. **Verify CI triggered**: Check [GitHub Actions](https://github.com/earthtoolsmaker/biowatch/actions) to ensure both workflows started.
+7. **Verify CI triggered**: Check [GitHub Actions](https://github.com/earthtoolsmaker/biowatch/actions) to ensure both workflows started.
 
 ### CI/CD Workflows
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biowatch",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Analyse and visualise camera trap datasets",
   "main": "./out/main/index.js",
   "author": "earthtoolsmaker.org",


### PR DESCRIPTION
## Summary

Release v1.8.1. Bumps `package.json` to 1.8.1 and adds the matching `CHANGELOG.md` entry. Also updates the documented release process to use a PR instead of pushing the bump straight to `main`.

Highlights since v1.8.0 (full list in CHANGELOG):
- Species tooltip with blurb, IUCN Red List badge, Wikipedia fallback image, and Wikipedia link
- New species-info module (GBIF + Wikipedia parsers, candidate pre-filter, sync resolver, build script CLI) shipping initial `data.json` for 2054 species
- Inline IUCN Red List badge in species rows; species hover migrated to HoverCard
- Hardening: atomic `data.json` writes, periodic flushes, IUCN code mapping, shared Wikipedia thumbnail cache

## Release steps after merge

1. `git checkout main && git pull`
2. `git tag v1.8.1 && git push origin v1.8.1`
3. Verify Build/Release and Create Release workflows both run.

## Test plan

- [x] CI green on this PR
- [ ] After merge: tag `v1.8.1` triggers both release workflows
- [ ] GitHub Release published with Win/macOS/Linux artifacts