### PR TITLE
ui(overview): vertically center carousel chevrons on image

### DIFF
--- a/src/renderer/src/overview/CommonSpeciesFallback.jsx
+++ b/src/renderer/src/overview/CommonSpeciesFallback.jsx
@@ -124,7 +124,7 @@ function ScrollableStrip({ children }) {
       {canScrollLeft && (
         <button
           type="button"
-          className="absolute left-0 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
+          className="absolute left-0 top-[5.75rem] -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
           onClick={() => scroll('left')}
           aria-label="Scroll left"
         >
@@ -134,7 +134,7 @@ function ScrollableStrip({ children }) {
       {canScrollRight && (
         <button
           type="button"
-          className="absolute right-0 top-1/2 -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
+          className="absolute right-0 top-[5.75rem] -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
           onClick={() => scroll('right')}
           aria-label="Scroll right"
         >

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -817,7 +817,7 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
         {/* Left scroll button */}
         {canScrollLeft && (
           <button
-            className="absolute left-0 top-1/2 translate-y-1 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
+            className="absolute left-0 top-[5.75rem] -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
             onClick={() => scroll('left')}
             aria-label="Scroll left"
           >
@@ -828,7 +828,7 @@ export default function BestMediaCarousel({ studyId, isRunning, renderEmpty }) {
         {/* Right scroll button */}
         {canScrollRight && (
           <button
-            className="absolute right-0 top-1/2 translate-y-1 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
+            className="absolute right-0 top-[5.75rem] -translate-y-1/2 z-10 bg-white/90 rounded-full p-1 shadow-md border border-gray-200"
             onClick={() => scroll('right')}
             aria-label="Scroll right"
           >


### PR DESCRIPTION
## Summary
- Anchor the prev/next chevrons of the Best Captures and Featured Species carousels to the image's vertical center (`top-[5.75rem] -translate-y-1/2`) instead of the geometric center of the strip — which sat below the image because the cards include a label area underneath.
- Also fixes an off-by-4px `translate-y-1` on the Best Captures chevrons.

## Test plan
- [x] Open the Overview tab on a study with enough best captures to require horizontal scrolling and confirm the chevrons sit visually centered on the image (not down by the label).
- [x] Repeat on a study that falls back to the Featured Species strip.