### PR TITLE
feat(settings): redesign Info tab with about, changelog, storage, license

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -7,7 +7,7 @@ files:
   - '!**/.vscode/*'
   - '!src/*'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
-  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
+  - '!{.eslintignore,.eslintrc.cjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,README.md}'
   - '!{.env,.env.*,.npmrc,pnpm-lock.yaml}'
   - '!python-environments/*'
 extraResources:

--- a/src/main/ipc/index.js
+++ b/src/main/ipc/index.js
@@ -21,6 +21,7 @@ import { registerMLIPCHandlers } from './ml.js'
 import { registerSequencesIPCHandlers } from './sequences.js'
 import { registerDiagnosticsIPCHandlers } from './diagnostics.js'
 import { registerQueueIPCHandlers } from './queue.js'
+import { registerInfoIPCHandlers } from './info.js'
 
 /**
  * Register all IPC handlers
@@ -44,6 +45,7 @@ export function registerAllIPCHandlers() {
   registerSequencesIPCHandlers()
   registerDiagnosticsIPCHandlers()
   registerQueueIPCHandlers()
+  registerInfoIPCHandlers()
 
   log.info('All IPC handlers registered')
 }
@@ -63,5 +65,6 @@ export {
   registerMLIPCHandlers,
   registerSequencesIPCHandlers,
   registerDiagnosticsIPCHandlers,
-  registerQueueIPCHandlers
+  registerQueueIPCHandlers,
+  registerInfoIPCHandlers
 }

--- a/src/main/ipc/info.js
+++ b/src/main/ipc/info.js
@@ -1,0 +1,38 @@
+/**
+ * Info-tab-related IPC handlers
+ */
+
+import { ipcMain } from 'electron'
+import log from '../services/logger.js'
+import { getRecentReleases } from '../services/changelog.js'
+import { getStorageUsage } from '../services/storage-usage.js'
+import { getLicenseText } from '../services/license.js'
+
+export function registerInfoIPCHandlers() {
+  ipcMain.handle('info:get-changelog', async (_, limit = 3) => {
+    try {
+      return getRecentReleases(limit)
+    } catch (err) {
+      log.error('info:get-changelog failed', err)
+      return []
+    }
+  })
+
+  ipcMain.handle('info:get-storage-usage', async () => {
+    try {
+      return await getStorageUsage()
+    } catch (err) {
+      log.error('info:get-storage-usage failed', err)
+      return null
+    }
+  })
+
+  ipcMain.handle('info:get-license-text', async () => {
+    try {
+      return getLicenseText()
+    } catch (err) {
+      log.error('info:get-license-text failed', err)
+      return ''
+    }
+  })
+}

--- a/src/main/services/changelog.js
+++ b/src/main/services/changelog.js
@@ -1,0 +1,75 @@
+import { app } from 'electron'
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import log from './logger.js'
+
+let cache = null
+
+function findChangelogPath() {
+  const candidates = [
+    path.join(app.getAppPath(), 'CHANGELOG.md'),
+    path.join(process.cwd(), 'CHANGELOG.md')
+  ]
+  return candidates.find((p) => existsSync(p))
+}
+
+export function parseChangelog(text) {
+  const releases = []
+  const headerRegex = /^##\s+\[([^\]]+)\](?:\s*[-–]\s*(.+))?$/
+  const sectionRegex = /^###\s+(.+)$/
+  const itemRegex = /^[-*]\s+(.+)$/
+
+  let current = null
+  let currentSection = null
+
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trimEnd()
+    const headerMatch = line.match(headerRegex)
+    if (headerMatch) {
+      if (current) releases.push(current)
+      current = {
+        version: headerMatch[1].trim(),
+        date: headerMatch[2]?.trim() || null,
+        added: [],
+        changed: [],
+        fixed: []
+      }
+      currentSection = null
+      continue
+    }
+    if (!current) continue
+    const sectionMatch = line.match(sectionRegex)
+    if (sectionMatch) {
+      currentSection = sectionMatch[1].trim().toLowerCase()
+      continue
+    }
+    if (!currentSection) continue
+    const itemMatch = line.match(itemRegex)
+    if (itemMatch && current[currentSection]) {
+      current[currentSection].push(itemMatch[1].trim())
+    }
+  }
+  if (current) releases.push(current)
+  return releases
+}
+
+export function getRecentReleases(limit = 3) {
+  if (cache) return cache.slice(0, limit)
+
+  const file = findChangelogPath()
+  if (!file) {
+    log.warn('CHANGELOG.md not found in any candidate path')
+    cache = []
+    return cache
+  }
+
+  try {
+    const text = readFileSync(file, 'utf-8')
+    cache = parseChangelog(text)
+    return cache.slice(0, limit)
+  } catch (err) {
+    log.error('Failed to read CHANGELOG.md:', err)
+    cache = []
+    return cache
+  }
+}

