### PR TITLE
feat(overview): mouse-wheel scrolling on best captures + featured species carousels

### DIFF
--- a/src/renderer/src/hooks/useHorizontalWheelScroll.js
+++ b/src/renderer/src/hooks/useHorizontalWheelScroll.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+/**
+ * Translate vertical mouse-wheel input into horizontal scroll on the
+ * referenced element. Native horizontal gestures (trackpad swipe, shift+wheel)
+ * are left alone.
+ */
+export function useHorizontalWheelScroll(ref) {
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const onWheel = (e) => {
+      if (e.deltaY === 0) return
+      e.preventDefault()
+      el.scrollLeft += e.deltaY
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [ref])
+}

--- a/src/renderer/src/overview/CommonSpeciesFallback.jsx
+++ b/src/renderer/src/overview/CommonSpeciesFallback.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { Children, cloneElement, useEffect, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router'
 import * as HoverCard from '@radix-ui/react-hover-card'
@@ -8,6 +8,7 @@ import { useCommonName } from '../utils/commonNames'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import { isBlank, isDomestic, isHumanOrVehicle, isNonSpeciesLabel } from '../utils/speciesUtils'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
+import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll'
 
 const TOP_N = 8
 
@@ -81,6 +82,9 @@ function ScrollableStrip({ children }) {
   const containerRef = useRef(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(false)
+  const [scrollSignal, setScrollSignal] = useState(0)
+
+  useHorizontalWheelScroll(containerRef)
 
   useEffect(() => {
     const container = containerRef.current
@@ -91,12 +95,17 @@ function ScrollableStrip({ children }) {
       setCanScrollRight(container.scrollLeft < container.scrollWidth - container.clientWidth - 5)
     }
 
-    container.addEventListener('scroll', checkScroll)
+    const onScroll = () => {
+      checkScroll()
+      setScrollSignal((s) => s + 1)
+    }
+
+    container.addEventListener('scroll', onScroll)
     checkScroll()
     window.addEventListener('resize', checkScroll)
 
     return () => {
-      container.removeEventListener('scroll', checkScroll)
+      container.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', checkScroll)
     }
   }, [children])
@@ -143,19 +152,24 @@ function ScrollableStrip({ children }) {
         className="flex gap-3 overflow-x-auto scrollbar-hide py-3"
         style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
       >
-        {children}
+        {Children.map(children, (child) => cloneElement(child, { scrollSignal }))}
       </div>
     </div>
   )
 }
 
-function SpeciesReferenceCard({ species, studyId, onClick }) {
+function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
   const [imageError, setImageError] = useState(false)
+  const [hoverOpen, setHoverOpen] = useState(false)
   const commonName =
     useCommonName(species.scientificName) || species.scientificName || 'Unknown species'
 
+  useEffect(() => {
+    if (scrollSignal > 0) setHoverOpen(false)
+  }, [scrollSignal])
+
   return (
-    <HoverCard.Root openDelay={200} closeDelay={120}>
+    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={200} closeDelay={120}>
       <HoverCard.Trigger asChild>
         <button
           type="button"

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight, CameraOff, X, Heart, Play, Loader2 } from 'l
 import { useCommonName } from '../utils/commonNames'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
+import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll'
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
@@ -564,10 +565,15 @@ function VideoViewerModal({
 /**
  * Individual media card for the carousel (supports both images and videos)
  */
-function MediaCard({ media, onClick, studyId }) {
+function MediaCard({ media, onClick, studyId, scrollSignal }) {
   const [imageError, setImageError] = useState(false)
   const [thumbnailUrl, setThumbnailUrl] = useState(null)
   const [isExtractingThumbnail, setIsExtractingThumbnail] = useState(false)
+  const [hoverOpen, setHoverOpen] = useState(false)
+
+  useEffect(() => {
+    if (scrollSignal > 0) setHoverOpen(false)
+  }, [scrollSignal])
 
   const isVideo = isVideoMedia(media)
 
@@ -695,7 +701,7 @@ function MediaCard({ media, onClick, studyId }) {
   if (!info?.imageUrl && !info?.blurb) return cardButton
 
   return (
-    <HoverCard.Root openDelay={200} closeDelay={120}>
+    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={200} closeDelay={120}>
       <HoverCard.Trigger asChild>{cardButton}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
@@ -728,6 +734,7 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
   const [canScrollLeft, setCanScrollLeft] = useState(false)
   const [canScrollRight, setCanScrollRight] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(null)
+  const [scrollSignal, setScrollSignal] = useState(0)
   const carouselRef = useRef(null)
   const queryClient = useQueryClient()
 
@@ -757,6 +764,8 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
     refetchInterval: isRunning ? 5000 : false // Poll every 5s during ML run
   })
 
+  useHorizontalWheelScroll(carouselRef)
+
   // Check scroll state when media changes or on resize
   useEffect(() => {
     if (!carouselRef.current) return
@@ -768,13 +777,18 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
       setCanScrollRight(container.scrollLeft < container.scrollWidth - container.clientWidth - 5)
     }
 
+    const onScroll = () => {
+      checkScroll()
+      setScrollSignal((s) => s + 1)
+    }
+
     const container = carouselRef.current
-    container.addEventListener('scroll', checkScroll)
+    container.addEventListener('scroll', onScroll)
     checkScroll()
     window.addEventListener('resize', checkScroll)
 
     return () => {
-      container?.removeEventListener('scroll', checkScroll)
+      container?.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', checkScroll)
     }
   }, [bestMedia])
@@ -844,6 +858,7 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
               media={media}
               onClick={() => setSelectedIndex(index)}
               studyId={studyId}
+              scrollSignal={scrollSignal}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Vertical mouse-wheel input over the best captures and featured species carousels now scrolls them horizontally instead of moving the page (matches Netflix-style horizontal shelves).
- Open species hover cards close when either carousel scrolls, mirroring the existing pattern in the species distribution list.
- Adds a small shared `useHorizontalWheelScroll` hook to keep the wheel-translation logic in one place.

## Test plan
- [x] Hover over the best captures carousel and roll the mouse wheel — carousel scrolls horizontally, page does not move.
- [x] Same check on the featured species strip (when shown as the best-captures fallback).
- [x] Open a hover card on a card, then scroll the carousel — hover card closes.
- [x] Trackpad two-finger horizontal swipe still works as before (we only intercept `deltaY`).
- [x] Chevron buttons + edge fades still behave correctly.