### PR TITLE
Hover card on study list rows

### DIFF
--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -8,6 +8,7 @@ import Import from './import'
 import Study from './study'
 import SettingsPage from './settings'
 import DeleteStudyModal from './DeleteStudyModal'
+import StudyHoverCard from './ui/StudyHoverCard'
 import { useEffect, useState, useRef } from 'react'
 
 // Create a client outside the component to avoid recreation
@@ -99,6 +100,10 @@ function AppContent() {
 
   const [showSkeleton, setShowSkeleton] = useState(true)
   const skeletonShownAt = useRef(Date.now())
+
+  // Bumped on every sidebar scroll — child hover cards watch this and close
+  // so the card doesn't drift while its anchor row scrolls.
+  const [scrollSignal, setScrollSignal] = useState(0)
 
   const { data: studies = [], isLoading } = useQuery({
     queryKey: ['studies'],
@@ -361,6 +366,7 @@ function AppContent() {
         <div
           className="flex-1 overflow-y-auto scrollbar-hide"
           style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}
+          onScroll={() => setScrollSignal((s) => s + 1)}
         >
           {showSkeleton && (
             <div className="p-2 space-y-1">
@@ -398,43 +404,53 @@ function AppContent() {
               </div>
             )}
           <div data-testid="studies-list" className="p-2">
-            {filteredStudies.map((study) => (
-              <div
-                key={study.id}
-                data-testid={`study-item-${study.id}`}
-                onContextMenu={(e) => handleContextMenu(e, study)}
-              >
-                {renamingStudyId === study.id ? (
-                  <input
-                    ref={renameInputRef}
-                    type="text"
-                    value={renameValue}
-                    onChange={(e) => setRenameValue(e.target.value)}
-                    onKeyDown={handleRenameKeyDown}
-                    onBlur={saveRename}
-                    className="w-full px-3 py-2.5 rounded-lg text-sm border border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
+            {filteredStudies.map((study) => {
+              const isCurrentStudy = location.pathname.includes(`/study/${study.id}`)
+              const showHoverCard =
+                renamingStudyId !== study.id && !isCurrentStudy && contextMenu === null
+              const navLink = (
+                <NavLink
+                  to={`/study/${study.id}`}
+                  className={({ isActive }) =>
+                    `w-full flex items-center gap-2 px-3 py-2.5 rounded-lg text-sm transition-all group mb-1 ${
+                      isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
+                    }`
+                  }
+                >
+                  <span className="flex-1 text-left truncate">{study.name}</span>
+                  <ChevronRight
+                    className={`h-4 w-4 flex-shrink-0 transition-opacity ${
+                      isCurrentStudy ? 'opacity-100' : 'opacity-0 group-hover:opacity-50'
+                    }`}
                   />
-                ) : (
-                  <NavLink
-                    to={`/study/${study.id}`}
-                    className={({ isActive }) =>
-                      `w-full flex items-center gap-2 px-3 py-2.5 rounded-lg text-sm transition-all group mb-1 ${
-                        isActive ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'
-                      }`
-                    }
-                  >
-                    <span className="flex-1 text-left truncate">{study.name}</span>
-                    <ChevronRight
-                      className={`h-4 w-4 flex-shrink-0 transition-opacity ${
-                        location.pathname.includes(`/study/${study.id}`)
-                          ? 'opacity-100'
-                          : 'opacity-0 group-hover:opacity-50'
-                      }`}
+                </NavLink>
+              )
+              return (
+                <div
+                  key={study.id}
+                  data-testid={`study-item-${study.id}`}
+                  onContextMenu={(e) => handleContextMenu(e, study)}
+                >
+                  {renamingStudyId === study.id ? (
+                    <input
+                      ref={renameInputRef}
+                      type="text"
+                      value={renameValue}
+                      onChange={(e) => setRenameValue(e.target.value)}
+                      onKeyDown={handleRenameKeyDown}
+                      onBlur={saveRename}
+                      className="w-full px-3 py-2.5 rounded-lg text-sm border border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500 mb-1"
                     />
-                  </NavLink>
-                )}
-              </div>
-            ))}
+                  ) : showHoverCard ? (
+                    <StudyHoverCard study={study} scrollSignal={scrollSignal}>
+                      {navLink}
+                    </StudyHoverCard>
+                  ) : (
+                    navLink
+                  )}
+                </div>
+              )
+            })}
           </div>
         </div>
 

--- a/src/renderer/src/ui/StudyHoverCard.jsx
+++ b/src/renderer/src/ui/StudyHoverCard.jsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react'
+import * as HoverCard from '@radix-ui/react-hover-card'
+import { useQuery } from '@tanstack/react-query'
+import {
+  PawPrint,
+  Camera,
+  CalendarDays,
+  Eye,
+  Image as ImageIcon,
+  AlertTriangle
+} from 'lucide-react'
+import { formatStatNumber, formatSpan, formatRangeShort } from '../overview/utils/formatStats'
+
+/**
+ * Hover card for a study list row in the sidebar. Shows title, description,
+ * a compact KPI strip, and a contributors byline. Stats are fetched lazily
+ * on first hover and cached for the session.
+ *
+ * @param {Object} props
+ * @param {Object} props.study - Study object as returned by getStudies()
+ *   (must include `id`, `name`, and optionally `data.{description,contributors}`).
+ * @param {number} props.scrollSignal - Bumped by the parent on scroll;
+ *   resets the open state so the card doesn't ride along with its anchor.
+ * @param {React.ReactNode} props.children - The trigger element (a NavLink).
+ */
+export default function StudyHoverCard({ study, scrollSignal, children }) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (scrollSignal > 0) setOpen(false)
+  }, [scrollSignal])
+
+  const { data: stats, isLoading } = useQuery({
+    queryKey: ['studyHoverStats', study.id],
+    queryFn: async () => {
+      const r = await window.api.getOverviewStats(study.id)
+      if (r.error) throw new Error(r.error)
+      return r.data
+    },
+    enabled: open,
+    staleTime: Infinity
+  })
+
+  return (
+    <HoverCard.Root open={open} onOpenChange={setOpen} openDelay={200} closeDelay={120}>
+      <HoverCard.Trigger asChild>{children}</HoverCard.Trigger>
+      <HoverCard.Portal>
+        <HoverCard.Content
+          side="right"
+          sideOffset={8}
+          align="start"
+          avoidCollisions
+          collisionPadding={16}
+          className="z-[10001] w-80 bg-white rounded-lg shadow-xl border border-gray-200 p-4"
+        >
+          <Body study={study} stats={stats} isLoading={isLoading} />
+        </HoverCard.Content>
+      </HoverCard.Portal>
+    </HoverCard.Root>
+  )
+}
+
+function Body({ study, stats, isLoading }) {
+  const description = study.data?.description
+  const contributors = study.data?.contributors || []
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h3 className="text-base font-semibold text-gray-900 capitalize leading-tight">
+        {study.name}
+      </h3>
+
+      {description && (
+        <p className="text-xs text-gray-600 leading-relaxed line-clamp-2">{description}</p>
+      )}
+
+      <KpiStrip stats={stats} isLoading={isLoading} />
+
+      {contributors.length > 0 && <ContributorsLine contributors={contributors} />}
+    </div>
+  )
+}
+
+function KpiStrip({ stats, isLoading }) {
+  if (isLoading || !stats) {
+    return (
+      <div className="flex flex-col gap-1.5">
+        <div className="h-3 bg-gray-200 rounded animate-pulse w-3/4" />
+        <div className="h-3 bg-gray-200 rounded animate-pulse w-2/3" />
+      </div>
+    )
+  }
+
+  const { speciesCount, threatenedCount, cameraCount, observationCount, mediaCount, derivedRange } =
+    stats
+  const span = formatSpan(derivedRange?.start, derivedRange?.end)
+  const rangeLabel = formatRangeShort(derivedRange?.start, derivedRange?.end)
+
+  return (
+    <div className="flex flex-col gap-1.5 text-xs text-gray-700">
+      <div className="flex items-center gap-3 flex-wrap">
+        <Stat icon={<PawPrint size={12} />}>{formatStatNumber(speciesCount)} species</Stat>
+        <Stat icon={<Camera size={12} />}>{formatStatNumber(cameraCount)} deployments</Stat>
+        {span !== '—' && (
+          <Stat icon={<CalendarDays size={12} />} title={rangeLabel || undefined}>
+            {span}
+          </Stat>
+        )}
+      </div>
+      <div className="flex items-center gap-3 flex-wrap">
+        <Stat icon={<Eye size={12} />}>{formatStatNumber(observationCount)} obs</Stat>
+        <Stat icon={<ImageIcon size={12} />}>{formatStatNumber(mediaCount)} media</Stat>
+        {threatenedCount > 0 && (
+          <span className="inline-flex items-center gap-1 text-amber-700">
+            <AlertTriangle size={12} />
+            {formatStatNumber(threatenedCount)} threatened
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Stat({ icon, children, title }) {
+  return (
+    <span className="inline-flex items-center gap-1" title={title}>
+      <span className="text-gray-500">{icon}</span>
+      {children}
+    </span>
+  )
+}
+
+function ContributorsLine({ contributors }) {
+  const visible = contributors.slice(0, 3)
+  const overflow = contributors.length - visible.length
+
+  return (
+    <div className="text-[0.7rem] text-gray-500 pt-2 border-t border-gray-100 flex items-center gap-1 flex-wrap">
+      <span className="text-gray-400">By</span>
+      {visible.map((c, i) => (
+        <span key={i} className="flex items-center gap-1">
+          <span className="text-gray-600">{displayName(c)}</span>
+          {i < visible.length - 1 && <span className="text-gray-300">·</span>}
+        </span>
+      ))}
+      {overflow > 0 && (
+        <>
+          <span className="text-gray-300">·</span>
+          <span className="text-gray-400">+{overflow} more</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+function displayName(c) {
+  if (c.title) return c.title
+  return `${c.firstName || ''} ${c.lastName || ''}`.trim() || 'Unnamed'
+}


### PR DESCRIPTION
## Summary
- Adds a hover card on each study list row in the sidebar showing the study title, description, a compact KPI strip (species/deployments/span ▸ obs/media/threatened), and a read-only contributors byline
- Stats are fetched lazily on first hover via `getOverviewStats` and cached for the session (`staleTime: Infinity`)
- Suppressed on the currently-active study row, during rename, and while the right-click context menu is open; closes when the sidebar scrolls

## Test plan
- [x] Hover a non-active study row → card appears after ~200ms with title, description, numbers, contributors
- [x] Hover the currently-selected study row → no card
- [x] Open the rename input or right-click context menu → no card
- [x] Scroll the sidebar with the card open → card closes
- [x] KPI numbers match the Overview tab's KPI band for the same study
- [x] Studies with no description / no contributors render cleanly (sections hidden)