### PR TITLE
feat(species): sort non-species processing labels below humans/vehicles

### DIFF
--- a/src/renderer/src/utils/speciesUtils.js
+++ b/src/renderer/src/utils/speciesUtils.js
@@ -9,12 +9,35 @@ import { BLANK_SENTINEL } from '../../../shared/constants.js'
 // Re-export for convenience
 export { BLANK_SENTINEL }
 
+// Processing/camera labels some camera-trap studies use for unusable frames
+// (broken camera, blurred image, deliberately skipped). Sort below real
+// observations but above the blank sentinel.
+const NON_SPECIES_LABELS = new Set([
+  'problem',
+  'blurred',
+  'ignore',
+  'misfire',
+  'setup_pickup',
+  'unclassifiable'
+])
+
 /**
  * Check if a species entry represents blank media (no observations)
  * @param {string} scientificName - The scientific name to check
  * @returns {boolean} - True if this is the blank sentinel value
  */
 export const isBlank = (scientificName) => scientificName === BLANK_SENTINEL
+
+/**
+ * Check if a label is a known non-species processing marker (not an animal).
+ * Match is case-insensitive and trims surrounding whitespace.
+ * @param {string} scientificName
+ * @returns {boolean}
+ */
+export const isNonSpeciesLabel = (scientificName) => {
+  if (!scientificName || typeof scientificName !== 'string') return false
+  return NON_SPECIES_LABELS.has(scientificName.trim().toLowerCase())
+}
 
 /**
  * Check if a species is human or vehicle (should be sorted to bottom of lists)
@@ -42,8 +65,9 @@ export const isHumanOrVehicle = (scientificName) => {
 }
 
 /**
- * Sort species data with humans/vehicles near the bottom and blanks at the very end.
- * Order: regular species (by count) > humans/vehicles (by count) > blank
+ * Sort species data with humans/vehicles near the bottom, processing labels
+ * (problem/blurred/ignore/...) below them, and blanks at the very end.
+ * Order: regular species > humans/vehicles > non-species labels > blank
  * @param {Array} data - Array of species objects with scientificName and count properties
  * @returns {Array} - Sorted array (does not mutate original)
  */
