### PR TITLE
feat(deployments): add 'No observations' (blanks) row to species filter

### DIFF
--- a/docs/specs/2026-05-02-deployments-tab-revamp-design.md
+++ b/docs/specs/2026-05-02-deployments-tab-revamp-design.md
@@ -326,3 +326,41 @@ is unchanged.
   `getSequences`.
 - `docs/architecture.md` — note the new `DeploymentDetailPane` and the
   shared `Gallery` extraction in the renderer's component tree.
+
+## Iterations beyond v1
+
+Landed during the implementation cycle on top of the v1 spec above.
+None of these change the architecture or non-goals; they're additive
+polish on the detail-pane chrome.
+
+- **Inline rename in the detail-pane header.** The deployment name is
+  rendered via `EditableLocationName` (extracted from `deployments.jsx`)
+  so users can rename a deployment from the same place they see its
+  media. New shared file: `src/renderer/src/deployments/EditableLocationName.jsx`.
+- **Species filter popover.** A filter button next to ✕ opens a popover
+  listing species observed at this deployment (one row per species:
+  common name + scientific name + media count). Click rows to toggle;
+  selection threads into `Gallery`'s `species` prop. Hovering a row
+  opens the project's `SpeciesTooltipContent` card. New IPC
+  `deployments:get-species` and DB query `getSpeciesForDeployment`.
+- **"No observations" (blanks) row.** The species filter popover
+  appends a synthetic row at the bottom for media at the deployment
+  with no observations. Reuses the existing `BLANK_SENTINEL` convention
+  — the sequences-paginated query already special-cases it on input,
+  so the popover passes it straight through.
+- **Top-row swap.** Map and list swapped horizontally — list on the
+  left (~62%), map on the right (~38%). The list timeline uses width
+  productively; the map's geography reads at any size.
+- **Subtle open/close animation.** 180ms fade-in + slide-up when the
+  detail pane mounts; 150ms fade-out via deferred unmount. Doesn't
+  retrigger on deployment-to-deployment swaps because the inner
+  `DeploymentDetailPane` keeps its own `key={deploymentID}` for state
+  isolation.
+- **Map polish.** `rounded-xl` + `shadow-md` chrome matching the
+  Overview tab; `max-h-[500px]` cap so the map doesn't stretch on tall
+  windows; `ImageModal` z-index raised to `z-[9999]` so it sits above
+  Leaflet's map controls.
+- **`embedded` prop on `Gallery`.** When set (true for
+  `DeploymentMediaGallery`), the controls bar and outer `bg-white
+  rounded border` chrome are dropped — the detail pane provides the
+  surrounding shell instead.

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -125,6 +125,13 @@ export async function getAllDeployments(dbPath) {
  * input, so the popover can pass it straight through to filter for
  * blanks.
  *
+ * Edge case: a media whose only observations have empty or NULL
+ * `scientificName` is neither a species nor a blank here — the species
+ * rows skip empty-name observations, and the blank count uses NOT
+ * EXISTS (any observation row disqualifies). Matches the convention in
+ * `getMediaForSequencePagination` so the popover and gallery agree on
+ * what "blank" means.
+ *
  * @param {string} dbPath - Path to the SQLite database
  * @param {string} deploymentID
  * @returns {Promise<Array<{scientificName: string, count: number}>>}

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -2,10 +2,11 @@
  * Deployment-related database queries
  */
 
-import { getDrizzleDb, deployments, observations } from '../index.js'
+import { getDrizzleDb, deployments, media, observations } from '../index.js'
 import { eq, desc, sql } from 'drizzle-orm'
 import log from 'electron-log'
 import { getStudyIdFromPath } from './utils.js'
+import { BLANK_SENTINEL } from '../../../shared/constants.js'
 
 /**
  * Get one deployment row per unique (latitude, longitude) — intended for
@@ -118,6 +119,12 @@ export async function getAllDeployments(dbPath) {
  * Not sequence-aware (counts are media, not sequences) — the popover only
  * needs the species set; exact counts are a nice-to-have.
  *
+ * Includes a synthetic row with `scientificName === BLANK_SENTINEL` and
+ * a count of media at this deployment that have no observations. The
+ * sequences-paginated query already special-cases BLANK_SENTINEL on
+ * input, so the popover can pass it straight through to filter for
+ * blanks.
+ *
  * @param {string} dbPath - Path to the SQLite database
  * @param {string} deploymentID
  * @returns {Promise<Array<{scientificName: string, count: number}>>}
@@ -140,9 +147,31 @@ export async function getSpeciesForDeployment(dbPath, deploymentID) {
       .groupBy(observations.scientificName)
       .orderBy(desc(sql`count`))
 
+    // Count media at this deployment with zero matching observations.
+    // Same NOT EXISTS shape the sequences query uses for BLANK_SENTINEL.
+    const blankRows = await db
+      .select({ count: sql`COUNT(*)`.as('count') })
+      .from(media)
+      .where(
+        sql`${media.deploymentID} = ${deploymentID} AND NOT EXISTS (SELECT 1 FROM ${observations} WHERE ${observations.mediaID} = ${media.mediaID})`
+      )
+    const blankCount = Number(blankRows[0]?.count || 0)
+
+    const result = rows.map((r) => ({
+      scientificName: r.scientificName,
+      count: Number(r.count)
+    }))
+    // Blanks pinned to the bottom of the list — keeps the species rows in
+    // count-desc order while still surfacing the no-observations bucket.
+    if (blankCount > 0) {
+      result.push({ scientificName: BLANK_SENTINEL, count: blankCount })
+    }
+
     const elapsedTime = Date.now() - startTime
-    log.info(`Retrieved ${rows.length} species for deployment ${deploymentID} in ${elapsedTime}ms`)
-    return rows.map((r) => ({ scientificName: r.scientificName, count: Number(r.count) }))
+    log.info(
+      `Retrieved ${rows.length} species (+ ${blankCount} blanks) for deployment ${deploymentID} in ${elapsedTime}ms`
+    )
+    return result
   } catch (error) {
     log.error(`Error querying species for deployment: ${error.message}`)
     throw error

--- a/src/renderer/src/deployments/DeploymentDetailPane.jsx
+++ b/src/renderer/src/deployments/DeploymentDetailPane.jsx
@@ -6,6 +6,7 @@ import DeploymentMediaGallery from '../media/DeploymentMediaGallery'
 import EditableLocationName from './EditableLocationName'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
+import { BLANK_SENTINEL } from '../../../shared/constants.js'
 
 /**
  * Bottom-pane container for the Deployments tab. Mounted only when a
@@ -170,47 +171,66 @@ function SpeciesFilterButton({ studyId, deploymentID, selectedSpecies, onChange 
 }
 
 function SpeciesFilterRow({ studyId, scientificName, count, isSelected, onToggle, scrollSignal }) {
-  const commonName = resolveCommonName(scientificName)
+  const isBlank = scientificName === BLANK_SENTINEL
+  const commonName = isBlank ? null : resolveCommonName(scientificName)
   const [hoverOpen, setHoverOpen] = useState(false)
   // Close any open card when the popover scrolls.
   useEffect(() => {
     if (scrollSignal > 0) setHoverOpen(false)
   }, [scrollSignal])
 
+  // Blanks (media with no observations) skip the species hover card —
+  // there's no scientificName to look up.
+  const rowButton = (
+    <button
+      onClick={onToggle}
+      className={`w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors ${
+        isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
+      }`}
+    >
+      <span
+        className={`flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center ${
+          isSelected ? 'bg-blue-500 border-blue-500' : 'border-gray-300 bg-white'
+        }`}
+      >
+        {isSelected && <Check size={12} className="text-white" />}
+      </span>
+      <span className="flex-1 min-w-0">
+        {isBlank ? (
+          <span
+            className={`block text-sm truncate italic ${
+              isSelected ? 'text-blue-900 font-medium' : 'text-gray-600'
+            }`}
+          >
+            No observations
+          </span>
+        ) : (
+          <>
+            <span
+              className={`block text-sm truncate ${commonName ? 'capitalize' : ''} ${
+                isSelected ? 'text-blue-900 font-medium' : 'text-gray-800'
+              }`}
+            >
+              {commonName || scientificName}
+            </span>
+            {commonName && (
+              <span className="block text-xs italic text-gray-500 truncate">{scientificName}</span>
+            )}
+          </>
+        )}
+      </span>
+      <span className="flex-shrink-0 text-xs tabular-nums text-gray-500">{count}</span>
+    </button>
+  )
+
+  if (isBlank) {
+    return <li>{rowButton}</li>
+  }
+
   return (
     <li>
       <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={250} closeDelay={120}>
-        <HoverCard.Trigger asChild>
-          <button
-            onClick={onToggle}
-            className={`w-full flex items-center gap-2 px-3 py-1.5 text-left transition-colors ${
-              isSelected ? 'bg-blue-50 hover:bg-blue-100' : 'hover:bg-gray-50'
-            }`}
-          >
-            <span
-              className={`flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center ${
-                isSelected ? 'bg-blue-500 border-blue-500' : 'border-gray-300 bg-white'
-              }`}
-            >
-              {isSelected && <Check size={12} className="text-white" />}
-            </span>
-            <span className="flex-1 min-w-0">
-              <span
-                className={`block text-sm truncate ${commonName ? 'capitalize' : ''} ${
-                  isSelected ? 'text-blue-900 font-medium' : 'text-gray-800'
-                }`}
-              >
-                {commonName || scientificName}
-              </span>
-              {commonName && (
-                <span className="block text-xs italic text-gray-500 truncate">
-                  {scientificName}
-                </span>
-              )}
-            </span>
-            <span className="flex-shrink-0 text-xs tabular-nums text-gray-500">{count}</span>
-          </button>
-        </HoverCard.Trigger>
+        <HoverCard.Trigger asChild>{rowButton}</HoverCard.Trigger>
         <HoverCard.Portal>
           <HoverCard.Content
             side="left"

--- a/test/main/database/queries/getSpeciesForDeployment.test.js
+++ b/test/main/database/queries/getSpeciesForDeployment.test.js
@@ -18,6 +18,7 @@ import {
   insertMedia,
   insertObservations
 } from '../../../../src/main/database/index.js'
+import { BLANK_SENTINEL } from '../../../../src/shared/constants.js'
 
 let testBiowatchDataPath
 let testDbPath
@@ -164,5 +165,68 @@ describe('getSpeciesForDeployment', () => {
     await seed()
     const rows = await getSpeciesForDeployment(testDbPath, 'does-not-exist')
     assert.deepEqual(rows, [])
+  })
+
+  test('appends a BLANK_SENTINEL row at the end when the deployment has media without observations', async () => {
+    const manager = await createImageDirectoryDatabase(testDbPath)
+    await insertDeployments(manager, {
+      d1: {
+        deploymentID: 'd1',
+        locationID: 'loc1',
+        locationName: 'Site A',
+        deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+        deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+        latitude: 1,
+        longitude: 1,
+        cameraID: 'cam1'
+      }
+    })
+    await insertMedia(manager, {
+      'with-obs.jpg': {
+        mediaID: 'with-obs',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-01T10:00:00Z'),
+        filePath: '/with-obs.jpg',
+        fileName: 'with-obs.jpg'
+      },
+      'blank-1.jpg': {
+        mediaID: 'blank-1',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-02T10:00:00Z'),
+        filePath: '/blank-1.jpg',
+        fileName: 'blank-1.jpg'
+      },
+      'blank-2.jpg': {
+        mediaID: 'blank-2',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-03T10:00:00Z'),
+        filePath: '/blank-2.jpg',
+        fileName: 'blank-2.jpg'
+      }
+    })
+    await insertObservations(manager, [
+      {
+        observationID: 'o1',
+        mediaID: 'with-obs',
+        deploymentID: 'd1',
+        scientificName: 'Vulpes vulpes'
+      }
+    ])
+
+    const rows = await getSpeciesForDeployment(testDbPath, 'd1')
+    // Species first, blanks at the bottom.
+    assert.equal(rows[0].scientificName, 'Vulpes vulpes')
+    assert.equal(rows[0].count, 1)
+    assert.equal(rows[rows.length - 1].scientificName, BLANK_SENTINEL)
+    assert.equal(rows[rows.length - 1].count, 2)
+  })
+
+  test('omits the BLANK_SENTINEL row when there are no blanks', async () => {
+    await seed() // every d1 media has at least one observation
+    const rows = await getSpeciesForDeployment(testDbPath, 'd1')
+    assert.equal(
+      rows.find((r) => r.scientificName === BLANK_SENTINEL),
+      undefined
+    )
   })
 })

--- a/test/main/database/queries/getSpeciesForDeployment.test.js
+++ b/test/main/database/queries/getSpeciesForDeployment.test.js
@@ -221,6 +221,49 @@ describe('getSpeciesForDeployment', () => {
     assert.equal(rows[rows.length - 1].count, 2)
   })
 
+  test('returns only the BLANK_SENTINEL row when the deployment has only blank media', async () => {
+    const manager = await createImageDirectoryDatabase(testDbPath)
+    await insertDeployments(manager, {
+      d1: {
+        deploymentID: 'd1',
+        locationID: 'loc1',
+        locationName: 'Site A',
+        deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+        deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+        latitude: 1,
+        longitude: 1,
+        cameraID: 'cam1'
+      }
+    })
+    await insertMedia(manager, {
+      'blank-1.jpg': {
+        mediaID: 'blank-1',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-01T10:00:00Z'),
+        filePath: '/blank-1.jpg',
+        fileName: 'blank-1.jpg'
+      },
+      'blank-2.jpg': {
+        mediaID: 'blank-2',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-02T10:00:00Z'),
+        filePath: '/blank-2.jpg',
+        fileName: 'blank-2.jpg'
+      },
+      'blank-3.jpg': {
+        mediaID: 'blank-3',
+        deploymentID: 'd1',
+        timestamp: DateTime.fromISO('2024-06-03T10:00:00Z'),
+        filePath: '/blank-3.jpg',
+        fileName: 'blank-3.jpg'
+      }
+    })
+    // No observations at all — every media is blank.
+
+    const rows = await getSpeciesForDeployment(testDbPath, 'd1')
+    assert.deepEqual(rows, [{ scientificName: BLANK_SENTINEL, count: 3 }])
+  })
+
   test('omits the BLANK_SENTINEL row when there are no blanks', async () => {
     await seed() // every d1 media has at least one observation
     const rows = await getSpeciesForDeployment(testDbPath, 'd1')


### PR DESCRIPTION
Stacked on top of #476 — must merge after that one.

## Summary

The species-filter popover in the Deployments tab gains a "No observations" row pinned to the bottom, with a count of media at the selected deployment that have no observations. Selecting it filters the gallery to blanks only via the existing `BLANK_SENTINEL` convention.

## Changes

- **`src/main/database/queries/deployments.js`** — `getSpeciesForDeployment` now appends a synthetic `{ scientificName: BLANK_SENTINEL, count }` row when the deployment has any blank media. Uses the same `NOT EXISTS` shape the sequences-paginated query uses on the input side, so the popover passes the sentinel straight through.
- **`src/renderer/src/deployments/DeploymentDetailPane.jsx`** — `SpeciesFilterRow` detects the sentinel and renders a distinct "No observations" italic row. No species hover card (nothing to look up). The checkbox + count column behavior is identical to species rows.
- **`test/main/database/queries/getSpeciesForDeployment.test.js`** — two new test cases: (1) blanks row appears at the end with the correct count when the deployment has unobserved media, (2) blanks row is omitted entirely when there are none.

The sequences pagination already handles `species.includes(BLANK_SENTINEL)` (verified earlier in PR #476), so no backend filter changes are needed beyond surfacing the count.

## Test plan
- [ ] Deployment with blanks → "No observations" row at the bottom of the popover with correct count
- [ ] Click it → gallery filters to blanks only
- [ ] Combine with a species pill → gallery shows both
- [ ] Deployment with no blanks → row absent
- [ ] Hovering the row does NOT open the species hover card