--- a/src/main/services/license.js
+++ b/src/main/services/license.js
@@ -1,0 +1,31 @@
+import { app } from 'electron'
+import { readFileSync, existsSync } from 'fs'
+import path from 'path'
+import log from './logger.js'
+
+let cache = null
+
+function findLicensePath() {
+  const candidates = [path.join(app.getAppPath(), 'LICENSE'), path.join(process.cwd(), 'LICENSE')]
+  return candidates.find((p) => existsSync(p))
+}
+
+export function getLicenseText() {
+  if (cache !== null) return cache
+
+  const file = findLicensePath()
+  if (!file) {
+    log.warn('LICENSE not found in any candidate path')
+    cache = ''
+    return cache
+  }
+
+  try {
+    cache = readFileSync(file, 'utf-8')
+    return cache
+  } catch (err) {
+    log.error('Failed to read LICENSE:', err)
+    cache = ''
+    return cache
+  }
+}

--- a/src/main/services/storage-usage.js
+++ b/src/main/services/storage-usage.js
@@ -1,0 +1,54 @@
+import { app } from 'electron'
+import { promises as fs } from 'fs'
+import path from 'path'
+import log from './logger.js'
+import { getMLModelLocalRootDir, getMLModelEnvironmentRootDir } from './ml/index.js'
+import { getBiowatchDataPath } from './paths.js'
+
+async function dirSize(dir) {
+  let total = 0
+  let entries
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true })
+  } catch (err) {
+    if (err.code === 'ENOENT') return 0
+    log.warn(`storage-usage: cannot read ${dir}: ${err.message}`)
+    return 0
+  }
+  await Promise.all(
+    entries.map(async (entry) => {
+      const full = path.join(dir, entry.name)
+      try {
+        if (entry.isDirectory()) {
+          total += await dirSize(full)
+        } else if (entry.isFile()) {
+          const st = await fs.stat(full)
+          total += st.size
+        }
+      } catch {
+        // ignore unreadable entries
+      }
+    })
+  )
+  return total
+}
+
+export async function getStorageUsage() {
+  const modelsRoot = getMLModelLocalRootDir()
+  const envsRoot = getMLModelEnvironmentRootDir()
+  const studiesRoot = path.join(getBiowatchDataPath(), 'studies')
+  const logsRoot = app.getPath('logs')
+
+  const [modelsBytes, envsBytes, studiesBytes, logsBytes] = await Promise.all([
+    dirSize(modelsRoot),
+    dirSize(envsRoot),
+    dirSize(studiesRoot),
+    dirSize(logsRoot)
+  ])
+
+  return {
+    models: { bytes: modelsBytes + envsBytes, path: modelsRoot },
+    studies: { bytes: studiesBytes, path: studiesRoot },
+    logs: { bytes: logsBytes, path: logsRoot }
+  }
+}

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -366,6 +366,20 @@ const api = {
     return await electronAPI.ipcRenderer.invoke('diagnostics:export')
   },
 
