### PR TITLE
ui(overview): cap max width at 1950px on wide screens

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -248,7 +248,7 @@ export default function Overview({ data, studyId, studyName }) {
   const error = speciesError?.message || deploymentsError?.message || null
 
   return (
-    <div className="flex flex-col px-6 h-full overflow-x-hidden">
+    <div className="flex flex-col px-6 h-full overflow-x-hidden max-w-[1950px]">
       <PanelGroup direction="vertical" autoSaveId="overview-layout">
         <Panel defaultSize={50} minSize={20} className="flex flex-col">
           <div className="flex flex-col gap-6 h-full pt-4 pb-2 pr-1">


### PR DESCRIPTION
## Summary
- Adds `max-w-[1950px]` to the overview tab's outer container so it stops sprawling on ultrawide displays
- Stays left-aligned (no `mx-auto`) so the layout flushes against the sidebar instead of centering

## Test plan
- [x] Open the overview on a standard 1080p/1440p screen — layout unchanged
- [x] Open on an ultrawide / very wide screen — content caps at 1950px and is left-aligned