### PR TITLE
feat(ui): hide study/settings tab labels below lg breakpoint

### DIFF
--- a/src/renderer/src/study.jsx
+++ b/src/renderer/src/study.jsx
@@ -149,6 +149,13 @@ export default function Study() {
     enabled: !!id
   })
 
+  const { importStatus } = useImportStatus(id)
+  const isImportActive =
+    study?.importerName?.startsWith('local/') &&
+    importStatus &&
+    importStatus.total > 0 &&
+    importStatus.total > importStatus.done
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -166,24 +173,24 @@ export default function Study() {
       <header className="w-full border-b border-gray-200 sticky top-0 bg-white z-10">
         <div className="flex items-center">
           <nav aria-label="Tabs" className="-mb-px flex space-x-8 px-4">
-            <Tab to={`/study/${id}`} icon={NotebookText} end>
+            <Tab to={`/study/${id}`} icon={NotebookText} end compact={isImportActive}>
               Overview
             </Tab>
-            <Tab to={`/study/${id}/activity`} icon={ChartBar}>
+            <Tab to={`/study/${id}/activity`} icon={ChartBar} compact={isImportActive}>
               Activity
             </Tab>
-            <Tab to={`/study/${id}/media`} icon={Image}>
+            <Tab to={`/study/${id}/media`} icon={Image} compact={isImportActive}>
               Media
             </Tab>
-            <Tab to={`/study/${id}/deployments`} icon={Cctv}>
+            <Tab to={`/study/${id}/deployments`} icon={Cctv} compact={isImportActive}>
               Deployments
             </Tab>
             {study?.importerName?.startsWith('local/') && (
-              <Tab to={`/study/${id}/files`} icon={FolderOpen}>
+              <Tab to={`/study/${id}/files`} icon={FolderOpen} compact={isImportActive}>
                 Files
               </Tab>
             )}
-            <Tab to={`/study/${id}/settings`} icon={Settings}>
+            <Tab to={`/study/${id}/settings`} icon={Settings} compact={isImportActive}>
               Settings
             </Tab>
           </nav>

--- a/src/renderer/src/ui/Tab.jsx
+++ b/src/renderer/src/ui/Tab.jsx
@@ -24,7 +24,9 @@ export function Tab({ to, icon: Icon, children, end = false, indicator = null, c
       {({ isActive }) => (
         <>
           <Icon size={20} className={classNames(isActive ? 'text-blue-600' : 'text-gray-500')} />
-          <span className={compact ? 'sr-only' : 'sr-only lg:not-sr-only'}>{children}</span>
+          <span className={compact ? 'sr-only xl:not-sr-only' : 'sr-only lg:not-sr-only'}>
+            {children}
+          </span>
           {indicator}
         </>
       )}

--- a/src/renderer/src/ui/Tab.jsx
+++ b/src/renderer/src/ui/Tab.jsx
@@ -11,6 +11,7 @@ export function Tab({ to, icon: Icon, children, end = false, indicator = null })
     <NavLink
       to={to}
       end={end}
+      title={typeof children === 'string' ? children : undefined}
       className={({ isActive }) =>
         classNames(
           isActive
@@ -23,7 +24,7 @@ export function Tab({ to, icon: Icon, children, end = false, indicator = null })
       {({ isActive }) => (
         <>
           <Icon size={20} className={classNames(isActive ? 'text-blue-600' : 'text-gray-500')} />
-          {children}
+          <span className="sr-only lg:not-sr-only">{children}</span>
           {indicator}
         </>
       )}

--- a/src/renderer/src/ui/Tab.jsx
+++ b/src/renderer/src/ui/Tab.jsx
@@ -6,7 +6,7 @@ function classNames(...classes) {
 }
 
 // Tab component
-export function Tab({ to, icon: Icon, children, end = false, indicator = null }) {
+export function Tab({ to, icon: Icon, children, end = false, indicator = null, compact = false }) {
   return (
     <NavLink
       to={to}
@@ -24,7 +24,7 @@ export function Tab({ to, icon: Icon, children, end = false, indicator = null })
       {({ isActive }) => (
         <>
           <Icon size={20} className={classNames(isActive ? 'text-blue-600' : 'text-gray-500')} />
-          <span className="sr-only lg:not-sr-only">{children}</span>
+          <span className={compact ? 'sr-only' : 'sr-only lg:not-sr-only'}>{children}</span>
           {indicator}
         </>
       )}


### PR DESCRIPTION
## Summary
- Tab labels now hide below 1024px (`lg`) so the study bar (Overview, Activity, Media, Deployments, Files, Settings) and the settings tab bar don't overflow on narrow windows
- Icons remain visible at all widths; labels stay accessible to screen readers via `sr-only` and surface as a native browser tooltip via `title` on hover

## Test plan
- [x] Resize app below 1024px on the study page — only icons visible, hovering shows the tab name
- [x] Resize at 1024px+ — full label + icon shown
- [x] Same checks on the Settings page
- [x] Verify nothing breaks while an import is running (ImportStatus block on the right)