+  // Settings → Info tab
+  getChangelog: async (limit = 3) => {
+    return await electronAPI.ipcRenderer.invoke('info:get-changelog', limit)
+  },
+  getStorageUsage: async () => {
+    return await electronAPI.ipcRenderer.invoke('info:get-storage-usage')
+  },
+  getLicenseText: async () => {
+    return await electronAPI.ipcRenderer.invoke('info:get-license-text')
+  },
+  openPath: async (filePath) => {
+    return await electronAPI.ipcRenderer.invoke('shell:open-path', filePath)
+  },
+
   // Remote image caching (for GBIF/Agouti imported images)
   imageCache: {
     // Get cached image path if it exists

--- a/src/renderer/src/SettingsInfo/AboutSection.jsx
+++ b/src/renderer/src/SettingsInfo/AboutSection.jsx
@@ -1,0 +1,14 @@
+export default function AboutSection() {
+  return (
+    <section className="py-6">
+      <h2 className="text-base font-medium text-gray-900 mb-2">
+        Analyze Camera Trap Data — Privately, On Your Machine
+      </h2>
+      <p className="text-sm text-gray-600 leading-relaxed">
+        Biowatch is a free, open-source desktop application for wildlife researchers and
+        conservationists. Analyze camera trap datasets completely offline — your data never leaves
+        your machine.
+      </p>
+    </section>
+  )
+}

--- a/src/renderer/src/SettingsInfo/LicenseModal.jsx
+++ b/src/renderer/src/SettingsInfo/LicenseModal.jsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+
+export default function LicenseModal({ isOpen, onClose }) {
+  const [text, setText] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen || text) return
+    let cancelled = false
+    setIsLoading(true)
+    window.api
+      .getLicenseText()
+      .then((value) => {
+        if (!cancelled) setText(value || '')
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, text])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000]"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+          <h2 className="text-base font-medium text-gray-900">License</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="px-6 py-4 overflow-y-auto">
+          {isLoading ? (
+            <div className="text-sm text-gray-400">Loading…</div>
+          ) : text ? (
+            <pre className="text-xs text-gray-700 whitespace-pre-wrap font-mono">{text}</pre>
+          ) : (
+            <div className="text-sm text-gray-400">License text not available.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/SettingsInfo/LicenseSection.jsx
+++ b/src/renderer/src/SettingsInfo/LicenseSection.jsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+import LicenseModal from './LicenseModal'
+
+export default function LicenseSection() {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  return (
+    <section className="py-6">
+      <h2 className="text-base font-medium text-gray-900 mb-1">License</h2>
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-gray-600">CC BY-NC 4.0 · © 2026 EarthToolsMaker</p>
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+        >
+          View license
+          <ExternalLink size={12} />
+        </button>
+      </div>
+      <LicenseModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
+    </section>
+  )
+}

--- a/src/renderer/src/SettingsInfo/RecentReleases.jsx
+++ b/src/renderer/src/SettingsInfo/RecentReleases.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { ExternalLink } from 'lucide-react'
+
+const SECTION_LABELS = {
+  added: 'Added',
+  changed: 'Changed',
+  fixed: 'Fixed'
+}
+
+const COLLAPSED_MAX_HEIGHT = 180
+
+function ReleaseBlock({ release }) {
+  const sections = ['added', 'changed', 'fixed'].filter(
+    (key) => release[key] && release[key].length > 0
+  )
+
+  return (
+    <div className="mb-5 last:mb-0">
+      <div className="flex items-baseline gap-2 mb-2">
+        <h3 className="text-sm font-semibold text-gray-900">{release.version}</h3>
+        {release.date && <span className="text-xs text-gray-500">{release.date}</span>}
+      </div>
+      <div className="space-y-2">
+        {sections.map((key) => (
+          <div key={key}>
+            <div className="text-xs font-medium uppercase tracking-wide text-gray-500 mb-1">
+              {SECTION_LABELS[key]}
+            </div>
+            <ul className="text-sm text-gray-700 space-y-0.5 list-disc list-inside marker:text-gray-300">
+              {release[key].map((item, i) => (
+                <li key={i}>{item}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function RecentReleases() {
+  const { data: releases = [], isLoading } = useQuery({
+    queryKey: ['settings-info', 'changelog'],
+    queryFn: () => window.api.getChangelog(3),
+    staleTime: Infinity
+  })
+
+  const [expanded, setExpanded] = useState(false)
+  const [overflowing, setOverflowing] = useState(false)
+  const contentRef = useRef(null)
+
+  useEffect(() => {
+    if (!contentRef.current) return
+    setOverflowing(contentRef.current.scrollHeight > COLLAPSED_MAX_HEIGHT + 4)
+  }, [releases])
+
+  const isCollapsed = !expanded && overflowing
+
+  return (
+    <section className="py-6">
+      <h2 className="text-base font-medium text-gray-900 mb-1">Recent releases</h2>
+      <p className="text-sm text-gray-500 mb-4">What&apos;s new in the last few versions.</p>
+
+      {isLoading ? (
+        <div className="text-sm text-gray-400">Loading…</div>
+      ) : releases.length === 0 ? (
+        <div className="text-sm text-gray-400">No release notes available.</div>
+      ) : (
+        <div
+          ref={contentRef}
+          className={`relative ${isCollapsed ? 'overflow-hidden' : ''}`}
+          style={isCollapsed ? { maxHeight: COLLAPSED_MAX_HEIGHT } : undefined}
+        >
+          {releases.map((r) => (
+            <ReleaseBlock key={r.version} release={r} />
+          ))}
+          {isCollapsed && (
+            <div className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-white to-transparent" />
+          )}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 mt-3">
+        {overflowing ? (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            {expanded ? 'Show less' : 'Show more'}
+          </button>
+        ) : (
+          <span />
+        )}
+        <a
+          href="https://github.com/earthtoolsmaker/biowatch/blob/main/CHANGELOG.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+        >
+          View full changelog
+          <ExternalLink size={12} />
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/SettingsInfo/StorageBreakdown.jsx
+++ b/src/renderer/src/SettingsInfo/StorageBreakdown.jsx
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query'
+import { FolderOpen } from 'lucide-react'
+
+function formatBytes(bytes) {
+  if (!bytes || bytes < 1024) return `${bytes || 0} B`
+  const units = ['KB', 'MB', 'GB', 'TB']
+  let value = bytes / 1024
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex++
+  }
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+const ROW_LABELS = {
+  models: 'AI Models',
+  studies: 'Studies',
+  logs: 'Logs'
+}
+
+function StorageRow({ label, entry, isLoading }) {
+  if (!entry) {
+    return (
+      <div className="flex items-center justify-between py-2">
+        <span className="text-sm text-gray-700">{label}</span>
+        <span className="text-sm text-gray-400">—</span>
+      </div>
+    )
+  }
+  return (
+    <div className="flex items-center justify-between py-2">
+      <span className="text-sm text-gray-700">{label}</span>
+      <div className="flex items-center gap-3">
+        <span className="text-sm tabular-nums text-gray-900">
+          {isLoading ? '…' : formatBytes(entry.bytes)}
+        </span>
+        <button
+          onClick={() => window.api.openPath(entry.path)}
+          className="text-gray-400 hover:text-gray-700 transition-colors"
+          title={`Open ${entry.path}`}
+        >
+          <FolderOpen size={14} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function StorageBreakdown() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['settings-info', 'storage-usage'],
+    queryFn: () => window.api.getStorageUsage(),
+    staleTime: 30_000
+  })
+
+  return (
+    <section className="py-6">
+      <h2 className="text-base font-medium text-gray-900 mb-1">Storage</h2>
+      <p className="text-sm text-gray-500 mb-2">Disk space used by Biowatch on this machine.</p>
+      <div className="divide-y divide-gray-100">
+        {Object.keys(ROW_LABELS).map((key) => (
+          <StorageRow key={key} label={ROW_LABELS[key]} entry={data?.[key]} isLoading={isLoading} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/SettingsInfo/SupportLinks.jsx
+++ b/src/renderer/src/SettingsInfo/SupportLinks.jsx
@@ -1,0 +1,48 @@
+import { Bug, Book, Github, Earth } from 'lucide-react'
+
+const LINKS = [
+  {
+    label: 'Report a bug',
+    href: 'https://github.com/earthtoolsmaker/biowatch/issues/new',
+    icon: Bug
+  },
+  {
+    label: 'Documentation',
+    href: 'https://biowatch.earthtoolsmaker.org/',
+    icon: Book
+  },
+  {
+    label: 'GitHub',
+    href: 'https://github.com/earthtoolsmaker/biowatch',
+    icon: Github
+  },
+  {
+    label: 'Website',
+    href: 'https://www.earthtoolsmaker.org/tools/biowatch/',
+    icon: Earth
+  }
+]
+
+export default function SupportLinks() {
+  return (
+    <section className="py-6">
+      <h2 className="text-base font-medium text-gray-900 mb-1">Support &amp; links</h2>
+      <p className="text-sm text-gray-500 mb-3">Help, source code, and where to find us.</p>
+      <ul className="space-y-1.5">
+        {LINKS.map(({ label, href, icon: Icon }) => (
+          <li key={label}>
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-blue-600 hover:underline"
+            >
+              <Icon size={14} />
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/renderer/src/SettingsInfo/index.jsx
+++ b/src/renderer/src/SettingsInfo/index.jsx
@@ -1,0 +1,27 @@
+import AboutSection from './AboutSection'
+import RecentReleases from './RecentReleases'
+import StorageBreakdown from './StorageBreakdown'
+import SupportLinks from './SupportLinks'
+import LicenseSection from './LicenseSection'
+
+export default function SettingsInfo({ version, platform }) {
+  return (
+    <div className="px-4 sm:px-6">
+      <div className="max-w-2xl mx-auto divide-y divide-gray-200">
+        <section className="py-6">
+          <div className="flex items-baseline gap-2">
+            <h1 className="text-lg font-semibold text-gray-900">Biowatch</h1>
+            <span className="text-sm text-gray-500">
+              v{version} · {platform}
+            </span>
+          </div>
+        </section>
+        <AboutSection />
+        <RecentReleases />
+        <StorageBreakdown />
+        <SupportLinks />
+        <LicenseSection />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/settings.jsx
+++ b/src/renderer/src/settings.jsx
@@ -2,11 +2,12 @@ import { useState } from 'react'
 import { Navigate, Route, Routes, useNavigate } from 'react-router'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useQuery } from '@tanstack/react-query'
-import { BrainCircuit, Info, Github, Earth, Loader2, Settings2 } from 'lucide-react'
+import { BrainCircuit, Info, Loader2, Settings2 } from 'lucide-react'
 import Zoo from './models'
 import { modelZoo } from '../../shared/mlmodels'
 import { Tab } from './ui/Tab'
 import Diagnostics from './Diagnostics'
+import SettingsInfo from './SettingsInfo'
 
 function SettingsFooter({ className, onRevealAdvanced }) {
   const handleLogoClick = (e) => {
@@ -37,42 +38,6 @@ function SettingsFooter({ className, onRevealAdvanced }) {
           </a>
         </span>
       </div>
-    </div>
-  )
-}
-
-function SettingsInfo({ version, platform }) {
-  return (
-    <div className="p-4">
-      <ul className="list-none space-y-2">
-        <li className="flex items-center">
-          <span className="font-semibold">
-            Biowatch version {version} for {platform}
-          </span>
-        </li>
-        <li className="flex items-center">
-          <Github size={14} className="mr-2" />
-          <a
-            href="https://github.com/earthtoolsmaker/biowatch"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
-          >
-            https://github.com/earthtoolsmaker/biowatch
-          </a>
-        </li>
-        <li className="flex items-center">
-          <Earth size={14} className="mr-2" />
-          <a
-            href="https://www.earthtoolsmaker.org/tools/biowatch/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
-          >
-            https://www.earthtoolsmaker.org/tools/biowatch/
-          </a>
-        </li>
-      </ul>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

<img width="585" height="1357" alt="image" src="https://github.com/user-attachments/assets/8dbc9d94-d5a0-4830-ad89-8b89a8d9aea0" />

- Single-column redesign of Settings → Info: hero with version + platform, About blurb (canonical README copy), Recent releases (last 3 versions parsed from `CHANGELOG.md` with show-more toggle), Storage breakdown (AI Models / Studies / Logs with reveal-in-folder), Support & links, License section with bundled-text modal.
- Removes `CHANGELOG.md` from the `electron-builder.yml` exclusion list so the parsed release notes ship with every build and work fully offline.
- New main-process services: `changelog.js` (Keep-a-Changelog parser, cached), `storage-usage.js` (recursive directory size), `license.js` (reads bundled `LICENSE`, cached).
- New IPC handlers under `info:*` namespace, exposed via `window.api.{getChangelog, getStorageUsage, getLicenseText, openPath}`.

## Test plan
- [x] Open Settings → Info — hero, About, Recent releases, Storage, Support & links, License all render in order.
- [x] Recent releases shows the last 3 versions from `CHANGELOG.md`; "Show more" toggle appears only when collapsed content overflows; "View full changelog" links to GitHub.
- [x] Storage shows three rows with sizes (briefly "…" while computing); clicking the folder icon reveals each path in the OS file manager.
- [x] Click "View license" → modal opens with bundled `LICENSE` text; Esc and overlay click both close it.
- [x] Shift-click on the ETM footer logo still reveals the Advanced tab.
- [x] Build a packaged version and verify `CHANGELOG.md` is bundled and the Info tab works offline.