### PR TITLE
Minimalistic study settings page

### DIFF
--- a/src/renderer/src/StudySettings.jsx
+++ b/src/renderer/src/StudySettings.jsx
@@ -63,12 +63,7 @@ export default function StudySettings({ studyId, studyName }) {
               <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent" />
             </div>
           ) : (
-            <SequenceGapSlider
-              value={sequenceGap}
-              onChange={setSequenceGap}
-              variant="full"
-              showDescription={true}
-            />
+            <SequenceGapSlider value={sequenceGap} onChange={setSequenceGap} variant="full" />
           )}
         </section>
 

--- a/src/renderer/src/StudySettings.jsx
+++ b/src/renderer/src/StudySettings.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Trash2, HelpCircle } from 'lucide-react'
+import { HelpCircle } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import DeleteStudyModal from './DeleteStudyModal'
 import Export from './export'
@@ -13,24 +13,21 @@ export default function StudySettings({ studyId, studyName }) {
   const handleDeleteStudy = async () => {
     try {
       await window.api.deleteStudyDatabase(studyId)
-      // The existing listener in base.jsx will handle navigation and query invalidation
-      // after receiving the 'study:delete' event
     } catch (error) {
       console.error('Failed to delete study:', error)
     }
   }
 
   return (
-    <div className="px-4">
-      {/* Sequence Grouping Section */}
-      <div className="border border-blue-200 rounded-lg mb-6">
-        <div className="px-4 py-3 bg-blue-50 border-b border-blue-200 rounded-t-lg">
-          <div className="flex items-center gap-2">
-            <h2 className="text-lg font-medium text-blue-800">Sequence Grouping</h2>
+    <div className="px-4 sm:px-6">
+      <div className="max-w-2xl mx-auto divide-y divide-gray-200">
+        <section className="py-6">
+          <div className="flex items-center gap-1.5 mb-1">
+            <h2 className="text-base font-medium text-gray-900">Sequence Grouping</h2>
             <Tooltip.Root>
               <Tooltip.Trigger asChild>
-                <button className="text-blue-400 hover:text-blue-600 transition-colors">
-                  <HelpCircle size={16} />
+                <button className="text-gray-400 hover:text-gray-600 transition-colors">
+                  <HelpCircle size={14} />
                 </button>
               </Tooltip.Trigger>
               <Tooltip.Portal>
@@ -58,46 +55,35 @@ export default function StudySettings({ studyId, studyName }) {
               </Tooltip.Portal>
             </Tooltip.Root>
           </div>
-        </div>
-        <div className="p-4">
+          <p className="text-sm text-gray-500 mb-4">
+            Group nearby photos and videos into sequences based on time gaps.
+          </p>
           {isLoadingSequenceGap ? (
             <div className="flex items-center justify-center py-4">
               <div className="animate-spin rounded-full h-5 w-5 border-2 border-blue-500 border-t-transparent" />
             </div>
           ) : (
-            <>
-              <SequenceGapSlider
-                value={sequenceGap}
-                onChange={setSequenceGap}
-                variant="full"
-                showDescription={true}
-              />
-              <p className="text-xs text-gray-500 mt-3">
-                Changes are saved automatically and apply across all views.
-              </p>
-            </>
+            <SequenceGapSlider
+              value={sequenceGap}
+              onChange={setSequenceGap}
+              variant="full"
+              showDescription={true}
+            />
           )}
-        </div>
-      </div>
+        </section>
 
-      {/* Export Section */}
-      <div className="border border-blue-200 rounded-lg mb-6">
-        <div className="px-4 py-3 bg-blue-50 border-b border-blue-200 rounded-t-lg">
-          <h2 className="text-lg font-medium text-blue-800">Export</h2>
-        </div>
-        <div className="p-4">
+        <section className="py-6">
+          <h2 className="text-base font-medium text-gray-900 mb-1">Export</h2>
+          <p className="text-sm text-gray-500 mb-4">
+            Export this study&apos;s data in standard formats.
+          </p>
           <Export studyId={studyId} />
-        </div>
-      </div>
+        </section>
 
-      <div className="border border-red-200 rounded-lg">
-        <div className="px-4 py-3 bg-red-50 border-b border-red-200 rounded-t-lg">
-          <h2 className="text-lg font-medium text-red-800">Danger Zone</h2>
-        </div>
-
-        <div className="p-4">
-          <div className="flex items-center justify-between">
-            <div>
+        <section className="py-6">
+          <h2 className="text-base font-medium text-red-700 mb-4">Danger Zone</h2>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div className="min-w-0">
               <h3 className="text-sm font-medium text-gray-900">Delete this study</h3>
               <p className="text-sm text-gray-500 mt-1">
                 Once deleted, all data associated with this study will be permanently removed.
@@ -105,13 +91,12 @@ export default function StudySettings({ studyId, studyName }) {
             </div>
             <button
               onClick={() => setIsDeleteModalOpen(true)}
-              className="cursor-pointer flex items-center gap-2 px-4 py-2 text-sm font-medium text-red-600 bg-white border border-red-300 rounded-md hover:bg-red-50 transition-colors"
+              className="cursor-pointer flex items-center justify-center px-4 py-2 text-sm font-medium text-red-600 bg-white border border-red-300 rounded-md hover:bg-red-50 transition-colors w-full sm:w-auto"
             >
-              <Trash2 size={16} />
-              Delete Study
+              Delete
             </button>
           </div>
-        </div>
+        </section>
       </div>
 
       <DeleteStudyModal

--- a/src/renderer/src/export.jsx
+++ b/src/renderer/src/export.jsx
@@ -4,7 +4,7 @@ import CamtrapDPExportModal from './CamtrapDPExportModal'
 import ImageDirectoriesExportModal from './ImageDirectoriesExportModal'
 import ExportProgressModal from './ExportProgressModal'
 
-function ExportButton({ onClick, children, className = '', disabled = false }) {
+function ExportRow({ icon: Icon, title, description, onClick, isFirst, isLast }) {
   const [isExporting, setIsExporting] = useState(false)
 
   const handleClick = async () => {
@@ -17,15 +17,28 @@ function ExportButton({ onClick, children, className = '', disabled = false }) {
   }
 
   return (
-    <button
-      onClick={handleClick}
-      disabled={isExporting || disabled}
-      className={`cursor-pointer transition-colors flex justify-center flex-row gap-2 items-center border border-gray-200 px-4 h-10 text-sm shadow-sm rounded-md hover:bg-gray-50 ${
-        isExporting || disabled ? 'opacity-70' : ''
-      } ${className}`}
+    <div
+      className={`flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 py-3 ${
+        isFirst ? 'pt-0' : ''
+      } ${isLast ? 'pb-0' : ''}`}
     >
-      {isExporting ? <span className="animate-pulse">Exporting...</span> : children}
-    </button>
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <Icon size={16} className="text-gray-500 shrink-0" />
+          <span className="text-sm font-medium text-gray-900">{title}</span>
+        </div>
+        <p className="text-sm text-gray-500 mt-1">{description}</p>
+      </div>
+      <button
+        onClick={handleClick}
+        disabled={isExporting}
+        className={`cursor-pointer transition-colors flex justify-center items-center gap-2 border border-gray-200 px-4 h-9 text-sm shadow-sm rounded-md hover:bg-gray-50 w-full sm:w-auto ${
+          isExporting ? 'opacity-70' : ''
+        }`}
+      >
+        {isExporting ? <span className="animate-pulse">Exporting...</span> : 'Export'}
+      </button>
+    </div>
   )
 }
 
@@ -36,7 +49,6 @@ export default function Export({ studyId }) {
   const [showProgressModal, setShowProgressModal] = useState(false)
   const [exportProgress, setExportProgress] = useState(null)
 
-  // Listen for export progress events
   useEffect(() => {
     const unsubscribe = window.api.onExportProgress((progress) => {
       setExportProgress(progress)
@@ -101,7 +113,6 @@ export default function Export({ studyId }) {
     setShowCamtrapDPModal(false)
     setExportStatus(null)
 
-    // Show progress modal only when including media (which triggers downloads)
     if (options.includeMedia) {
       setShowProgressModal(true)
       setExportProgress(null)
@@ -150,67 +161,44 @@ export default function Export({ studyId }) {
   }
 
   return (
-    <div className="flex h-full py-6 overflow-auto">
-      <div className="max-w-4xl w-full">
-        {/* Status Messages */}
-        {exportStatus && (
-          <div
-            className={`mb-6 p-4 rounded-lg ${
-              exportStatus.type === 'success'
-                ? 'bg-green-50 text-green-800 border border-green-200'
-                : 'bg-red-50 text-red-800 border border-red-200'
-            }`}
-          >
-            <div className="flex items-center justify-between">
-              <p className="text-sm">{exportStatus.message}</p>
-              {exportStatus.type === 'success' && exportStatus.exportPath && (
-                <button
-                  onClick={handleOpenExportFolder}
-                  className="cursor-pointer border border-green-400 ml-4 px-3 py-1 bg-green-100 hover:bg-green-200 text-green-800 rounded text-sm font-medium transition-colors"
-                >
-                  Open Folder
-                </button>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Export Methods Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* Image Directories Export Card */}
-          <div className="border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-2 mb-2">
-              <FolderTree size={20} className="text-gray-700" />
-              <h3 className="text-lg font-semibold">Media Directories</h3>
-            </div>
-            <p className="text-sm text-gray-600 mb-4">
-              Export media organized into directories by species. Each species will have its own
-              folder containing all identified media.
-            </p>
-            <div className="flex justify-start">
-              <ExportButton onClick={handleImageDirectoriesExport} className="">
-                Export Media Directories
-              </ExportButton>
-            </div>
-          </div>
-
-          {/* Camtrap DP Export Card */}
-          <div className="border border-gray-200 rounded-lg p-6 shadow-sm hover:shadow-md transition-shadow">
-            <div className="flex items-center gap-2 mb-2">
-              <Package size={20} className="text-gray-700" />
-              <h3 className="text-lg font-semibold">Camtrap DP</h3>
-            </div>
-            <p className="text-sm text-gray-600 mb-4">
-              Export as a Camera Trap Data Package, a standardized format compatible with GBIF and
-              other biodiversity platforms.
-            </p>
-            <div className="flex justify-start">
-              <ExportButton onClick={handleCamtrapDPExport} className="">
-                Export Camtrap DP
-              </ExportButton>
-            </div>
+    <>
+      {exportStatus && (
+        <div
+          className={`mb-4 p-3 rounded-md text-sm ${
+            exportStatus.type === 'success'
+              ? 'bg-green-50 text-green-800 border border-green-200'
+              : 'bg-red-50 text-red-800 border border-red-200'
+          }`}
+        >
+          <div className="flex items-center justify-between gap-3">
+            <p>{exportStatus.message}</p>
+            {exportStatus.type === 'success' && exportStatus.exportPath && (
+              <button
+                onClick={handleOpenExportFolder}
+                className="cursor-pointer border border-green-400 px-3 py-1 bg-green-100 hover:bg-green-200 text-green-800 rounded text-xs font-medium transition-colors whitespace-nowrap"
+              >
+                Open Folder
+              </button>
+            )}
           </div>
         </div>
+      )}
+
+      <div className="divide-y divide-gray-100">
+        <ExportRow
+          icon={FolderTree}
+          title="Media Directories"
+          description="Media organized into folders by species."
+          onClick={handleImageDirectoriesExport}
+          isFirst
+        />
+        <ExportRow
+          icon={Package}
+          title="Camtrap DP"
+          description="Camera Trap Data Package — GBIF compatible."
+          onClick={handleCamtrapDPExport}
+          isLast
+        />
       </div>
 
       <CamtrapDPExportModal
@@ -232,6 +220,6 @@ export default function Export({ studyId }) {
         onCancel={handleCancelExport}
         progress={exportProgress}
       />
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Replace blue/red colored card sections with a rule-divided layout (`max-w-2xl`, `divide-y`); no card wrappers, no tinted headers — consistent with the rest of the study tabs.
- Convert the Export section from two side-by-side cards to a compact row list. Buttons sit on the right at ≥640px and stack full-width below the description on narrower screens.
- Simplify the Delete action — drop the trash icon, shorten "Delete Study" to "Delete".
- Drop the redundant slider description in Sequence Grouping (section title, tooltip, and subtitle already explain it). The same slider keeps its description in `CamtrapDPExportModal` where context is sparser.

<img width="842" height="634" alt="image" src="https://github.com/user-attachments/assets/ad7f455d-b114-4efa-aa4b-3b485c9520df" />


## Test plan
- [x] Open a study, navigate to Settings — sections are separated by thin rules, no colored backgrounds.
- [x] Sequence Grouping: drag the slider; "?" tooltip still shows the Off/On explanation.
- [x] Export: both rows trigger their respective modals (Media Directories, Camtrap DP); success/error banner still appears above the rows.
- [x] Delete: opens the confirm modal; cancel returns without deleting.
- [x] Resize the window narrow (<640px): action buttons drop full-width below their description.
- [x] At very wide widths the column stays centered (intentional — settings convention).