### PR TITLE
feat(activity): show common names + React hovercard on map

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -13,7 +13,7 @@ import PlaceholderMap from './ui/PlaceholderMap'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
-import { getMapDisplayName } from './utils/commonNames'
+import { buildScientificToCommonMap, getMapDisplayName } from './utils/commonNames'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 
@@ -488,19 +488,12 @@ export default function Activity({ studyData, studyId }) {
 
   // scientificName -> English vernacular name from CamtrapDP imports.
   // Used by the map's marker tooltips and bottom-right legend so they can
-  // show common names alongside (or instead of) scientific names. Mirrors
-  // the same map built in speciesDistribution.jsx.
-  const scientificToCommon = useMemo(() => {
-    const map = {}
-    if (taxonomicData && Array.isArray(taxonomicData)) {
-      taxonomicData.forEach((taxon) => {
-        if (taxon.scientificName && taxon?.vernacularNames?.eng) {
-          map[taxon.scientificName] = taxon.vernacularNames.eng
-        }
-      })
-    }
-    return map
-  }, [taxonomicData])
+  // show common names alongside (or instead of) scientific names. Same
+  // helper feeds the species sidebar, so the two surfaces stay in sync.
+  const scientificToCommon = useMemo(
+    () => buildScientificToCommonMap(taxonomicData),
+    [taxonomicData]
+  )
 
   // Fetch sequence-aware species distribution data
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -2,15 +2,18 @@ import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import { MapPin } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { LayersControl, MapContainer, Marker, TileLayer, useMap } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import CircularTimeFilter, { DailyActivityRadar } from './ui/clock'
+import MarkerHoverCard from './ui/MarkerHoverCard'
 import PlaceholderMap from './ui/PlaceholderMap'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
+import { getMapDisplayName } from './utils/commonNames'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 
@@ -71,7 +74,8 @@ const SpeciesMap = ({
   selectedSpecies,
   palette,
   geoKey,
-  studyId
+  studyId,
+  scientificToCommon
 }) => {
   // Persist map layer selection per study
   const mapLayerKey = `mapLayer:${studyId}`
@@ -176,37 +180,20 @@ const SpeciesMap = ({
     })
   }
 
-  // Create tooltip content for species counts
-  const createTooltipContent = (counts) => {
-    const entries = Object.entries(counts)
-      .filter(([species]) => selectedSpecies.some((s) => s.scientificName === species))
-      .sort((a, b) => b[1] - a[1])
-
-    const total = entries.reduce((sum, [, count]) => sum + count, 0)
-
-    const rows = entries
-      .map(([species, count]) => {
-        const index = selectedSpecies.findIndex((s) => s.scientificName === species)
-        const color = palette[index % palette.length]
-        return `
-      <div style="display: flex; align-items: center; gap: 8px; padding: 2px 0;">
-        <span style="width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; background-color: ${color};"></span>
-        <span style="font-size: 12px; font-style: italic; flex: 1;">${species}</span>
-        <span style="font-size: 11px; color: #6b7280;">${count}</span>
-      </div>
-    `
-      })
-      .join('')
-
-    return `
-    <div style="padding: 8px; min-width: 160px;">
-      <div style="font-size: 11px; font-weight: 500; color: #6b7280; margin-bottom: 4px; padding-bottom: 4px; border-bottom: 1px solid #e5e7eb;">
-        ${total} observation${total !== 1 ? 's' : ''}
-      </div>
-      ${rows}
-    </div>
-  `
-  }
+  // Render the React MarkerHoverCard to an HTML string. Leaflet's tooltip API
+  // takes raw HTML, so we serialize the JSX once per call. Using a React
+  // component (instead of a template-string builder) keeps the markup
+  // testable, properly indented, and shared between per-marker and
+  // per-cluster tooltips below.
+  const createTooltipContent = (counts) =>
+    renderToStaticMarkup(
+      <MarkerHoverCard
+        counts={counts}
+        selectedSpecies={selectedSpecies}
+        palette={palette}
+        scientificToCommon={scientificToCommon}
+      />
+    )
 
   // PieChartMarker component with tooltip binding
   function PieChartMarker({ point, icon }) {
@@ -219,8 +206,14 @@ const SpeciesMap = ({
       const tooltipHtml = createTooltipContent(point.counts)
       marker.unbindTooltip()
       marker.bindTooltip(tooltipHtml, {
-        direction: 'top',
-        offset: [0, -10],
+        // 'auto' resolves to 'right' or 'left' depending on whether the
+        // marker is left or right of map center, so the card sits BESIDE
+        // the pie chart rather than above it. The CSS rule
+        // `.leaflet-tooltip-{right,left}.species-map-tooltip` adds a
+        // horizontal gap so the card doesn't overlap the marker.
+        direction: 'auto',
+        offset: [0, 0],
+        opacity: 1,
         className: 'species-map-tooltip'
       })
 
@@ -403,12 +396,14 @@ const SpeciesMap = ({
                   Object.entries(combinedCounts).filter(([, count]) => count > 0)
                 )
 
-                // Bind tooltip to cluster
+                // Bind tooltip to cluster. Same beside-the-pie behavior as
+                // individual markers — see the per-marker bindTooltip above.
                 const tooltipHtml = createTooltipContent(filteredCounts)
                 cluster.unbindTooltip()
                 cluster.bindTooltip(tooltipHtml, {
-                  direction: 'top',
-                  offset: [0, -10],
+                  direction: 'auto',
+                  offset: [0, 0],
+                  opacity: 1,
                   className: 'species-map-tooltip'
                 })
 
@@ -423,16 +418,29 @@ const SpeciesMap = ({
         </LayersControl.Overlay>
 
         {/* Add a legend */}
-        <div className="absolute bottom-5 right-5 bg-white p-2 rounded shadow-md z-[1000]">
-          {selectedSpecies.map((species, index) => (
-            <div key={index} className="flex items-center space-x-2 space-y-1">
-              <div
-                className="w-3 h-3 rounded-full"
-                style={{ backgroundColor: palette[index % palette.length] }}
-              ></div>
-              <span className="text-xs">{species.scientificName}</span>
-            </div>
-          ))}
+        <div className="absolute bottom-5 right-5 bg-white p-2 rounded shadow-md z-[1000] flex flex-col gap-2">
+          {selectedSpecies.map((species, index) => {
+            const common = getMapDisplayName(species.scientificName, scientificToCommon)
+            const showSci = common && common !== species.scientificName
+            return (
+              <div key={index} className="flex items-start gap-2">
+                <div
+                  className="w-3 h-3 rounded-full mt-0.5 flex-shrink-0"
+                  style={{ backgroundColor: palette[index % palette.length] }}
+                ></div>
+                <div className="flex flex-col min-w-0 leading-tight">
+                  <span className={`text-xs ${common ? 'capitalize' : 'italic'}`}>
+                    {common || species.scientificName}
+                  </span>
+                  {showSci && (
+                    <span className="text-[10px] text-gray-500 italic">
+                      {species.scientificName}
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
         </div>
       </LayersControl>
       <LayerChangeHandler onLayerChange={setSelectedLayer} />
@@ -477,6 +485,22 @@ export default function Activity({ studyData, studyId }) {
 
   // Get taxonomic data from studyData
   const taxonomicData = studyData?.taxonomic || null
+
+  // scientificName -> English vernacular name from CamtrapDP imports.
+  // Used by the map's marker tooltips and bottom-right legend so they can
+  // show common names alongside (or instead of) scientific names. Mirrors
+  // the same map built in speciesDistribution.jsx.
+  const scientificToCommon = useMemo(() => {
+    const map = {}
+    if (taxonomicData && Array.isArray(taxonomicData)) {
+      taxonomicData.forEach((taxon) => {
+        if (taxon.scientificName && taxon?.vernacularNames?.eng) {
+          map[taxon.scientificName] = taxon.vernacularNames.eng
+        }
+      })
+    }
+    return map
+  }, [taxonomicData])
 
   // Fetch sequence-aware species distribution data
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)
@@ -699,6 +723,7 @@ export default function Activity({ studyData, studyId }) {
                     palette={palette}
                     studyId={actualStudyId}
                     geoKey={geoKey}
+                    scientificToCommon={scientificToCommon}
                   />
                 )}
               {heatmapStatus === 'noData' && !isHeatmapLoading && (

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -330,3 +330,15 @@ input::-webkit-inner-spin-button {
 .leaflet-tooltip.species-map-tooltip::before {
   display: none;
 }
+
+/* Push the hovercard sideways off the pie marker so it sits BESIDE the
+   camembert rather than overlapping its right or left half. The pie marker
+   scales up to 60px wide; 36px clears the largest pie with a small gap.
+   `direction: 'auto'` on the tooltip resolves to either 'right' or 'left'
+   based on map-center, so we cover both cases. */
+.leaflet-tooltip-right.species-map-tooltip {
+  margin-left: 36px;
+}
+.leaflet-tooltip-left.species-map-tooltip {
+  margin-left: -36px;
+}

--- a/src/renderer/src/ui/MarkerHoverCard.jsx
+++ b/src/renderer/src/ui/MarkerHoverCard.jsx
@@ -1,0 +1,84 @@
+import { getMapDisplayName } from '../utils/commonNames'
+
+// Static React tooltip card for Leaflet markers and clusters in the Activity
+// map. Rendered to HTML via renderToStaticMarkup, then handed to
+// `marker.bindTooltip` / `cluster.bindTooltip`. The outer chrome (white
+// background, rounded corners, border, shadow) comes from the
+// `.leaflet-tooltip.species-map-tooltip` CSS rule in main.css — this
+// component only renders the inner content.
+export default function MarkerHoverCard({ counts, selectedSpecies, palette, scientificToCommon }) {
+  const entries = Object.entries(counts)
+    .filter(([species]) => selectedSpecies.some((s) => s.scientificName === species))
+    .sort((a, b) => b[1] - a[1])
+
+  const total = entries.reduce((sum, [, count]) => sum + count, 0)
+
+  return (
+    <div style={{ padding: '8px', minWidth: '180px' }}>
+      <div
+        style={{
+          fontSize: '11px',
+          fontWeight: 500,
+          color: '#6b7280',
+          marginBottom: '4px',
+          paddingBottom: '4px',
+          borderBottom: '1px solid #e5e7eb'
+        }}
+      >
+        {total} observation{total !== 1 ? 's' : ''}
+      </div>
+      {entries.map(([species, count]) => {
+        const index = selectedSpecies.findIndex((s) => s.scientificName === species)
+        const color = palette[index % palette.length]
+        const common = getMapDisplayName(species, scientificToCommon)
+        const showSci = common && common !== species
+        return (
+          <div
+            key={species}
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: '8px',
+              padding: '3px 0'
+            }}
+          >
+            <span
+              style={{
+                width: '8px',
+                height: '8px',
+                borderRadius: '50%',
+                flexShrink: 0,
+                backgroundColor: color,
+                marginTop: '5px'
+              }}
+            />
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div
+                style={{
+                  fontSize: '12px',
+                  color: '#111827',
+                  textTransform: common ? 'capitalize' : 'none',
+                  fontStyle: common ? 'normal' : 'italic'
+                }}
+              >
+                {common || species}
+              </div>
+              {showSci && (
+                <div
+                  style={{
+                    fontSize: '10px',
+                    color: '#6b7280',
+                    fontStyle: 'italic'
+                  }}
+                >
+                  {species}
+                </div>
+              )}
+            </div>
+            <span style={{ fontSize: '11px', color: '#6b7280', flexShrink: 0 }}>{count}</span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -9,7 +9,7 @@ import {
   VEHICLE_SENTINEL
 } from '../utils/speciesUtils'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
-import { useCommonName } from '../utils/commonNames'
+import { buildScientificToCommonMap, useCommonName } from '../utils/commonNames'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 
 function SpeciesRow({
@@ -172,17 +172,10 @@ function SpeciesDistribution({
   }, [bestImagesData])
 
   // Map of scientific names -> authoritative vernacular names from CamtrapDP imports.
-  const scientificToCommonMap = useMemo(() => {
-    const map = {}
-    if (taxonomicData && Array.isArray(taxonomicData)) {
-      taxonomicData.forEach((taxon) => {
-        if (taxon.scientificName && taxon?.vernacularNames?.eng) {
-          map[taxon.scientificName] = taxon.vernacularNames.eng
-        }
-      })
-    }
-    return map
-  }, [taxonomicData])
+  const scientificToCommonMap = useMemo(
+    () => buildScientificToCommonMap(taxonomicData),
+    [taxonomicData]
+  )
 
   // Handle toggling species selection when clicking on the dot
   const handleSpeciesToggle = (species) => {

--- a/src/renderer/src/utils/commonNames.js
+++ b/src/renderer/src/utils/commonNames.js
@@ -1,6 +1,20 @@
 import { useQuery } from '@tanstack/react-query'
 import { resolveCommonName, pickEnglishCommonName } from '../../../shared/commonNames/index.js'
 
+/**
+ * Synchronous version of the common-name cascade for contexts that can't run
+ * hooks (e.g. renderToStaticMarkup): study-imported vernacular →
+ * shipped dictionary → null. Skips the GBIF async tier.
+ *
+ * @param {string | null | undefined} scientificName
+ * @param {Record<string, string> | undefined} scientificToCommon
+ * @returns {string | null}
+ */
+export function getMapDisplayName(scientificName, scientificToCommon) {
+  if (!scientificName) return null
+  return scientificToCommon?.[scientificName] || resolveCommonName(scientificName) || null
+}
+
 // In-memory cache + fetcher live inside a closure — the cache isn't reachable
 // from outside the IIFE, only the exported functions are. Avoids module-level
 // mutable state bleeding through the import surface.

--- a/src/renderer/src/utils/commonNames.js
+++ b/src/renderer/src/utils/commonNames.js
@@ -15,6 +15,26 @@ export function getMapDisplayName(scientificName, scientificToCommon) {
   return scientificToCommon?.[scientificName] || resolveCommonName(scientificName) || null
 }
 
+/**
+ * Build a `scientificName -> English vernacular` map from a CamtrapDP-style
+ * taxonomic block. Defensive against null/non-array input and taxa missing
+ * either field. Used by both the Activity map and the species sidebar so the
+ * two surfaces stay in sync.
+ *
+ * @param {Array<{scientificName?: string, vernacularNames?: {eng?: string}}> | null | undefined} taxonomicData
+ * @returns {Record<string, string>}
+ */
+export function buildScientificToCommonMap(taxonomicData) {
+  const map = {}
+  if (!Array.isArray(taxonomicData)) return map
+  for (const taxon of taxonomicData) {
+    if (taxon?.scientificName && taxon?.vernacularNames?.eng) {
+      map[taxon.scientificName] = taxon.vernacularNames.eng
+    }
+  }
+  return map
+}
+
 // In-memory cache + fetcher live inside a closure — the cache isn't reachable
 // from outside the IIFE, only the exported functions are. Avoids module-level
 // mutable state bleeding through the import surface.

--- a/test/renderer/utils/commonNames.test.js
+++ b/test/renderer/utils/commonNames.test.js
@@ -2,7 +2,9 @@ import { test, describe, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   fetchGbifCommonName,
-  _clearGbifCache
+  _clearGbifCache,
+  getMapDisplayName,
+  buildScientificToCommonMap
 } from '../../../src/renderer/src/utils/commonNames.js'
 
 // Mock global fetch on each test.
@@ -79,5 +81,69 @@ describe('fetchGbifCommonName', () => {
     assert.equal(a, null)
     assert.equal(b, null)
     assert.equal(fetchCalls.length, 1)
+  })
+})
+
+describe('getMapDisplayName', () => {
+  test('prefers study-imported vernacular over the dictionary', () => {
+    // `vulpes vulpes` resolves to "red fox" via the shipped dictionary, but
+    // the study's own vernacular should win.
+    const result = getMapDisplayName('Vulpes vulpes', { 'Vulpes vulpes': 'European Red Fox' })
+    assert.equal(result, 'European Red Fox')
+  })
+
+  test('falls through to the shipped dictionary when no study match', () => {
+    const result = getMapDisplayName('Vulpes vulpes', {})
+    assert.equal(result, 'red fox')
+  })
+
+  test('handles undefined scientificToCommon (callers may omit it)', () => {
+    const result = getMapDisplayName('Vulpes vulpes', undefined)
+    assert.equal(result, 'red fox')
+  })
+
+  test('returns null when no name is known and nothing is in the map', () => {
+    const result = getMapDisplayName('Genus speciesthatdoesnotexist', {})
+    assert.equal(result, null)
+  })
+
+  test('returns null for null/empty scientific names', () => {
+    assert.equal(getMapDisplayName(null, { foo: 'bar' }), null)
+    assert.equal(getMapDisplayName('', { foo: 'bar' }), null)
+    assert.equal(getMapDisplayName(undefined, { foo: 'bar' }), null)
+  })
+})
+
+describe('buildScientificToCommonMap', () => {
+  test('returns an empty object for null/undefined input', () => {
+    assert.deepEqual(buildScientificToCommonMap(null), {})
+    assert.deepEqual(buildScientificToCommonMap(undefined), {})
+  })
+
+  test('returns an empty object for non-array input', () => {
+    assert.deepEqual(buildScientificToCommonMap({}), {})
+    assert.deepEqual(buildScientificToCommonMap('not an array'), {})
+  })
+
+  test('maps scientificName to vernacularNames.eng', () => {
+    const result = buildScientificToCommonMap([
+      { scientificName: 'Vulpes vulpes', vernacularNames: { eng: 'Red Fox' } },
+      { scientificName: 'Sus scrofa', vernacularNames: { eng: 'Wild Boar' } }
+    ])
+    assert.deepEqual(result, {
+      'Vulpes vulpes': 'Red Fox',
+      'Sus scrofa': 'Wild Boar'
+    })
+  })
+
+  test('skips taxa missing scientificName or vernacularNames.eng', () => {
+    const result = buildScientificToCommonMap([
+      { scientificName: 'Vulpes vulpes', vernacularNames: { eng: 'Red Fox' } },
+      { vernacularNames: { eng: 'Orphan' } }, // no scientificName
+      { scientificName: 'Sus scrofa' }, // no vernacularNames
+      { scientificName: 'Felis catus', vernacularNames: { fra: 'Chat' } }, // no eng
+      null // defensive: ignore null entries
+    ])
+    assert.deepEqual(result, { 'Vulpes vulpes': 'Red Fox' })
   })
 })


### PR DESCRIPTION
## Summary

- Map pie-marker tooltips and the bottom-right legend now show **common names** (with scientific names in italic gray as a subline when both are known).
- Tooltip content moved from hand-concatenated HTML strings to a real React component (`MarkerHoverCard`), rendered to HTML via `renderToStaticMarkup` and handed to Leaflet's `bindTooltip` API. Same component covers per-marker and per-cluster tooltips.
- Hovercard now sits **beside** the pie marker (camembert) instead of overlapping its right half: `direction: 'auto'` + a direction-aware CSS margin.
- Legend rows now have proper vertical spacing.

## Implementation notes

- Common-name resolution for the map uses a sync cascade: study taxonomic `vernacularNames.eng` → shipped dictionary → fall back to scientific name. The async GBIF tier from `useCommonName` is intentionally skipped — hooks can't run inside `renderToStaticMarkup`. CamtrapDP imports almost always carry vernacular names, so this rarely matters in practice.
- New helper `getMapDisplayName` in `utils/commonNames.js` for hookless callers.
- Tooltip viewport flip preserved via `direction: 'auto'`, which resolves to `'right'` or `'left'` based on whether the marker is left or right of map center.

## Out of scope

- TimelineChart and DailyActivityRadar tooltips (they have none today; deferred).
- Sidebar `SpeciesDistribution` (already uses common names + Radix HoverCard).
- Skeleton-mode loading tooltip ("Loading species data…") unchanged.

## Test plan

- [x] Activity tab loads, map shows pie markers as before.
- [x] Hover a single-species marker — card appears next to the pie, shows common name + italic scientific subline + count.
- [x] Hover a multi-species cluster — card lists all species sorted by count, with total at top.
- [x] Hover a marker on the right side of the map — card flips to the left and is fully visible.
- [x] Bottom-right legend shows common name as primary, italic scientific underneath, with vertical gap between rows.
- [x] No regression on skeleton-mode "Loading species data…" tooltip.