### PR TITLE
feat(deployments): make timeline adapt to screen width

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -67,12 +67,14 @@ const { data, error } = await window.api.getSequences(studyId, { limit: 20 })
 | -------------------------------------------------------------- | ------------------------------- | --------------------------------- | ------------------------ |
 | `getDeploymentLocations(studyId)`                              | `deployments:get-locations`     | studyId                           | `{ data: Deployment[] }` |
 | `getAllDeployments(studyId)`                                   | `deployments:get-all`           | studyId                           | `{ data: Deployment[] }` |
-| `getDeploymentsActivity(studyId)`                              | `deployments:get-activity`      | studyId                           | `{ data: Activity[] }`   |
+| `getDeploymentsActivity(studyId, periodCount?)`                | `deployments:get-activity`      | studyId, periodCount (optional)   | `{ data: Activity[] }`   |
 | `setDeploymentLatitude(studyId, deploymentID, latitude)`       | `deployments:set-latitude`      | studyId, deploymentID, latitude   | `{ success: boolean }`   |
 | `setDeploymentLongitude(studyId, deploymentID, longitude)`     | `deployments:set-longitude`     | studyId, deploymentID, longitude  | `{ success: boolean }`   |
 | `setDeploymentLocationName(studyId, locationID, locationName)` | `deployments:set-location-name` | studyId, locationID, locationName | `{ success: boolean }`   |
 
 **Note on `getDeploymentLocations` vs `getAllDeployments`:** `getDeploymentLocations` dedupes by `(latitude, longitude)` and returns one row per physical camera-trap location — intended for read-only overview maps. `getAllDeployments` returns every deployment row (no dedup) — used by the Deployments tab's editable map so `MarkerClusterGroup` can correctly count co-located deployments and dragging doesn't silently split a group. `getDeploymentsActivity` runs in the sequences worker thread to keep the UI responsive on large studies.
