### PR TITLE
fix(overview): skip hover card on best captures when no wiki image or blurb

### DIFF
--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -4,6 +4,7 @@ import * as HoverCard from '@radix-ui/react-hover-card'
 import { ChevronLeft, ChevronRight, CameraOff, X, Heart, Play, Loader2 } from 'lucide-react'
 import { useCommonName } from '../utils/commonNames'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
+import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
@@ -687,6 +688,11 @@ function MediaCard({ media, onClick, studyId }) {
 
   // No species attached → no hover card (e.g., misc captures)
   if (!media.scientificName) return cardButton
+
+  // No Wikipedia image and no blurb → skip the hover card; the name + IUCN badge
+  // alone aren't worth the popup (e.g., Impala/Roan in Nkhotakota).
+  const info = resolveSpeciesInfo(media.scientificName)
+  if (!info?.imageUrl && !info?.blurb) return cardButton
 
   return (
     <HoverCard.Root openDelay={200} closeDelay={120}>


### PR DESCRIPTION
## Summary
- Suppress the species hover card on the Overview "Best captures" carousel when the species has neither a Wikipedia image nor a blurb (e.g., Impala/Roan in the Nkhotakota Camera Traps study), so hovering no longer opens an empty card with just a name and IUCN badge.

## Test plan
- [x] Open the Nkhotakota Camera Traps study → Overview tab → hover an Impala or Roan thumbnail in Best captures → no hover card appears.
- [x] Hover a species with a Wikipedia image and/or blurb → hover card still appears with image and blurb as before.
- [x] Hover a thumbnail with no scientific name (misc capture) → no hover card (unchanged).