### PR TITLE
style(settings): cap AI Models table width on wide screens

### DIFF
--- a/src/renderer/src/models.jsx
+++ b/src/renderer/src/models.jsx
@@ -469,7 +469,7 @@ export default function Zoo({ modelZoo }) {
     }
   }
   return (
-    <div className="px-8 py-4">
+    <div className="px-8 py-4 max-w-5xl mx-auto">
       <div className="overflow-x-auto border border-gray-200 rounded-lg shadow-sm">
         <table className="min-w-full divide-y divide-gray-200 bg-white">
           <thead className="bg-gray-50">


### PR DESCRIPTION
## Summary
- Constrain the AI Models settings table to `max-w-5xl` and center it so it doesn't stretch edge-to-edge on very wide displays.

## Test plan
- [ ] Open Settings → AI Models on a wide monitor and confirm the table caps around 1024px and stays centered.
- [ ] Resize to a narrow window and confirm the table still fills available width and remains scrollable.