### PR TITLE
ui(overview): make all sections fit; tighten for small screens

### DIFF
--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -217,9 +217,36 @@ function DeploymentMap({ deployments, studyId }) {
 // Overview — the editorial showcase tab.
 // ──────────────────────────────────────────────────────────────────────────
 
+// Pixels the bottom panel needs to keep visible: BestCaptures band
+// (~220px) + species header + 3 rows (~108px) + tightened IUCN legend +
+// vertical padding/gaps. Used to compute a dynamic `minSize` % on the
+// bottom panel so the resizer can never crush the species list below
+// 3 visible rows.
+const BOTTOM_MIN_PX = 440
+
 export default function Overview({ data, studyId, studyName }) {
   const { importStatus } = useImportStatus(studyId)
   const { sequenceGap } = useSequenceGap(studyId)
+
+  const containerRef = useRef(null)
+  const [bottomMinPercent, setBottomMinPercent] = useState(40)
+
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el) return
+    const compute = () => {
+      const h = el.clientHeight
+      if (h <= 0) return
+      // Cap at 65 so the user can still grow the top section meaningfully.
+      // Floor at 30 so very tall windows don't pin the resizer too high.
+      const pct = Math.min(65, Math.max(30, Math.ceil((BOTTOM_MIN_PX / h) * 100)))
+      setBottomMinPercent(pct)
+    }
+    compute()
+    const ro = new ResizeObserver(compute)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
 
   const { data: deploymentsData, error: deploymentsError } = useQuery({
     queryKey: ['deploymentLocations', studyId],
@@ -248,33 +275,44 @@ export default function Overview({ data, studyId, studyName }) {
   const error = speciesError?.message || deploymentsError?.message || null
 
   return (
-    <div className="flex flex-col px-6 h-full overflow-x-hidden max-w-[1950px]">
+    <div
+      ref={containerRef}
+      className="@container flex flex-col px-6 h-full overflow-x-hidden max-w-[1950px]"
+    >
       <PanelGroup direction="vertical" autoSaveId="overview-layout">
-        <Panel defaultSize={50} minSize={20} className="flex flex-col">
-          <div className="flex flex-col gap-6 h-full pt-4 pb-2 pr-1">
-            <EditorialHeader
-              studyId={studyId}
-              studyName={studyName}
-              studyData={data}
-              mapSlot={
-                <DeploymentMap key={studyId} deployments={deploymentsData} studyId={studyId} />
-              }
-            />
-            <KpiBand studyId={studyId} studyData={data} isImporting={importStatus?.isRunning} />
+        <Panel defaultSize={50} minSize={30} className="flex flex-col">
+          <div className="flex flex-col gap-4 h-full pt-4 pb-2 pr-1 min-h-0">
+            <div className="flex-1 min-h-0">
+              <EditorialHeader
+                studyId={studyId}
+                studyName={studyName}
+                studyData={data}
+                mapSlot={
+                  <DeploymentMap key={studyId} deployments={deploymentsData} studyId={studyId} />
+                }
+              />
+            </div>
+            <div className="flex-shrink-0">
+              <KpiBand studyId={studyId} studyData={data} isImporting={importStatus?.isRunning} />
+            </div>
           </div>
         </Panel>
 
         <PanelResizeHandle className="h-1 my-1.5 rounded-full bg-gray-100 hover:bg-gray-300 data-[resize-handle-state=drag]:bg-blue-300 cursor-row-resize transition-colors" />
 
-        <Panel defaultSize={50} minSize={20} className="flex flex-col">
-          <div className="flex flex-col gap-6 overflow-y-auto pt-2 pb-4 pr-1">
-            <BestCapturesSection studyId={studyId} isRunning={importStatus?.isRunning} />
-            <SpeciesDistribution
-              studyId={studyId}
-              speciesData={speciesData}
-              taxonomicData={data?.taxonomic || null}
-            />
-            {error && <div className="text-red-500 text-sm">Error: {error}</div>}
+        <Panel defaultSize={50} minSize={bottomMinPercent} className="flex flex-col">
+          <div className="flex flex-col gap-4 h-full pt-2 pb-1 pr-1 min-h-0">
+            <div className="flex-shrink-0">
+              <BestCapturesSection studyId={studyId} isRunning={importStatus?.isRunning} />
+            </div>
+            <div className="flex-1 min-h-0">
+              <SpeciesDistribution
+                studyId={studyId}
+                speciesData={speciesData}
+                taxonomicData={data?.taxonomic || null}
+              />
+            </div>
+            {error && <div className="text-red-500 text-sm flex-shrink-0">Error: {error}</div>}
           </div>
         </Panel>
       </PanelGroup>

--- a/src/renderer/src/overview/EditorialHeader.jsx
+++ b/src/renderer/src/overview/EditorialHeader.jsx
@@ -142,7 +142,7 @@ export default function EditorialHeader({ studyId, studyName, studyData, mapSlot
   }, [description, editingDescription])
 
   return (
-    <header className="grid grid-cols-[minmax(20rem,_42%)_1fr] gap-6 flex-1 min-h-[18rem] min-h-0 overflow-hidden">
+    <header className="grid grid-cols-[minmax(20rem,_50%)_1fr] @7xl:grid-cols-[minmax(20rem,_42%)_1fr] gap-6 h-full min-h-0 overflow-hidden">
       <div className="group flex flex-col min-h-0">
         {/* Title */}
         <div className="flex items-baseline gap-2">

--- a/src/renderer/src/overview/KpiBand.jsx
+++ b/src/renderer/src/overview/KpiBand.jsx
@@ -125,7 +125,7 @@ export default function KpiBand({ studyId, studyData, isImporting }) {
   }
 
   return (
-    <div className="grid grid-cols-5 gap-2.5">
+    <div className="grid grid-cols-5 gap-2 @7xl:gap-2.5">
       <div className="flex" ref={speciesTriggerRef}>
         <KpiTile
           icon={<PawPrint size={ICON_SIZE} />}

--- a/src/renderer/src/overview/KpiTile.jsx
+++ b/src/renderer/src/overview/KpiTile.jsx
@@ -27,7 +27,7 @@ export default function KpiTile({ icon, label, value, sub, subAccent, onEdit, on
     <Tag
       type={interactive ? 'button' : undefined}
       onClick={interactive ? action : undefined}
-      className={`group relative w-full bg-white border border-gray-200 rounded-lg px-3.5 py-3.5 text-left transition-shadow flex flex-col ${
+      className={`group relative w-full bg-white border border-gray-200 rounded-lg px-3 py-2.5 @7xl:px-3.5 @7xl:py-3.5 text-left transition-shadow flex flex-col ${
         interactive
           ? 'cursor-pointer hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-300'
           : ''
@@ -41,14 +41,14 @@ export default function KpiTile({ icon, label, value, sub, subAccent, onEdit, on
         />
       )}
 
-      <div className="flex items-center justify-center gap-1.5 mb-1.5 text-blue-600">
+      <div className="flex items-center justify-center gap-1.5 mb-1 @7xl:mb-1.5 text-blue-600">
         {icon}
         <span className="text-[0.65rem] font-semibold tracking-wide text-gray-500 uppercase">
           {label}
         </span>
       </div>
 
-      <div className="text-2xl font-bold text-gray-900 tabular-nums leading-none text-center">
+      <div className="text-xl @7xl:text-2xl font-bold text-gray-900 tabular-nums leading-none text-center">
         {value}
       </div>
 
@@ -57,7 +57,7 @@ export default function KpiTile({ icon, label, value, sub, subAccent, onEdit, on
           its siblings — the grid stretches all tiles to the tallest, and
           mt-auto keeps the visual baselines matching. */}
       {sub && (
-        <div className="mt-auto pt-2 text-[0.7rem] text-gray-500 text-center">
+        <div className="mt-auto pt-1.5 @7xl:pt-2 text-[0.7rem] text-gray-500 text-center">
           {subAccent && <span className="text-blue-700 font-semibold">{subAccent}</span>}
           {subAccent && ' '}
           {sub}

--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -148,8 +148,8 @@ export default function SpeciesDistribution({ studyId, speciesData, taxonomicDat
   }
 
   return (
-    <section className="flex flex-col min-h-0">
-      <h3 className="text-[0.7rem] uppercase tracking-wider text-gray-500 font-semibold mb-3">
+    <section className="flex flex-col h-full min-h-0">
+      <h3 className="text-[0.7rem] uppercase tracking-wider text-gray-500 font-semibold mb-3 flex-shrink-0">
         Species distribution
       </h3>
 
@@ -164,7 +164,10 @@ export default function SpeciesDistribution({ studyId, speciesData, taxonomicDat
         </div>
       ) : (
         <>
-          <div className="overflow-y-auto overflow-x-hidden pr-3" onScroll={handleScroll}>
+          <div
+            className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-3"
+            onScroll={handleScroll}
+          >
             {sortedSpecies.map((species) => {
               const storedCommonName = scientificToCommonMap[species.scientificName] || null
               return (
@@ -190,9 +193,9 @@ export default function SpeciesDistribution({ studyId, speciesData, taxonomicDat
 
 function IucnLegend() {
   return (
-    <div className="mt-3 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500 flex items-start gap-x-4">
-      <span className="flex-shrink-0 leading-5">IUCN status:</span>
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5">
+    <div className="mt-2 pt-3 border-t border-gray-100 text-[0.7rem] text-gray-500 flex items-start gap-x-3 flex-shrink-0">
+      <span className="flex-shrink-0 leading-4">IUCN:</span>
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 leading-4">
         <LegendItem code="NE" label="Not Evaluated" />
         <LegendItem code="LC" label="Least Concern" />
         <LegendItem code="NT" label="Near Threatened" />


### PR DESCRIPTION
## Summary
- Restructure the overview tab so the editorial header, KPI band, best captures, and species distribution are all visible at default — the resizer just redistributes between the two flexible regions (description+map and species list)
- Constrain the resizer so the bottom panel always shows at least 3 species rows (dynamic `minSize` computed from container height)
- Tighten layout for small containers via Tailwind v4 container queries: 50/50 description+map split below 1280px (vs 42/58 above), smaller KPI tile padding, value text, and gap; trimmed IUCN legend chrome and bottom padding

<img width="1503" height="867" alt="image" src="https://github.com/user-attachments/assets/3115b9af-41ed-456d-a6be-9b73f56a839d" />


## Test plan
- [x] On a 13" macOS window, all four sections (header+map, KpiBand, BestCaptures, SpeciesDistribution) are visible at first load without scrolling
- [x] Drag resizer all the way down — bottom panel still shows 3 species rows + IUCN legend
- [x] Drag resizer all the way up — top section still shows description, map, and the full KPI band
- [x] Resize the window narrower — description column widens (50/50) and KPI tile padding/text shrinks; widen past 1280px and the original spacing returns
- [x] Verify saved layout (`autoSaveId`) still loads correctly across reloads