+
+**Note on `periodCount`:** `getDeploymentsActivity` accepts an optional `periodCount` (number of time-period buckets in the per-deployment timeline). The Deployments tab measures the timeline column width and passes a bucketed value (multiples of 10) so wider screens get more circles per row. Defaults to 20 if null/0/non-numeric, and is clamped to a maximum of 100 backend-side to bound the SUM(CASE)×N SQL aggregation.
 
 **Note on `setDeploymentLocationName`:** This updates the `locationName` for ALL deployments with the given `locationID`. When deployments share a `locationID` (grouped deployments), renaming any one updates the entire group.
 

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -296,8 +296,12 @@ export async function getDeploymentsActivity(dbPath, periodCount) {
   const startTime = Date.now()
   // Robust against null/0/NaN from the IPC boundary — JS default params only
   // fire on undefined, but the renderer can legitimately send null before the
-  // timeline width is measured.
-  const buckets = typeof periodCount === 'number' && periodCount > 0 ? periodCount : 20
+  // timeline width is measured. Also clamped to a sane upper bound: each extra
+  // bucket adds a SUM(CASE) expression to a single GROUP BY scan, so an
+  // ultra-wide / multi-monitor renderer asking for hundreds of buckets would
+  // make the worker query proportionally slower on large studies.
+  const requested = typeof periodCount === 'number' && periodCount > 0 ? periodCount : 20
+  const buckets = Math.min(requested, 100)
   log.info(`Querying deployment activity from: ${dbPath}`)
 
   try {

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -289,10 +289,15 @@ export async function insertDeployments(manager, deploymentsData) {
  * Get activity data (observation counts) per deployment over time periods
  * Uses SQL-level aggregation for performance with large datasets
  * @param {string} dbPath - Path to the SQLite database
+ * @param {number} [periodCount=20] - Number of time-period buckets to aggregate into
  * @returns {Promise<Object>} - Activity data with periods and counts per deployment
  */
-export async function getDeploymentsActivity(dbPath) {
+export async function getDeploymentsActivity(dbPath, periodCount) {
   const startTime = Date.now()
+  // Robust against null/0/NaN from the IPC boundary — JS default params only
+  // fire on undefined, but the renderer can legitimately send null before the
+  // timeline width is measured.
+  const buckets = typeof periodCount === 'number' && periodCount > 0 ? periodCount : 20
   log.info(`Querying deployment activity from: ${dbPath}`)
 
   try {
@@ -323,7 +328,7 @@ export async function getDeploymentsActivity(dbPath) {
     const minDate = new Date(dateRange.minDate)
     const maxDate = new Date(dateRange.maxDate)
     const totalDays = (maxDate - minDate) / (1000 * 60 * 60 * 24)
-    const periodDays = Math.max(1, Math.ceil(totalDays / 20))
+    const periodDays = Math.max(1, Math.ceil(totalDays / buckets))
 
     // Generate periods
     const periods = []

--- a/src/main/ipc/deployments.js
+++ b/src/main/ipc/deployments.js
@@ -62,7 +62,7 @@ export function registerDeploymentsIPCHandlers() {
   // Per-deployment period-bucket aggregation for the Deployments tab. Runs in
   // the sequences worker so the SUM(CASE) × 20 scan over observations doesn't
   // block the renderer UI on large studies.
-  ipcMain.handle('deployments:get-activity', async (_, studyId) => {
+  ipcMain.handle('deployments:get-activity', async (_, studyId, periodCount) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
       if (!dbPath || !existsSync(dbPath)) {
@@ -70,7 +70,7 @@ export function registerDeploymentsIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      const activity = await runInWorker({ type: 'deployments-activity', dbPath })
+      const activity = await runInWorker({ type: 'deployments-activity', dbPath, periodCount })
       return { data: activity }
     } catch (error) {
       log.error('Error getting deployments activity:', error)

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -134,9 +134,9 @@ async function run() {
     }
     case 'deployments-activity': {
       // Deployments tab's per-deployment period-bucket aggregation. The
-      // SUM(CASE) × 20 scan over observations was locking the renderer for
+      // SUM(CASE) × N scan over observations was locking the renderer for
       // multiple seconds on first open of large studies.
-      return getDeploymentsActivity(dbPath)
+      return getDeploymentsActivity(dbPath, workerData.periodCount)
     }
     default:
       throw new Error(`Unknown worker task type: ${type}`)

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -51,8 +51,8 @@ const api = {
   getLocationsActivity: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('locations:get-activity', studyId)
   },
-  getDeploymentsActivity: async (studyId) => {
-    return await electronAPI.ipcRenderer.invoke('deployments:get-activity', studyId)
+  getDeploymentsActivity: async (studyId, periodCount) => {
+    return await electronAPI.ipcRenderer.invoke('deployments:get-activity', studyId, periodCount)
   },
   getMediaBboxes: async (studyId, mediaID, includeWithoutBbox = false) => {
     return await electronAPI.ipcRenderer.invoke(

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -623,7 +623,7 @@ const DeploymentRow = memo(function DeploymentRow({
           <div
             key={period.start}
             title={`${period.count} observations`}
-            className="flex items-center justify-center h-[25px] w-[5%]"
+            className="flex items-center justify-center h-[25px] flex-1 min-w-0"
           >
             <div
               className="rounded-full bg-[#77b7ff] aspect-square max-w-[25px]"
@@ -696,7 +696,7 @@ const LocationGroupHeader = memo(function LocationGroupHeader({
           <div
             key={period.start}
             title={`${period.count} observations (aggregated)`}
-            className="flex items-center justify-center h-[25px] w-[5%]"
+            className="flex items-center justify-center h-[25px] flex-1 min-w-0"
           >
             <div
               className="rounded-full bg-[#77b7ff] aspect-square max-w-[25px]"
@@ -821,9 +821,33 @@ function LocationsList({
   onRenameLocation,
   isPlaceMode,
   groupToExpand,
-  onGroupExpanded
+  onGroupExpanded,
+  onPeriodCountChange
 }) {
   const parentRef = useRef(null)
+  const timelineRef = useRef(null)
+  const [timelineWidth, setTimelineWidth] = useState(0)
+
+  useEffect(() => {
+    const node = timelineRef.current
+    if (!node) return
+    const ro = new ResizeObserver(([entry]) => {
+      setTimelineWidth(entry.contentRect.width)
+    })
+    ro.observe(node)
+    return () => ro.disconnect()
+  }, [])
+
+  // Date markers: live frontend-only count, ~1 per 150px, clamped 2..15.
+  const dateCount = timelineWidth ? Math.max(2, Math.min(15, Math.round(timelineWidth / 150))) : 5
+
+  // Period circles: bucketed to multiples of 10 (~1 per 30px) so we don't
+  // refetch the SQL aggregation on every pixel of resize.
+  const periodCount = timelineWidth ? Math.max(10, Math.round(timelineWidth / 30 / 10) * 10) : 20
+
+  useEffect(() => {
+    onPeriodCountChange?.(periodCount)
+  }, [periodCount, onPeriodCountChange])
 
   // Track which groups are expanded (collapsed by default)
   const [expandedGroups, setExpandedGroups] = useState(new Set())
@@ -890,8 +914,8 @@ function LocationsList({
 
   // Memoize date markers for timeline header
   const dateMarkers = useMemo(
-    () => getDateMarkers(activity.startDate, activity.endDate, 5),
-    [activity.startDate, activity.endDate]
+    () => getDateMarkers(activity.startDate, activity.endDate, dateCount),
+    [activity.startDate, activity.endDate, dateCount]
   )
 
   // Setup virtualizer with dynamic sizing
@@ -955,9 +979,9 @@ function LocationsList({
   return (
     <div className="flex-1 flex flex-col overflow-hidden min-h-0">
       <header className="bg-white z-10 pl-68 py-3 border-b border-gray-300">
-        <div className="flex justify-between text-xs text-gray-600">
+        <div ref={timelineRef} className="flex justify-between text-xs text-gray-600">
           {dateMarkers.map((date, i) => (
-            <div key={i} className="flex flex-col items-center" style={{ width: '20%' }}>
+            <div key={i} className="flex flex-col items-center flex-1 min-w-0">
               <span>{formatDateShort(date)}</span>
               <div className="w-px h-2 bg-gray-400 mt-1" />
             </div>
@@ -1040,6 +1064,9 @@ export default function Deployments({ studyId }) {
   const [selectedLocation, setSelectedLocation] = useState(null)
   const [isPlaceMode, setIsPlaceMode] = useState(false)
   const [groupToExpand, setGroupToExpand] = useState(null)
+  // Bucketed period count, set by LocationsList from its measured timeline
+  // width. Drives the SQL aggregation; null until the timeline measures itself.
+  const [periodCount, setPeriodCount] = useState(null)
   const queryClient = useQueryClient()
   const { importStatus } = useImportStatus(studyId)
 
@@ -1059,17 +1086,21 @@ export default function Deployments({ studyId }) {
   })
 
   // Heavy per-deployment period-bucket query for the list timeline. Runs in
-  // the sequences worker so the 20-CASE aggregate over observations doesn't
-  // block the UI. Resolves ~1.2s after mount on gmu8_leuven.
+  // the sequences worker so the SUM(CASE) × N aggregate over observations
+  // doesn't block the UI. periodCount is set by LocationsList from the
+  // measured timeline width (bucketed to multiples of 10) so wider screens
+  // get more circles per row; keepPreviousData smooths the bucket-crossing
+  // refetch.
   const { data: activity, isLoading: isActivityLoading } = useQuery({
-    queryKey: ['deploymentsActivity', studyId],
+    queryKey: ['deploymentsActivity', studyId, periodCount],
     queryFn: async () => {
-      const response = await window.api.getDeploymentsActivity(studyId)
+      const response = await window.api.getDeploymentsActivity(studyId, periodCount)
       if (response.error) {
         throw new Error(response.error)
       }
       return response.data
     },
+    keepPreviousData: true,
     refetchInterval: () => (importStatus?.isRunning ? 5000 : false),
     enabled: !!studyId
   })
@@ -1080,17 +1111,22 @@ export default function Deployments({ studyId }) {
         const lat = parseFloat(latitude)
         const result = await window.api.setDeploymentLatitude(studyId, deploymentID, lat)
 
-        // Optimistic update via queryClient
-        queryClient.setQueryData(['deploymentsActivity', studyId], (prevActivity) => {
-          if (!prevActivity) return prevActivity
-          const updatedDeployments = prevActivity.deployments.map((deployment) => {
-            if (deployment.deploymentID === deploymentID) {
-              return { ...deployment, latitude: lat }
-            }
-            return deployment
-          })
-          return { ...prevActivity, deployments: updatedDeployments }
-        })
+        // Optimistic update via queryClient. Use setQueriesData (plural) with
+        // a prefix key so we patch every periodCount variant cached for this
+        // study, since periodCount is part of the full query key.
+        queryClient.setQueriesData(
+          { queryKey: ['deploymentsActivity', studyId] },
+          (prevActivity) => {
+            if (!prevActivity) return prevActivity
+            const updatedDeployments = prevActivity.deployments.map((deployment) => {
+              if (deployment.deploymentID === deploymentID) {
+                return { ...deployment, latitude: lat }
+              }
+              return deployment
+            })
+            return { ...prevActivity, deployments: updatedDeployments }
+          }
+        )
 
         // Also patch the un-deduped map cache so the dragged marker doesn't
         // snap back during the post-invalidation refetch.
@@ -1122,17 +1158,20 @@ export default function Deployments({ studyId }) {
         const lng = parseFloat(longitude)
         const result = await window.api.setDeploymentLongitude(studyId, deploymentID, lng)
 
-        // Optimistic update via queryClient
-        queryClient.setQueryData(['deploymentsActivity', studyId], (prevActivity) => {
-          if (!prevActivity) return prevActivity
-          const updatedDeployments = prevActivity.deployments.map((deployment) => {
-            if (deployment.deploymentID === deploymentID) {
-              return { ...deployment, longitude: lng }
-            }
-            return deployment
-          })
-          return { ...prevActivity, deployments: updatedDeployments }
-        })
+        // Optimistic update via queryClient (matches all periodCount variants).
+        queryClient.setQueriesData(
+          { queryKey: ['deploymentsActivity', studyId] },
+          (prevActivity) => {
+            if (!prevActivity) return prevActivity
+            const updatedDeployments = prevActivity.deployments.map((deployment) => {
+              if (deployment.deploymentID === deploymentID) {
+                return { ...deployment, longitude: lng }
+              }
+              return deployment
+            })
+            return { ...prevActivity, deployments: updatedDeployments }
+          }
+        )
 
         queryClient.setQueryData(['deploymentsAll', studyId], (prev) => {
           if (!prev) return prev
@@ -1201,17 +1240,20 @@ export default function Deployments({ studyId }) {
           throw new Error(result.error)
         }
 
-        // Optimistic update via queryClient
-        queryClient.setQueryData(['deploymentsActivity', studyId], (prevActivity) => {
-          if (!prevActivity) return prevActivity
-          const updatedDeployments = prevActivity.deployments.map((deployment) => {
-            if (deployment.locationID === locationID) {
-              return { ...deployment, locationName: newName }
-            }
-            return deployment
-          })
-          return { ...prevActivity, deployments: updatedDeployments }
-        })
+        // Optimistic update via queryClient (matches all periodCount variants).
+        queryClient.setQueriesData(
+          { queryKey: ['deploymentsActivity', studyId] },
+          (prevActivity) => {
+            if (!prevActivity) return prevActivity
+            const updatedDeployments = prevActivity.deployments.map((deployment) => {
+              if (deployment.locationID === locationID) {
+                return { ...deployment, locationName: newName }
+              }
+              return deployment
+            })
+            return { ...prevActivity, deployments: updatedDeployments }
+          }
+        )
 
         queryClient.setQueryData(['deploymentsAll', studyId], (prev) => {
           if (!prev) return prev
@@ -1269,6 +1311,7 @@ export default function Deployments({ studyId }) {
               isPlaceMode={isPlaceMode}
               groupToExpand={groupToExpand}
               onGroupExpanded={handleGroupExpanded}
+              onPeriodCountChange={setPeriodCount}
             />
           ) : null}
         </Panel>

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -1089,8 +1089,9 @@ export default function Deployments({ studyId }) {
   // the sequences worker so the SUM(CASE) × N aggregate over observations
   // doesn't block the UI. periodCount is set by LocationsList from the
   // measured timeline width (bucketed to multiples of 10) so wider screens
-  // get more circles per row; keepPreviousData smooths the bucket-crossing
-  // refetch.
+  // get more circles per row; placeholderData holds the previous bucket's
+  // rows during the bucket-crossing refetch (v5 idiom — keepPreviousData was
+  // removed in @tanstack/react-query v5).
   const { data: activity, isLoading: isActivityLoading } = useQuery({
     queryKey: ['deploymentsActivity', studyId, periodCount],
     queryFn: async () => {
@@ -1100,7 +1101,7 @@ export default function Deployments({ studyId }) {
       }
       return response.data
     },
-    keepPreviousData: true,
+    placeholderData: (prev) => prev,
     refetchInterval: () => (importStatus?.isRunning ? 5000 : false),
     enabled: !!studyId
   })

--- a/src/renderer/src/ui/SkeletonDeploymentsList.jsx
+++ b/src/renderer/src/ui/SkeletonDeploymentsList.jsx
@@ -29,8 +29,9 @@ function SkeletonDeploymentsList({ itemCount = 5 }) {
                 </div>
               </div>
               {/* Activity periods skeleton — matches DeploymentRow's h-[25px]
-                  flex-1 wrapper + max-w-[25px] circle so the row height stays
-                  bounded regardless of container width. */}
+                  flex-1 wrapper so the row height stays bounded regardless
+                  of container width. Pixel widths give consistent variety
+                  across wide and narrow screens. */}
               <div className="flex gap-2 flex-1">
                 {Array.from({ length: 10 }).map((_, periodIndex) => (
                   <div
@@ -38,8 +39,8 @@ function SkeletonDeploymentsList({ itemCount = 5 }) {
                     className="flex items-center justify-center h-[25px] flex-1 min-w-0"
                   >
                     <div
-                      className="rounded-full bg-gray-200 aspect-square max-w-[25px] animate-pulse"
-                      style={{ width: `${20 + ((periodIndex * 7) % 60)}%` }}
+                      className="rounded-full bg-gray-200 aspect-square animate-pulse"
+                      style={{ width: `${10 + ((periodIndex * 5) % 16)}px` }}
                     />
                   </div>
                 ))}

--- a/src/renderer/src/ui/SkeletonDeploymentsList.jsx
+++ b/src/renderer/src/ui/SkeletonDeploymentsList.jsx
@@ -28,15 +28,17 @@ function SkeletonDeploymentsList({ itemCount = 5 }) {
                   <div className="h-6 w-6 bg-gray-200 rounded animate-pulse" />
                 </div>
               </div>
-              {/* Activity periods skeleton */}
+              {/* Activity periods skeleton — matches DeploymentRow's h-[25px]
+                  flex-1 wrapper + max-w-[25px] circle so the row height stays
+                  bounded regardless of container width. */}
               <div className="flex gap-2 flex-1">
                 {Array.from({ length: 10 }).map((_, periodIndex) => (
                   <div
                     key={periodIndex}
-                    className="flex items-center justify-center aspect-square w-[5%]"
+                    className="flex items-center justify-center h-[25px] flex-1 min-w-0"
                   >
                     <div
-                      className="rounded-full bg-gray-200 aspect-square animate-pulse"
+                      className="rounded-full bg-gray-200 aspect-square max-w-[25px] animate-pulse"
                       style={{ width: `${20 + ((periodIndex * 7) % 60)}%` }}
                     />
                   </div>


### PR DESCRIPTION
## Summary

<img width="3118" height="486" alt="image" src="https://github.com/user-attachments/assets/1417270a-e1aa-4c00-8cb4-953f7a6f0d12" />

<img width="570" height="485" alt="image" src="https://github.com/user-attachments/assets/671f6310-1fe3-462e-bbc9-6a07b55d5c69" />


- Deployments timeline (header date markers + per-row period circles) now adapts to the screen width: more dates and more circles as the window gets wider.
- A `ResizeObserver` in `LocationsList` measures the timeline column. `dateCount` recomputes live (~1 per 150px, clamped 2–15). `periodCount` is bucketed to multiples of 10 (~1 per 30px) so we don't refetch on every pixel of resize.
- `periodCount` threads through preload → IPC handler → sequences worker → SQL aggregation in `getDeploymentsActivity`. The renderer's `useQuery` keys on it with `keepPreviousData: true` so rows don't disappear during the bucket-crossing refetch. Optimistic `setQueryData` calls switched to `setQueriesData` with prefix matching so they patch every cached `periodCount` variant.
- Layout swapped from fixed percentages (`width: 20%`, `w-[5%]`) to `flex-1 min-w-0` so date markers and circles auto-distribute regardless of count.
- Skeleton row updated to mirror the bounded `h-[25px]` / `max-w-[25px]` circle layout so its row height no longer balloons on wide screens.

## Test plan

- [x] `npm run dev`, open a study with deployments, resize from ~800px to full screen — date labels grow from ~5 to ~10+, circles from 20 to 40+, with one refetch per crossed multiple of 10.
- [x] Resize back narrower — counts decrease again, no overflow or wrap.
- [x] Edit a deployment's lat/lng inline — optimistic update still patches the row immediately.
- [x] Rename a location — optimistic update applies across cached variants.
- [x] Initial load shows the skeleton at the same row height as real rows (no inflated squares).
- [x] `npm test` passes.