### PR TITLE
fix(files): truncate long import paths from the start

### DIFF
--- a/src/renderer/src/files.jsx
+++ b/src/renderer/src/files.jsx
@@ -80,9 +80,15 @@ export default function Files({ studyId }) {
         {Object.entries(importFolders).map(([importFolder, directories]) => (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200" key={importFolder}>
             <div className="px-6 py-4 border-b border-gray-200">
-              <div className="flex items-center justify-between">
-                <div>{importFolder}</div>
-                <div className="text-sm text-gray-500">
+              <div className="flex items-center justify-between gap-4">
+                <div
+                  className="min-w-0 flex-1 truncate"
+                  style={{ direction: 'rtl', textAlign: 'left' }}
+                  title={importFolder}
+                >
+                  {'‎' + importFolder}
+                </div>
+                <div className="text-sm text-gray-500 flex-shrink-0">
                   {directories.length} {directories.length === 1 ? 'directory' : 'directories'}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Long import folder paths in the Files tab were getting cut off on small screens
- Truncate from the start (e.g. \`…/etm/camtrapdp/images\`) so the deeper, more identifying folder stays visible
- Full path remains available via \`title\` tooltip on hover

## Implementation
CSS-only via \`direction: rtl\` + \`text-align: left\` on the path container, with a leading LRM character to anchor the leading \`/\`. Truncation only kicks in when the flex item runs out of space.

## Test plan
- [x] Wide window: full path renders normally, no ellipsis
- [x] Narrow window: path truncates from the start with \`…\` prefix
- [x] Hover: tooltip shows the full untruncated path
- [x] Directory count on the right stays pinned and doesn't shrink