### PR TITLE
fix(overview): IUCN legend uses 2-col grid on narrow widths

### DIFF
--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -190,9 +190,9 @@ export default function SpeciesDistribution({ studyId, speciesData, taxonomicDat
 
 function IucnLegend() {
   return (
-    <div className="mt-3 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500">
-      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 md:flex md:flex-wrap md:items-center">
-        <span className="col-span-2 md:col-auto">IUCN status:</span>
+    <div className="mt-3 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500 flex items-start gap-x-4">
+      <span className="flex-shrink-0 leading-5">IUCN status:</span>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
         <LegendItem code="NE" label="Not Evaluated" />
         <LegendItem code="LC" label="Least Concern" />
         <LegendItem code="NT" label="Near Threatened" />

--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -190,14 +190,16 @@ export default function SpeciesDistribution({ studyId, speciesData, taxonomicDat
 
 function IucnLegend() {
   return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-3 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500">
-      <span>IUCN status:</span>
-      <LegendItem code="NE" label="Not Evaluated" />
-      <LegendItem code="LC" label="Least Concern" />
-      <LegendItem code="NT" label="Near Threatened" />
-      <LegendItem code="VU" label="Vulnerable" />
-      <LegendItem code="EN" label="Endangered" />
-      <LegendItem code="CR" label="Critically Endangered" />
+    <div className="mt-3 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500">
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 md:flex md:flex-wrap md:items-center">
+        <span className="col-span-2 md:col-auto">IUCN status:</span>
+        <LegendItem code="NE" label="Not Evaluated" />
+        <LegendItem code="LC" label="Least Concern" />
+        <LegendItem code="NT" label="Near Threatened" />
+        <LegendItem code="VU" label="Vulnerable" />
+        <LegendItem code="EN" label="Endangered" />
+        <LegendItem code="CR" label="Critically Endangered" />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

<img width="437" height="153" alt="image" src="https://github.com/user-attachments/assets/f0fbf995-0a32-4209-b5ca-7d86b5e417c8" />


- The single `flex flex-wrap` IUCN legend row orphaned `CR Critically Endangered` onto its own line when the overview panel was narrow.
- Below the `md` breakpoint, switch to a 2-column grid with `IUCN status:` on its own line so all six items align consistently.
- At `md` and above, the existing inline flex-wrap layout is preserved unchanged.

## Test plan
- [x] `npm run dev`, open a study's Overview tab.
- [x] Resize window from wide to narrow and confirm the legend transitions cleanly across the 768px breakpoint with no orphaned items.
- [x] Hover an IUCN badge in both layouts and confirm the native title tooltip still shows `<code> — <label> (IUCN Red List)`.