### PR TITLE
fix(sequences): tiebreak by fileName instead of filePath

### DIFF
--- a/src/main/services/sequences/grouping.js
+++ b/src/main/services/sequences/grouping.js
@@ -147,10 +147,11 @@ export function groupMediaIntoSequences(mediaFiles, gapThresholdSeconds, isVideo
         const timeA = new Date(a.timestamp).getTime()
         const timeB = new Date(b.timestamp).getTime()
         if (timeA !== timeB) return timeA - timeB
-        // Secondary sort by filePath for stable ordering when timestamps match
-        const pathA = a.filePath || ''
-        const pathB = b.filePath || ''
-        return pathA.localeCompare(pathB)
+        // Tiebreak by fileName: filePath is a random-UUID remote URL for
+        // Agouti/CamtrapDP imports, so sorting by filePath produces noise.
+        const nameA = a.fileName || ''
+        const nameB = b.fileName || ''
+        return nameA.localeCompare(nameB)
       })
 
       // Update startTime/endTime based on sorted items
@@ -228,10 +229,11 @@ export function groupMediaByEventID(mediaFiles) {
       const timeA = new Date(a.timestamp).getTime()
       const timeB = new Date(b.timestamp).getTime()
       if (timeA !== timeB) return timeA - timeB
-      // Secondary sort by filePath for stable ordering when timestamps match
-      const pathA = a.filePath || ''
-      const pathB = b.filePath || ''
-      return pathA.localeCompare(pathB)
+      // Tiebreak by fileName: filePath is a random-UUID remote URL for
+      // Agouti/CamtrapDP imports, so sorting by filePath produces noise.
+      const nameA = a.fileName || ''
+      const nameB = b.fileName || ''
+      return nameA.localeCompare(nameB)
     })
 
     sequences.push({

--- a/test/main/services/sequences/grouping.test.js
+++ b/test/main/services/sequences/grouping.test.js
@@ -507,54 +507,54 @@ describe('groupMediaIntoSequences', () => {
   })
 
   describe('same timestamp ordering', () => {
-    test('items with same timestamp are ordered by filePath ascending', () => {
+    test('items with same timestamp are ordered by fileName ascending', () => {
       const media = [
         {
           mediaID: 'c',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/IMAG0445.JPG',
+          fileName: 'IMAG0445.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'a',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/IMAG0443.JPG',
+          fileName: 'IMAG0443.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'b',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/IMAG0444.JPG',
+          fileName: 'IMAG0444.JPG',
           deploymentID: 'dep1'
         }
       ]
       const { sequences } = groupMediaIntoSequences(media, 60)
 
       assert.equal(sequences.length, 1)
-      // Should be ordered: 443, 444, 445 (by filePath)
-      assert.equal(sequences[0].items[0].filePath, 'KRU_S1/IMAG0443.JPG')
-      assert.equal(sequences[0].items[1].filePath, 'KRU_S1/IMAG0444.JPG')
-      assert.equal(sequences[0].items[2].filePath, 'KRU_S1/IMAG0445.JPG')
+      // Should be ordered: 443, 444, 445 (by fileName)
+      assert.equal(sequences[0].items[0].fileName, 'IMAG0443.JPG')
+      assert.equal(sequences[0].items[1].fileName, 'IMAG0444.JPG')
+      assert.equal(sequences[0].items[2].fileName, 'IMAG0445.JPG')
     })
 
-    test('sequence id uses first item by filePath when timestamps match', () => {
+    test('sequence id uses first item by fileName when timestamps match', () => {
       const media = [
         {
           mediaID: 'c',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/IMAG0445.JPG',
+          fileName: 'IMAG0445.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'a',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/IMAG0443.JPG',
+          fileName: 'IMAG0443.JPG',
           deploymentID: 'dep1'
         }
       ]
       const { sequences } = groupMediaIntoSequences(media, 60)
 
-      // 'a' has the earliest filePath, so it should be the sequence ID
+      // 'a' has the earliest fileName, so it should be the sequence ID
       assert.equal(sequences[0].id, 'a')
     })
 
@@ -563,27 +563,27 @@ describe('groupMediaIntoSequences', () => {
         {
           mediaID: 'm3',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0445.JPG',
+          fileName: 'KRU_S1_7_R1_IMAG0445.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'm2',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0444.JPG',
+          fileName: 'KRU_S1_7_R1_IMAG0444.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'm1',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0443.JPG',
+          fileName: 'KRU_S1_7_R1_IMAG0443.JPG',
           deploymentID: 'dep1'
         }
       ]
       const { sequences } = groupMediaIntoSequences(media, 60)
 
-      assert.equal(sequences[0].items[0].filePath, 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0443.JPG')
-      assert.equal(sequences[0].items[1].filePath, 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0444.JPG')
-      assert.equal(sequences[0].items[2].filePath, 'KRU_S1/7/7_R1/KRU_S1_7_R1_IMAG0445.JPG')
+      assert.equal(sequences[0].items[0].fileName, 'KRU_S1_7_R1_IMAG0443.JPG')
+      assert.equal(sequences[0].items[1].fileName, 'KRU_S1_7_R1_IMAG0444.JPG')
+      assert.equal(sequences[0].items[2].fileName, 'KRU_S1_7_R1_IMAG0445.JPG')
     })
 
     test('user example: KRU_S1_44_R1 files ordered correctly', () => {
@@ -591,47 +591,73 @@ describe('groupMediaIntoSequences', () => {
         {
           mediaID: 'm3',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0058.JPG',
+          fileName: 'KRU_S1_44_R1_IMAG0058.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'm2',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0057.JPG',
+          fileName: 'KRU_S1_44_R1_IMAG0057.JPG',
           deploymentID: 'dep1'
         },
         {
           mediaID: 'm1',
           timestamp: baseTime.toISOString(),
-          filePath: 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0056.JPG',
+          fileName: 'KRU_S1_44_R1_IMAG0056.JPG',
           deploymentID: 'dep1'
         }
       ]
       const { sequences } = groupMediaIntoSequences(media, 60)
 
       // Should be 56, 57, 58
-      assert.equal(sequences[0].items[0].filePath, 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0056.JPG')
-      assert.equal(sequences[0].items[1].filePath, 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0057.JPG')
-      assert.equal(sequences[0].items[2].filePath, 'KRU_S1/44/44_R1/KRU_S1_44_R1_IMAG0058.JPG')
+      assert.equal(sequences[0].items[0].fileName, 'KRU_S1_44_R1_IMAG0056.JPG')
+      assert.equal(sequences[0].items[1].fileName, 'KRU_S1_44_R1_IMAG0057.JPG')
+      assert.equal(sequences[0].items[2].fileName, 'KRU_S1_44_R1_IMAG0058.JPG')
     })
 
-    test('mixed timestamps still sorted correctly with filePath tiebreaker', () => {
+    test('mixed timestamps still sorted correctly with fileName tiebreaker', () => {
       const time1 = baseTime.toISOString()
       const time2 = new Date(baseTime.getTime() + 1000).toISOString()
       const media = [
-        { mediaID: 'm4', timestamp: time2, filePath: 'D.JPG', deploymentID: 'dep1' },
-        { mediaID: 'm2', timestamp: time1, filePath: 'B.JPG', deploymentID: 'dep1' },
-        { mediaID: 'm3', timestamp: time2, filePath: 'C.JPG', deploymentID: 'dep1' },
-        { mediaID: 'm1', timestamp: time1, filePath: 'A.JPG', deploymentID: 'dep1' }
+        { mediaID: 'm4', timestamp: time2, fileName: 'D.JPG', deploymentID: 'dep1' },
+        { mediaID: 'm2', timestamp: time1, fileName: 'B.JPG', deploymentID: 'dep1' },
+        { mediaID: 'm3', timestamp: time2, fileName: 'C.JPG', deploymentID: 'dep1' },
+        { mediaID: 'm1', timestamp: time1, fileName: 'A.JPG', deploymentID: 'dep1' }
       ]
       const { sequences } = groupMediaIntoSequences(media, 60)
 
       // All within 60s, so one sequence
       // Order: A.JPG (time1), B.JPG (time1), C.JPG (time2), D.JPG (time2)
-      assert.equal(sequences[0].items[0].filePath, 'A.JPG')
-      assert.equal(sequences[0].items[1].filePath, 'B.JPG')
-      assert.equal(sequences[0].items[2].filePath, 'C.JPG')
-      assert.equal(sequences[0].items[3].filePath, 'D.JPG')
+      assert.equal(sequences[0].items[0].fileName, 'A.JPG')
+      assert.equal(sequences[0].items[1].fileName, 'B.JPG')
+      assert.equal(sequences[0].items[2].fileName, 'C.JPG')
+      assert.equal(sequences[0].items[3].fileName, 'D.JPG')
+    })
+
+    test('Agouti-style filePath (random UUID) does not affect order — fileName wins', () => {
+      // Regression: GMU8 Leuven items had filePath like
+      //   https://multimedia.agouti.eu/assets/<random-uuid>/file
+      // so localeCompare on filePath produced UUID order, not filename order.
+      const media = [
+        {
+          mediaID: 'a',
+          timestamp: baseTime.toISOString(),
+          filePath: 'https://multimedia.agouti.eu/assets/d0f01610-zzz/file',
+          fileName: '20180601125157-101RECNX_IMG_0317.JPG',
+          deploymentID: 'dep1'
+        },
+        {
+          mediaID: 'b',
+          timestamp: baseTime.toISOString(),
+          filePath: 'https://multimedia.agouti.eu/assets/d58f72fa-aaa/file',
+          fileName: '20180601125157-101RECNX_IMG_0316.JPG',
+          deploymentID: 'dep1'
+        }
+      ]
+      const { sequences } = groupMediaIntoSequences(media, 60)
+
+      assert.equal(sequences[0].items[0].fileName, '20180601125157-101RECNX_IMG_0316.JPG')
+      assert.equal(sequences[0].items[1].fileName, '20180601125157-101RECNX_IMG_0317.JPG')
     })
   })
 
@@ -957,17 +983,17 @@ describe('groupMediaByEventID', () => {
   })
 
   describe('same timestamp ordering', () => {
-    test('items with same timestamp are ordered by filePath ascending', () => {
+    test('items with same timestamp are ordered by fileName ascending', () => {
       const media = [
-        { mediaID: 'c', timestamp: baseTime.toISOString(), eventID: 'e1', filePath: 'C.JPG' },
-        { mediaID: 'a', timestamp: baseTime.toISOString(), eventID: 'e1', filePath: 'A.JPG' },
-        { mediaID: 'b', timestamp: baseTime.toISOString(), eventID: 'e1', filePath: 'B.JPG' }
+        { mediaID: 'c', timestamp: baseTime.toISOString(), eventID: 'e1', fileName: 'C.JPG' },
+        { mediaID: 'a', timestamp: baseTime.toISOString(), eventID: 'e1', fileName: 'A.JPG' },
+        { mediaID: 'b', timestamp: baseTime.toISOString(), eventID: 'e1', fileName: 'B.JPG' }
       ]
       const { sequences } = groupMediaByEventID(media)
 
-      assert.equal(sequences[0].items[0].filePath, 'A.JPG')
-      assert.equal(sequences[0].items[1].filePath, 'B.JPG')
-      assert.equal(sequences[0].items[2].filePath, 'C.JPG')
+      assert.equal(sequences[0].items[0].fileName, 'A.JPG')
+      assert.equal(sequences[0].items[1].fileName, 'B.JPG')
+      assert.equal(sequences[0].items[2].fileName, 'C.JPG')
     })
   })
 


### PR DESCRIPTION
## Summary
- Within-sequence tiebreaker for items at identical timestamps now uses `fileName` instead of `filePath`.
- Reason: Agouti/CamtrapDP imports (e.g. GMU8 Leuven) store `filePath` as `https://multimedia.agouti.eu/assets/<random-uuid>/file`, so `localeCompare` on `filePath` was sorting by random UUID.
- Applied to both `groupMediaIntoSequences` and `groupMediaByEventID` in `src/main/services/sequences/grouping.js`. Added a regression test pinning the Agouti scenario.

## Repro / verification
GMU8 Leuven, items at the same/adjacent seconds:

| fileName | filePath UUID | timestamp |
|---|---|---|
| IMG_0315 | `75df59c0…` | 17:36:08 |
| IMG_0316 | `d58f72fa…` | 17:36:09 |
| IMG_0317 | `d0f01610…` | 17:36:09 |
| IMG_0318 | `18326681…` | 17:36:10 |

`d0f01610 < d58f72fa` → 0317 sorted before 0316. After the fix, sort is `0315, 0316, 0317, 0318`.

## Test plan
- [x] `npm test` — 1072/1072 pass
- [x] `npx prettier --write` and `npx eslint --cache` — clean
- [x] Reload GMU8 Leuven in the gallery and confirm bursts at tied timestamps render in filename order