### PR TITLE
style(species-list): edge-to-edge light blue hover on species rows

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -296,7 +296,7 @@ function SpeciesRow({
     >
       <HoverCard.Trigger asChild>
         <div
-          className="cursor-pointer hover:bg-gray-50 transition-colors rounded py-1"
+          className="cursor-pointer hover:bg-blue-50 transition-colors py-2 -mx-3 px-3 first:pt-3 last:pb-3"
           onClick={() => onRowClick(species)}
         >
           <div className="flex justify-between mb-1 items-center gap-2">
@@ -396,10 +396,10 @@ function SpeciesDistribution({ data, taxonomicData, studyId }) {
 
   return (
     <div
-      className="w-1/2 bg-white rounded border border-gray-200 p-3 overflow-y-auto relative"
+      className="w-1/2 bg-white rounded border border-gray-200 px-3 overflow-y-auto relative"
       onScroll={handleScroll}
     >
-      <div className="space-y-2">
+      <div>
         {sortSpeciesHumansLast(data).map((species) => {
           const storedCommonName = scientificToCommonMap[species.scientificName] || null
           return (

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -46,7 +46,10 @@ function SpeciesRow({
   const enableTooltip = studyId && !!tooltipImageData
 
   const rowContent = (
-    <div className="cursor-pointer group" onClick={() => onToggle(species)}>
+    <div
+      className="cursor-pointer group hover:bg-blue-50 transition-colors py-2 -mx-3 px-3 first:pt-3 last:pb-3"
+      onClick={() => onToggle(species)}
+    >
       <div className="flex justify-between mb-1 items-center cursor-pointer gap-2">
         <div className="flex items-center cursor-pointer min-w-0 flex-1">
           <div
@@ -104,7 +107,7 @@ function SpeciesRow({
     )
   }
 
-  return <div key={species.scientificName || index}>{rowContent}</div>
+  return rowContent
 }
 
 function SpeciesDistribution({
@@ -200,8 +203,8 @@ function SpeciesDistribution({
         <span className="text-xs text-gray-400">({speciesCount})</span>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-3 myscroll" onScroll={handleScroll}>
-        <div className="space-y-4">
+      <div className="flex-1 overflow-y-auto px-3 myscroll" onScroll={handleScroll}>
+        <div>
           {sortSpeciesHumansLast(displayData).map((species, index) => {
             const isBlankEntry = isBlank(species.scientificName)
             const storedCommonName = isBlankEntry


### PR DESCRIPTION
## Summary
- Replace gray hover with `bg-blue-50` and extend the hover band edge-to-edge across the species list card by negating the parent's horizontal padding on each row.
- Move vertical spacing from the list wrapper into each row (`py-2` + `first:pt-3 last:pb-3`) so the gap between rows is part of the hover area while the top and bottom of the card keep some breathing room.
- Applies to the species list on the overview, activity, and media tabs (the activity/media list lives in the shared `speciesDistribution.jsx`).

## Test plan
- [x] Open a study and hover species rows on the overview tab — light blue band spans full card width with no gaps between rows.
- [x] Same on the activity tab species sidebar.
- [x] Same on the media tab species sidebar.
- [x] First and last rows still have visible top/bottom breathing room before the card edge / header border.