### PR TITLE
feat(deployments): resizable map/list split with persisted layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biowatch",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biowatch",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",
@@ -36,6 +36,7 @@
         "react-error-boundary": "^6.0.2",
         "react-leaflet": "^5.0.0",
         "react-leaflet-cluster": "^4.0.0",
+        "react-resizable-panels": "^3.0.6",
         "react-router": "^7.11.0",
         "recharts": "^2.15.3",
         "sonner": "^2.0.7",
@@ -11362,6 +11363,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-3.0.6.tgz",
+      "integrity": "sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-error-boundary": "^6.0.2",
     "react-leaflet": "^5.0.0",
     "react-leaflet-cluster": "^4.0.0",
+    "react-resizable-panels": "^3.0.6",
     "react-router": "^7.11.0",
     "recharts": "^2.15.3",
     "sonner": "^2.0.7",

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -5,6 +5,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactDOMServer from 'react-dom/server'
 import { LayersControl, MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useImportStatus } from '@renderer/hooks/import'
@@ -147,6 +148,20 @@ function MapEventHandler({ isPlaceMode, onMapClick }) {
       }
     }
   })
+  return null
+}
+
+// Component that calls map.invalidateSize() whenever the map's container resizes.
+// Required when the map sits inside a resizable panel — Leaflet caches its size
+// and won't repaint tiles correctly without this.
+function InvalidateOnResize() {
+  const map = useMap()
+  useEffect(() => {
+    const container = map.getContainer()
+    const observer = new ResizeObserver(() => map.invalidateSize())
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [map])
   return null
 }
 
@@ -318,6 +333,9 @@ function LocationMap({
           </LayersControl.BaseLayer>
         </LayersControl>
         <LayerChangeHandler onLayerChange={setSelectedLayer} />
+
+        {/* Repaint Leaflet whenever the panel housing the map is resized */}
+        <InvalidateOnResize />
 
         {/* Fly to selected location when it changes */}
         <FlyToSelected selectedLocation={selectedLocation} />
@@ -1216,42 +1234,45 @@ export default function Deployments({ studyId }) {
 
   return (
     <div
-      className={`flex flex-col px-4 h-full gap-4 overflow-hidden ${isPlaceMode ? 'place-mode-active' : ''}`}
+      className={`flex flex-col px-4 h-full overflow-hidden ${isPlaceMode ? 'place-mode-active' : ''}`}
     >
-      <div className="h-96">
-        {deploymentsList && (
-          <LocationMap
-            locations={deploymentsList}
-            selectedLocation={selectedLocation}
-            setSelectedLocation={setSelectedLocation}
-            onNewLatitude={onNewLatitude}
-            onNewLongitude={onNewLongitude}
-            isPlaceMode={isPlaceMode}
-            onPlaceLocation={handlePlaceLocation}
-            onExitPlaceMode={handleExitPlaceMode}
-            onExpandGroup={handleExpandGroup}
-            studyId={studyId}
-          />
-        )}
-      </div>
-      <div className="flex-1 min-h-0 flex flex-col">
-        {isActivityLoading ? (
-          <SkeletonDeploymentsList itemCount={6} />
-        ) : activity ? (
-          <LocationsList
-            activity={activity}
-            selectedLocation={selectedLocation}
-            setSelectedLocation={setSelectedLocation}
-            onNewLatitude={onNewLatitude}
-            onNewLongitude={onNewLongitude}
-            onEnterPlaceMode={handleEnterPlaceMode}
-            onRenameLocation={onRenameLocation}
-            isPlaceMode={isPlaceMode}
-            groupToExpand={groupToExpand}
-            onGroupExpanded={handleGroupExpanded}
-          />
-        ) : null}
-      </div>
+      <PanelGroup direction="vertical" autoSaveId="deployments-layout">
+        <Panel defaultSize={55} minSize={20} className="flex flex-col">
+          {deploymentsList && (
+            <LocationMap
+              locations={deploymentsList}
+              selectedLocation={selectedLocation}
+              setSelectedLocation={setSelectedLocation}
+              onNewLatitude={onNewLatitude}
+              onNewLongitude={onNewLongitude}
+              isPlaceMode={isPlaceMode}
+              onPlaceLocation={handlePlaceLocation}
+              onExitPlaceMode={handleExitPlaceMode}
+              onExpandGroup={handleExpandGroup}
+              studyId={studyId}
+            />
+          )}
+        </Panel>
+        <PanelResizeHandle className="h-2 my-1 rounded bg-gray-200 hover:bg-blue-300 data-[resize-handle-state=drag]:bg-blue-400 cursor-row-resize transition-colors" />
+        <Panel defaultSize={45} minSize={20} className="flex flex-col">
+          {isActivityLoading ? (
+            <SkeletonDeploymentsList itemCount={6} />
+          ) : activity ? (
+            <LocationsList
+              activity={activity}
+              selectedLocation={selectedLocation}
+              setSelectedLocation={setSelectedLocation}
+              onNewLatitude={onNewLatitude}
+              onNewLongitude={onNewLongitude}
+              onEnterPlaceMode={handleEnterPlaceMode}
+              onRenameLocation={onRenameLocation}
+              isPlaceMode={isPlaceMode}
+              groupToExpand={groupToExpand}
+              onGroupExpanded={handleGroupExpanded}
+            />
+          ) : null}
+        </Panel>
+      </PanelGroup>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replace the fixed `h-96` map + `flex-1` list layout with a vertical `PanelGroup` from `react-resizable-panels`
- `autoSaveId="deployments-layout"` persists the user's chosen split across sessions
- Default split favors the map (55/45) — slightly taller than the previous `h-96`
- New `InvalidateOnResize` helper inside `LocationMap` calls `map.invalidateSize()` via a `ResizeObserver` so Leaflet repaints correctly while the divider is dragged
- Pinned `react-resizable-panels` to `^3.0.6`; v4 (released recently) renamed all exports

## Test plan
- [ ] `npm run dev` — open a study, go to the Deployments tab
- [ ] Drag the bar between map and list; map tiles repaint smoothly without grey gaps
- [ ] Resize, reload the app, confirm the split is restored
- [ ] Confirm the list still scrolls and the timeline header stays sticky
- [ ] Confirm `npm run lint` and `npm run format:check` pass