### PR TITLE
fix(deployments): cap row height and truncate long names

### DIFF
--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -487,10 +487,10 @@ const EditableLocationName = memo(function EditableLocationName({
   }
 
   return (
-    <div className="group flex items-center gap-1">
+    <div className="group flex items-center gap-1 min-w-0">
       <span
         onClick={startEditing}
-        className={`cursor-pointer text-sm truncate ${
+        className={`cursor-pointer text-sm truncate min-w-0 ${
           isSelected ? 'font-semibold text-blue-700' : 'text-gray-700'
         }`}
         title={`${displayName} (click to rename)`}
@@ -499,7 +499,7 @@ const EditableLocationName = memo(function EditableLocationName({
       </span>
       <button
         onClick={startEditing}
-        className="p-0.5 opacity-0 group-hover:opacity-100 hover:bg-gray-200 rounded text-gray-500 transition-opacity"
+        className="p-0.5 opacity-0 group-hover:opacity-100 hover:bg-gray-200 rounded text-gray-500 transition-opacity flex-shrink-0"
         title="Rename"
       >
         <Pencil size={12} />
@@ -605,7 +605,7 @@ const DeploymentRow = memo(function DeploymentRow({
           <div
             key={period.start}
             title={`${period.count} observations`}
-            className="flex items-center justify-center aspect-square w-[5%]"
+            className="flex items-center justify-center h-[25px] w-[5%]"
           >
             <div
               className="rounded-full bg-[#77b7ff] aspect-square max-w-[25px]"
@@ -678,7 +678,7 @@ const LocationGroupHeader = memo(function LocationGroupHeader({
           <div
             key={period.start}
             title={`${period.count} observations (aggregated)`}
-            className="flex items-center justify-center aspect-square w-[5%]"
+            className="flex items-center justify-center h-[25px] w-[5%]"
           >
             <div
               className="rounded-full bg-[#77b7ff] aspect-square max-w-[25px]"


### PR DESCRIPTION
## Summary
- Cap deployment row height by replacing `aspect-square` on timeline cells with a fixed `h-[25px]`, so rows no longer expand on wider screens.
- Truncate long location names/IDs in `EditableLocationName` via `min-w-0` + `flex-shrink-0`, so they no longer overflow into the timeline column.

## Test plan
- [x] Open the Deployments tab on a wide window — rows stay at a fixed compact height regardless of width.
- [x] Open a study with long UUID-style location IDs — names truncate with ellipsis and the timeline dots stay aligned in their column.
- [x] Hover a row — pencil rename icon still appears on the right and is not pushed off.
- [x] Click to rename a deployment — inline edit input still works and saves correctly.