### PR TITLE
feat(media-modal): move zoom control into top toolbar

### DIFF
--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -1134,6 +1134,65 @@ function ImageModal({
                 <Info size={18} />
               </button>
 
+              {!isVideoMedia(media) && !isDrawMode && (
+                <>
+                  {!isZoomed ? (
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        zoomIn()
+                      }}
+                      className="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:bg-gray-100 transition-colors"
+                      aria-label="Zoom in"
+                      title="Zoom in (+)"
+                    >
+                      <ZoomIn size={18} />
+                    </button>
+                  ) : (
+                    <div className="flex items-center">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          zoomOut()
+                        }}
+                        disabled={zoomTransform.scale <= 1}
+                        className="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        aria-label="Zoom out"
+                        title="Zoom out (-)"
+                      >
+                        <ZoomOut size={18} />
+                      </button>
+                      <span className="text-xs text-gray-600 font-medium min-w-[2.75rem] text-center tabular-nums">
+                        {Math.round(zoomTransform.scale * 100)}%
+                      </span>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          zoomIn()
+                        }}
+                        disabled={zoomTransform.scale >= 5}
+                        className="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                        aria-label="Zoom in"
+                        title="Zoom in (+)"
+                      >
+                        <ZoomIn size={18} />
+                      </button>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          resetZoom()
+                        }}
+                        className="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:bg-gray-100 transition-colors"
+                        aria-label="Reset zoom"
+                        title="Reset zoom (0)"
+                      >
+                        <RotateCcw size={16} />
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+
               <div className="w-px h-5 bg-gray-200 mx-1" />
 
               <button
@@ -1387,49 +1446,6 @@ function ImageModal({
                       />
                     )}
                   </div>
-
-                  {/* Zoom controls - positioned at top center, outside the transformed container */}
-                  {!isDrawMode && (
-                    <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-2 bg-black/70 rounded-full px-3 py-1.5 shadow-lg">
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          zoomOut()
-                        }}
-                        className="p-1 text-white hover:text-blue-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        disabled={zoomTransform.scale <= 1}
-                        title="Zoom out (-)"
-                      >
-                        <ZoomOut size={18} />
-                      </button>
-                      <span className="text-white text-sm font-medium min-w-[3rem] text-center">
-                        {Math.round(zoomTransform.scale * 100)}%
-                      </span>
-                      <button
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          zoomIn()
-                        }}
-                        className="p-1 text-white hover:text-blue-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        disabled={zoomTransform.scale >= 5}
-                        title="Zoom in (+)"
-                      >
-                        <ZoomIn size={18} />
-                      </button>
-                      {isZoomed && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            resetZoom()
-                          }}
-                          className="p-1 text-white hover:text-blue-300 transition-colors ml-1"
-                          title="Reset zoom (0 or Esc)"
-                        >
-                          <RotateCcw size={16} />
-                        </button>
-                      )}
-                    </div>
-                  )}
                 </>
               )}
             </div>


### PR DESCRIPTION
## Summary

- Replaces the floating zoom pill rendered over the image with an inline control in the modal's top toolbar — the previous pill could overlap detections and animals.
- At rest: a single **ZoomIn** icon sits in the right cluster of the top bar (between **Info** and the close divider). Clicking it zooms in one step.
- When zoomed: it expands inline to **ZoomOut · percentage · ZoomIn · Reset**, styled to match the other top-bar buttons.
- Hidden for video and draw mode (matches prior behavior). Keyboard shortcuts (`+`, `-`, `0`) unchanged.

## Test plan

- [x] Open the media modal on an image, verify the **ZoomIn** icon shows in the top bar between **Info** and the close button.
- [x] Click the icon → image zooms to 125%, top bar replaces the icon with the expanded strip in place.
- [x] Use `+`/`-`/`0` shortcuts and the wheel; verify the percentage label tracks and the **Reset** button collapses the strip back to the single icon.
- [x] Open the modal on a video → no zoom UI appears.
- [x] Enter draw mode on an image → zoom UI hidden; exit draw mode → it reappears.
- [x] Resize the modal narrower while zoomed; verify the timestamp truncates rather than the zoom strip overflowing.