@@ -54,6 +78,11 @@ export const sortSpeciesHumansLast = (data) => {
     const aIsBlank = isBlank(a.scientificName)
     const bIsBlank = isBlank(b.scientificName)
     if (aIsBlank !== bIsBlank) return aIsBlank ? 1 : -1
+
+    // Then non-species processing labels
+    const aIsNonSpecies = isNonSpeciesLabel(a.scientificName)
+    const bIsNonSpecies = isNonSpeciesLabel(b.scientificName)
+    if (aIsNonSpecies !== bIsNonSpecies) return aIsNonSpecies ? 1 : -1
 
     // Then humans/vehicles
     const aIsHumanVehicle = isHumanOrVehicle(a.scientificName)
@@ -66,15 +95,21 @@ export const sortSpeciesHumansLast = (data) => {
 }
 
 /**
- * Get the top N non-human/vehicle/blank species, sorted by count descending.
+ * Get the top N real species (excluding humans/vehicles, blanks, and non-species
+ * processing labels), sorted by count descending.
  * Used for default species selection in Activity and Media tabs.
  * @param {Array} data - Array of species objects with scientificName and count properties
  * @param {number} n - Number of species to return (default: 2)
- * @returns {Array} - Top N non-human/vehicle/blank species
+ * @returns {Array} - Top N real species
  */
 export const getTopNonHumanSpecies = (data, n = 2) => {
   if (!data || !Array.isArray(data)) return []
   return sortSpeciesHumansLast(data)
-    .filter((s) => !isHumanOrVehicle(s.scientificName) && !isBlank(s.scientificName))
+    .filter(
+      (s) =>
+        !isHumanOrVehicle(s.scientificName) &&
+        !isBlank(s.scientificName) &&
+        !isNonSpeciesLabel(s.scientificName)
+    )
     .slice(0, n)
 }

--- a/test/renderer/speciesUtils.test.js
+++ b/test/renderer/speciesUtils.test.js
@@ -1,0 +1,103 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isNonSpeciesLabel,
+  sortSpeciesHumansLast,
+  getTopNonHumanSpecies,
+  BLANK_SENTINEL
+} from '../../src/renderer/src/utils/speciesUtils.js'
+
+describe('isNonSpeciesLabel', () => {
+  test('returns true for the six known processing labels (case-insensitive)', () => {
+    for (const label of [
+      'problem',
+      'blurred',
+      'ignore',
+      'misfire',
+      'setup_pickup',
+      'unclassifiable'
+    ]) {
+      assert.equal(isNonSpeciesLabel(label), true, `expected true for ${label}`)
+      assert.equal(
+        isNonSpeciesLabel(label.toUpperCase()),
+        true,
+        `expected true for ${label.toUpperCase()}`
+      )
+    }
+  })
+
+  test('trims surrounding whitespace before matching', () => {
+    assert.equal(isNonSpeciesLabel('  problem  '), true)
+  })
+
+  test('returns false for real species and human/vehicle labels', () => {
+    assert.equal(isNonSpeciesLabel('Vulpes vulpes'), false)
+    assert.equal(isNonSpeciesLabel('Homo sapiens'), false)
+    assert.equal(isNonSpeciesLabel('vehicle'), false)
+  })
+
+  test('returns false for unknown/unidentified/other labels (intentionally NOT in this tier)', () => {
+    assert.equal(isNonSpeciesLabel('unknown'), false)
+    assert.equal(isNonSpeciesLabel('unidentified_bird'), false)
+    assert.equal(isNonSpeciesLabel('other'), false)
+  })
+
+  test('returns false for null/undefined/empty', () => {
+    assert.equal(isNonSpeciesLabel(null), false)
+    assert.equal(isNonSpeciesLabel(undefined), false)
+    assert.equal(isNonSpeciesLabel(''), false)
+  })
+})
+
+describe('sortSpeciesHumansLast — non-species tier', () => {
+  test('order is: regular species → humans/vehicles → non-species labels → blank', () => {
+    const data = [
+      { scientificName: BLANK_SENTINEL, count: 1000 },
+      { scientificName: 'problem', count: 200 },
+      { scientificName: 'Homo sapiens', count: 100 },
+      { scientificName: 'Vulpes vulpes', count: 50 },
+      { scientificName: 'blurred', count: 10 }
+    ]
+    const sorted = sortSpeciesHumansLast(data).map((s) => s.scientificName)
+    assert.deepEqual(sorted, [
+      'Vulpes vulpes',
+      'Homo sapiens',
+      'problem',
+      'blurred',
+      BLANK_SENTINEL
+    ])
+  })
+
+  test('within the non-species tier, sorts by count descending', () => {
+    const data = [
+      { scientificName: 'ignore', count: 5 },
+      { scientificName: 'misfire', count: 50 },
+      { scientificName: 'problem', count: 20 },
+      { scientificName: 'Vulpes vulpes', count: 100 }
+    ]
+    const sorted = sortSpeciesHumansLast(data).map((s) => s.scientificName)
+    assert.deepEqual(sorted, ['Vulpes vulpes', 'misfire', 'problem', 'ignore'])
+  })
+
+  test('non-species labels sort below humans/vehicles even with higher count', () => {
+    const data = [
+      { scientificName: 'problem', count: 10000 },
+      { scientificName: 'Homo sapiens', count: 1 }
+    ]
+    const sorted = sortSpeciesHumansLast(data).map((s) => s.scientificName)
+    assert.deepEqual(sorted, ['Homo sapiens', 'problem'])
+  })
+})
+
+describe('getTopNonHumanSpecies — non-species tier excluded', () => {
+  test('non-species labels are excluded from the top-N default selection', () => {
+    const data = [
+      { scientificName: 'problem', count: 1000 },
+      { scientificName: 'blurred', count: 800 },
+      { scientificName: 'Vulpes vulpes', count: 50 },
+      { scientificName: 'Canis lupus', count: 30 }
+    ]
+    const top2 = getTopNonHumanSpecies(data, 2).map((s) => s.scientificName)
+    assert.deepEqual(top2, ['Vulpes vulpes', 'Canis lupus'])
+  })
+})


### PR DESCRIPTION
## Summary

Some camera-trap studies use processing/camera labels (`problem`, `blurred`, `ignore`, `misfire`, `setup_pickup`, `unclassifiable`) to mark unusable frames. Previously these sorted alongside real species in the species distribution list — they could even appear at the top of small studies. This PR pushes them to the bottom of the list, just above the `Blank` row.

## Order

`regular species → humans/vehicles → non-species labels → blank`

(Was: `regular species → humans/vehicles → blank`.)

## Labels

I scanned all 30+ local studies for `scientificName` / `commonName` values that aren't real species. The six in this set are the pure processing markers (not animals at all). Intentionally **not** included in this tier:

- `unknown` / `unidentified_*` — these are real animal observations with uncertain ID. Belongs with regular species.
- `other` / `*_other` — residual catch-all buckets, also real observations.

## Side effect

`getTopNonHumanSpecies` (used to seed default selections in Activity/Media tabs) now also excludes these labels — so a study with a huge `problem` count won't pre-select `problem` as one of the top two species.

## Test plan
- [x] `npm test` — 950 tests pass (was 941; 9 new)
- [x] `npm run lint` — no new errors (only pre-existing warnings)
- [x] `npm run format:check` — clean
- [x] Visual check in app: open a study with `problem`/`blurred`/`ignore` labels, confirm they appear above `Blank` and below humans/vehicles in the Species sidebar