### PR TITLE
chore(ui): normalize scientific-name display to ICZN binomial form

### DIFF
--- a/src/renderer/src/CamtrapDPExportModal.jsx
+++ b/src/renderer/src/CamtrapDPExportModal.jsx
@@ -3,6 +3,7 @@ import { X, AlertTriangle } from 'lucide-react'
 import { useSequenceGap } from './hooks/useSequenceGap'
 import { SequenceGapSlider } from './ui/SequenceGapSlider'
 import { resolveCommonName } from '../../shared/commonNames/index.js'
+import { formatScientificName } from './utils/scientificName'
 
 function CamtrapDPExportModal({ isOpen, onConfirm, onCancel, studyId }) {
   const [includeMedia, setIncludeMedia] = useState(true)
@@ -151,8 +152,8 @@ function CamtrapDPExportModal({ isOpen, onConfirm, onCancel, studyId }) {
                 <div className="space-y-1">
                   {species.map((s) => {
                     const dictCommon = resolveCommonName(s.scientificName)
-                    const display = dictCommon || s.scientificName
-                    const showSci = display !== s.scientificName
+                    const showSci = dictCommon && dictCommon !== s.scientificName
+                    const display = dictCommon || formatScientificName(s.scientificName)
                     return (
                       <label
                         key={s.scientificName}
@@ -165,11 +166,13 @@ function CamtrapDPExportModal({ isOpen, onConfirm, onCancel, studyId }) {
                           className="w-4 h-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                         />
                         <div className="flex-1 flex justify-between items-center min-w-0">
-                          <span className="text-sm text-gray-900 truncate capitalize">
+                          <span
+                            className={`text-sm text-gray-900 truncate ${showSci ? 'capitalize' : 'italic'}`}
+                          >
                             {display}
                             {showSci && (
                               <span className="text-xs text-gray-500 ml-2 italic normal-case">
-                                ({s.scientificName})
+                                ({formatScientificName(s.scientificName)})
                               </span>
                             )}
                           </span>

--- a/src/renderer/src/ExportProgressModal.jsx
+++ b/src/renderer/src/ExportProgressModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Download, Copy, AlertCircle, Clock } from 'lucide-react'
+import { formatScientificName } from './utils/scientificName'
 
 /**
  * Format seconds into a human-readable time string
@@ -131,7 +132,9 @@ function ExportProgressModal({ isOpen, onCancel, progress }) {
             <div className="bg-gray-50 rounded-lg p-3 mb-4 overflow-hidden">
               <p className="text-xs text-gray-500 mb-1">Current file:</p>
               {speciesName && (
-                <p className="text-sm text-gray-900 font-medium italic mb-1">{speciesName}</p>
+                <p className="text-sm text-gray-900 font-medium italic mb-1">
+                  {formatScientificName(speciesName)}
+                </p>
               )}
               <p className="text-sm text-gray-700 truncate font-mono">{fileName}</p>
               {isDownloading && downloadPercent > 0 && (

--- a/src/renderer/src/ImageDirectoriesExportModal.jsx
+++ b/src/renderer/src/ImageDirectoriesExportModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { X } from 'lucide-react'
 import { resolveCommonName } from '../../shared/commonNames/index.js'
+import { formatScientificName } from './utils/scientificName'
 
 function ImageDirectoriesExportModal({ isOpen, onConfirm, onCancel, studyId }) {
   const [species, setSpecies] = useState([])
@@ -140,8 +141,8 @@ function ImageDirectoriesExportModal({ isOpen, onConfirm, onCancel, studyId }) {
                     // scientific name. Show the scientific in italics when it
                     // differs (so "yellow baboon (papio cynocephalus)").
                     const dictCommon = resolveCommonName(s.scientificName)
-                    const display = dictCommon || s.scientificName
-                    const showSci = display !== s.scientificName
+                    const showSci = dictCommon && dictCommon !== s.scientificName
+                    const display = dictCommon || formatScientificName(s.scientificName)
                     return (
                       <label
                         key={s.scientificName}
@@ -154,11 +155,13 @@ function ImageDirectoriesExportModal({ isOpen, onConfirm, onCancel, studyId }) {
                           className="w-4 h-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                         />
                         <div className="flex-1 flex justify-between items-center min-w-0">
-                          <span className="text-sm text-gray-900 truncate capitalize">
+                          <span
+                            className={`text-sm text-gray-900 truncate ${showSci ? 'capitalize' : 'italic'}`}
+                          >
                             {display}
                             {showSci && (
                               <span className="text-xs text-gray-500 ml-2 italic normal-case">
-                                ({s.scientificName})
+                                ({formatScientificName(s.scientificName)})
                               </span>
                             )}
                           </span>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -14,6 +14,7 @@ import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
 import { buildScientificToCommonMap, getMapDisplayName } from './utils/commonNames'
+import { formatScientificName } from './utils/scientificName'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 
@@ -430,11 +431,11 @@ const SpeciesMap = ({
                 ></div>
                 <div className="flex flex-col min-w-0 leading-tight">
                   <span className={`text-xs ${common ? 'capitalize' : 'italic'}`}>
-                    {common || species.scientificName}
+                    {common || formatScientificName(species.scientificName)}
                   </span>
                   {showSci && (
                     <span className="text-[10px] text-gray-500 italic">
-                      {species.scientificName}
+                      {formatScientificName(species.scientificName)}
                     </span>
                   )}
                 </div>

--- a/src/renderer/src/deployments/DeploymentDetailPane.jsx
+++ b/src/renderer/src/deployments/DeploymentDetailPane.jsx
@@ -7,6 +7,7 @@ import EditableLocationName from './EditableLocationName'
 import LocationPopover from './LocationPopover'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
+import { formatScientificName } from '../utils/scientificName'
 import { isBlank, isVehicle } from '../utils/speciesUtils'
 
 /**
@@ -216,15 +217,17 @@ function SpeciesFilterRow({ studyId, scientificName, count, isSelected, onToggle
           className={`block text-sm truncate ${
             isPseudo
               ? 'italic text-gray-500'
-              : `${commonName ? 'capitalize' : ''} ${
+              : `${commonName ? 'capitalize' : 'italic'} ${
                   isSelected ? 'text-blue-900 font-medium' : 'text-gray-800'
                 }`
           }`}
         >
-          {pseudoLabel || commonName || scientificName}
+          {pseudoLabel || commonName || formatScientificName(scientificName)}
         </span>
         {!isPseudo && commonName && (
-          <span className="block text-xs italic text-gray-500 truncate">{scientificName}</span>
+          <span className="block text-xs italic text-gray-500 truncate">
+            {formatScientificName(scientificName)}
+          </span>
         )}
       </span>
       <span className="flex-shrink-0 text-xs tabular-nums text-gray-500">{count}</span>

--- a/src/renderer/src/overview/CommonSpeciesFallback.jsx
+++ b/src/renderer/src/overview/CommonSpeciesFallback.jsx
@@ -5,6 +5,7 @@ import * as HoverCard from '@radix-ui/react-hover-card'
 import { CameraOff, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useSequenceGap } from '../hooks/useSequenceGap'
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import { isBlank, isDomestic, isHumanOrVehicle, isNonSpeciesLabel } from '../utils/speciesUtils'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
@@ -161,8 +162,10 @@ function ScrollableStrip({ children }) {
 function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
   const [imageError, setImageError] = useState(false)
   const [hoverOpen, setHoverOpen] = useState(false)
+  const resolvedCommon = useCommonName(species.scientificName)
+  const showSci = !resolvedCommon && species.scientificName
   const commonName =
-    useCommonName(species.scientificName) || species.scientificName || 'Unknown species'
+    resolvedCommon || formatScientificName(species.scientificName) || 'Unknown species'
 
   useEffect(() => {
     if (scrollSignal > 0) setHoverOpen(false)
@@ -193,7 +196,11 @@ function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
             )}
           </div>
           <div className="px-2 py-1.5">
-            <p className="text-xs font-medium text-gray-900 truncate capitalize">{commonName}</p>
+            <p
+              className={`text-xs font-medium text-gray-900 truncate ${showSci ? 'italic' : 'capitalize'}`}
+            >
+              {commonName}
+            </p>
             <p className="text-[0.65rem] text-gray-500">
               {species.count.toLocaleString('en-US')} observations
             </p>

--- a/src/renderer/src/overview/KpiBand.jsx
+++ b/src/renderer/src/overview/KpiBand.jsx
@@ -9,6 +9,7 @@ import SpanPicker from './SpanPicker'
 import IucnBadge from '../ui/IucnBadge'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
 import {
   formatStatNumber,
@@ -274,7 +275,8 @@ function ThreatenedSpeciesPopover({ studyId, species, onClose, ignoreOutsideClic
 
 function ThreatenedSpeciesRow({ studyId, scientificName, iucn, onClick, scrollSignal }) {
   const commonName = useCommonName(scientificName)
-  const display = commonName && commonName !== scientificName ? commonName : scientificName
+  const display =
+    commonName && commonName !== scientificName ? commonName : formatScientificName(scientificName)
   const showScientific = commonName && commonName !== scientificName
   const [hoverOpen, setHoverOpen] = useState(false)
   // Close any open card when the parent list scrolls — Radix HoverCard
@@ -295,9 +297,13 @@ function ThreatenedSpeciesRow({ studyId, scientificName, iucn, onClick, scrollSi
               <IucnBadge category={iucn} />
             </span>
             <span className="min-w-0 flex-1 truncate">
-              <span className="text-sm capitalize text-gray-900">{display}</span>
+              <span className={`text-sm text-gray-900 ${showScientific ? 'capitalize' : 'italic'}`}>
+                {display}
+              </span>
               {showScientific && (
-                <span className="text-xs italic text-gray-400 ml-1.5">{scientificName}</span>
+                <span className="text-xs italic text-gray-400 ml-1.5">
+                  {formatScientificName(scientificName)}
+                </span>
               )}
             </span>
           </button>

--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -6,6 +6,7 @@ import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
 import IucnBadge from '../ui/IucnBadge'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { sortSpeciesHumansLast } from '../utils/speciesUtils'
 
 /**
@@ -20,9 +21,10 @@ function SpeciesRow({
   onRowClick,
   scrollSignal
 }) {
-  const displayName =
-    useCommonName(species.scientificName, { storedCommonName }) || species.scientificName
-  const showScientific = species.scientificName && displayName !== species.scientificName
+  const commonName = useCommonName(species.scientificName, { storedCommonName })
+  const displayName = commonName || formatScientificName(species.scientificName)
+  const showScientific =
+    species.scientificName && commonName && commonName !== species.scientificName
   const info = resolveSpeciesInfo(species.scientificName)
   const iucn = info?.iucn
   const studyImage = speciesImageMap[species.scientificName]
@@ -51,9 +53,15 @@ function SpeciesRow({
         <HoverCard.Trigger asChild>
           <div className="flex items-center gap-3 flex-shrink-0">
             <div className="w-80 flex-shrink-0">
-              <span className="capitalize text-sm text-gray-900 font-medium">{displayName}</span>
+              <span
+                className={`text-sm text-gray-900 font-medium ${showScientific ? 'capitalize' : 'italic'}`}
+              >
+                {displayName}
+              </span>
               {showScientific && (
-                <span className="text-gray-400 text-xs italic ml-2">{species.scientificName}</span>
+                <span className="text-gray-400 text-xs italic ml-2">
+                  {formatScientificName(species.scientificName)}
+                </span>
               )}
             </div>
             <div className="w-8 flex-shrink-0">

--- a/src/renderer/src/ui/BboxLabelMinimal.jsx
+++ b/src/renderer/src/ui/BboxLabelMinimal.jsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react'
 import { computeBboxLabelPosition } from '../utils/positioning'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
+import { formatScientificName } from '../utils/scientificName'
 
 /**
  * Species-only label pill anchored above a bbox on the image.
@@ -22,10 +23,11 @@ const BboxLabelMinimal = forwardRef(function BboxLabelMinimal(
   // for confirmed-blank observationType; bbox without classification reads as
   // "—".
   const dictCommon = resolveCommonName(bbox.scientificName)
+  const resolvedCommon = dictCommon || bbox.commonName
+  const showSci = !resolvedCommon && bbox.scientificName
   const displayName =
-    dictCommon ||
-    bbox.commonName ||
-    bbox.scientificName ||
+    resolvedCommon ||
+    formatScientificName(bbox.scientificName) ||
     (bbox.observationType === 'blank' ? 'Blank' : '—')
   const { left: leftPos, top: topPos, transform: transformVal } = computeBboxLabelPosition(bbox)
 
@@ -39,17 +41,17 @@ const BboxLabelMinimal = forwardRef(function BboxLabelMinimal(
         e.stopPropagation()
         onClick()
       }}
-      className={`absolute pointer-events-auto h-5 px-2 text-white text-xs font-medium whitespace-nowrap max-w-full truncate flex items-center capitalize transition-colors hover:brightness-110 ${bg} ${
-        isSelected ? 'ring-2 ring-white/60' : ''
-      }`}
+      className={`absolute pointer-events-auto h-5 px-2 text-white text-xs font-medium whitespace-nowrap max-w-full truncate flex items-center transition-colors hover:brightness-110 ${
+        showSci ? 'italic' : 'capitalize'
+      } ${bg} ${isSelected ? 'ring-2 ring-white/60' : ''}`}
       style={{
         left: leftPos,
         top: topPos,
         transform: transformVal
       }}
       title={
-        bbox.scientificName && displayName !== bbox.scientificName
-          ? `${displayName} (${bbox.scientificName})`
+        bbox.scientificName && !showSci
+          ? `${displayName} (${formatScientificName(bbox.scientificName)})`
           : displayName
       }
     >

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -3,18 +3,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import * as HoverCard from '@radix-ui/react-hover-card'
 import { ChevronLeft, ChevronRight, CameraOff, X, Heart, Play, Loader2 } from 'lucide-react'
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll'
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
-}
-
-// Binomial nomenclature: only the genus (first letter) is capitalized.
-function capitalizeGenus(str) {
-  if (!str) return str
-  return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
 /**
@@ -25,7 +20,7 @@ function SpeciesThumbnailLabel({ scientificName }) {
   const common = useCommonName(scientificName)
   if (!scientificName) return <>Unknown species</>
   if (common && common !== scientificName) return <>{toTitleCase(common)}</>
-  return <>{capitalizeGenus(scientificName)}</>
+  return <>{formatScientificName(scientificName)}</>
 }
 
 /**
@@ -41,12 +36,12 @@ function SpeciesHeading({ scientificName }) {
       <>
         {toTitleCase(common)}{' '}
         <span className="italic text-gray-500 font-normal">
-          ({capitalizeGenus(scientificName)})
+          ({formatScientificName(scientificName)})
         </span>
       </>
     )
   }
-  return <>{capitalizeGenus(scientificName)}</>
+  return <>{formatScientificName(scientificName)}</>
 }
 
 /**

--- a/src/renderer/src/ui/MarkerHoverCard.jsx
+++ b/src/renderer/src/ui/MarkerHoverCard.jsx
@@ -1,4 +1,5 @@
 import { getMapDisplayName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 
 // Static React tooltip card for Leaflet markers and clusters in the Activity
 // map. Rendered to HTML via renderToStaticMarkup, then handed to
@@ -61,7 +62,7 @@ export default function MarkerHoverCard({ counts, selectedSpecies, palette, scie
                   fontStyle: common ? 'normal' : 'italic'
                 }}
               >
-                {common || species}
+                {common || formatScientificName(species)}
               </div>
               {showSci && (
                 <div
@@ -71,7 +72,7 @@ export default function MarkerHoverCard({ counts, selectedSpecies, palette, scie
                     fontStyle: 'italic'
                   }}
                 >
-                  {species}
+                  {formatScientificName(species)}
                 </div>
               )}
             </div>

--- a/src/renderer/src/ui/ObservationRow.jsx
+++ b/src/renderer/src/ui/ObservationRow.jsx
@@ -5,6 +5,7 @@ import LifeStageSelector from './LifeStageSelector'
 import BehaviorSelector from './BehaviorSelector'
 import SpeciesPicker from './SpeciesPicker'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
+import { formatScientificName } from '../utils/scientificName'
 
 const BBOX_TYPE_ICON = (
   <span
@@ -60,11 +61,10 @@ export default function ObservationRow({
   // (blank/unclassified/unknown/null).
   const isPseudoSpecies = !observation.scientificName && !observation.commonName
   const pseudoLabel = observation.observationType === 'vehicle' ? 'Vehicle' : 'Blank'
+  const resolvedCommon = resolveCommonName(observation.scientificName) || observation.commonName
+  const showSci = !resolvedCommon && observation.scientificName
   const displayName =
-    resolveCommonName(observation.scientificName) ||
-    observation.commonName ||
-    observation.scientificName ||
-    pseudoLabel
+    resolvedCommon || formatScientificName(observation.scientificName) || pseudoLabel
 
   const confidence =
     observation.classificationProbability != null && !isHuman
@@ -114,7 +114,9 @@ export default function ObservationRow({
 
         <span
           className={`text-sm flex-1 min-w-0 truncate ${
-            isPseudoSpecies ? 'italic text-gray-400' : 'text-[#030213] font-medium capitalize'
+            isPseudoSpecies
+              ? 'italic text-gray-400'
+              : `text-[#030213] font-medium ${showSci ? 'italic' : 'capitalize'}`
           }`}
         >
           {displayName}

--- a/src/renderer/src/ui/SpeciesLabel.jsx
+++ b/src/renderer/src/ui/SpeciesLabel.jsx
@@ -1,4 +1,5 @@
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { isBlank, isVehicle } from '../utils/speciesUtils'
 
 // Render a single species name. Pseudo-species sentinels (Blank, Vehicle)
@@ -14,8 +15,10 @@ function pseudoLabelFor(scientificName) {
 function SpeciesName({ scientificName }) {
   const pseudo = pseudoLabelFor(scientificName)
   // Hook must be called unconditionally; pass null for pseudo-species.
-  const resolved = useCommonName(pseudo ? null : scientificName) || scientificName
-  return <>{pseudo || resolved}</>
+  const resolved = useCommonName(pseudo ? null : scientificName)
+  if (pseudo) return <>{pseudo}</>
+  if (resolved) return <>{resolved}</>
+  return <span className="italic">{formatScientificName(scientificName)}</span>
 }
 
 /**
@@ -43,11 +46,12 @@ export default function SpeciesLabel({ names }) {
 
 function SpeciesNameWithCount({ scientificName, count }) {
   const pseudo = pseudoLabelFor(scientificName)
-  const resolved = useCommonName(pseudo ? null : scientificName) || scientificName
-  const label = pseudo || resolved
+  const resolved = useCommonName(pseudo ? null : scientificName)
+  const showSci = !pseudo && !resolved
+  const label = pseudo || resolved || formatScientificName(scientificName)
   return (
     <>
-      {label}
+      {showSci ? <span className="italic">{label}</span> : label}
       {count > 1 && <span className="text-gray-500 font-normal"> ×{count}</span>}
     </>
   )

--- a/src/renderer/src/ui/SpeciesPicker.jsx
+++ b/src/renderer/src/ui/SpeciesPicker.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Search, Plus } from 'lucide-react'
 import { searchSpecies } from '../utils/dictionarySearch'
+import { formatScientificName } from '../utils/scientificName'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
 
 /**
@@ -152,14 +153,17 @@ export default function SpeciesPicker({
                 // "yellow_baboon"). Falls through to the DB value, then to
                 // the scientific name.
                 const dictCommon = resolveCommonName(species.scientificName)
-                const display = dictCommon || species.commonName || species.scientificName
-                const showSci = display !== species.scientificName
+                const resolvedCommon = dictCommon || species.commonName
+                const showSci = resolvedCommon && resolvedCommon !== species.scientificName
+                const display = resolvedCommon || formatScientificName(species.scientificName)
                 return (
                   <div className="min-w-0 truncate">
-                    <span className="text-sm font-medium capitalize">{display}</span>
+                    <span className={`text-sm font-medium ${showSci ? 'capitalize' : 'italic'}`}>
+                      {display}
+                    </span>
                     {showSci && (
                       <span className="text-xs text-gray-500 ml-2 italic normal-case">
-                        ({species.scientificName})
+                        ({formatScientificName(species.scientificName)})
                       </span>
                     )}
                   </div>

--- a/src/renderer/src/ui/SpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/SpeciesTooltipContent.jsx
@@ -1,17 +1,13 @@
 import { useState, useEffect } from 'react'
 import { CameraOff, Loader2 } from 'lucide-react'
 import { useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import IucnBadge from './IucnBadge'
 import { IUCN_ACCENT_BORDER } from './iucnPalette'
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
-}
-
-function capitalizeGenus(str) {
-  if (!str) return str
-  return str.charAt(0).toUpperCase() + str.slice(1)
 }
 
 /**
@@ -129,10 +125,10 @@ export default function SpeciesTooltipContent({ imageData, studyId, size = 'md' 
             {hasCommon ? (
               <>
                 {toTitleCase(common)}{' '}
-                <span className="italic text-gray-500">({capitalizeGenus(sciName)})</span>
+                <span className="italic text-gray-500">({formatScientificName(sciName)})</span>
               </>
             ) : (
-              <span className="italic">{capitalizeGenus(sciName)}</span>
+              <span className="italic">{formatScientificName(sciName)}</span>
             )}
           </p>
           <IucnBadge category={info?.iucn} />

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -10,6 +10,7 @@ import {
 } from '../utils/speciesUtils'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
 import { buildScientificToCommonMap, useCommonName } from '../utils/commonNames'
+import { formatScientificName } from '../utils/scientificName'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 
 function SpeciesRow({
@@ -42,14 +43,14 @@ function SpeciesRow({
     ? 'Blank'
     : isVehicleEntry
       ? 'Vehicle'
-      : resolved || species.scientificName
+      : resolved || formatScientificName(species.scientificName)
 
   const isSelected = selectedSpecies.some((s) => s.scientificName === species.scientificName)
   const colorIndex = selectedSpecies.findIndex((s) => s.scientificName === species.scientificName)
   const color = colorIndex >= 0 ? palette[colorIndex % palette.length] : '#ccc'
 
   const showScientificInItalic =
-    !isPseudoEntry && species.scientificName && displayName !== species.scientificName
+    !isPseudoEntry && species.scientificName && resolved && resolved !== species.scientificName
   // resolveSpeciesInfo is still used to surface a Wikipedia thumbnail when the
   // study has no best-media image. The inline IUCN badge is intentionally NOT
   // rendered on the media/activity sidebars — only inside the hover card.
@@ -71,12 +72,18 @@ function SpeciesRow({
             style={{ backgroundColor: isSelected ? color : null }}
           ></div>
           <span
-            className={`text-sm truncate ${isPseudoEntry ? 'text-gray-500 italic' : 'capitalize'}`}
+            className={`text-sm truncate ${
+              isPseudoEntry
+                ? 'text-gray-500 italic'
+                : showScientificInItalic
+                  ? 'capitalize'
+                  : 'italic'
+            }`}
           >
             {displayName}
             {showScientificInItalic && (
               <span className="text-gray-500 italic ml-2 normal-case">
-                {species.scientificName}
+                {formatScientificName(species.scientificName)}
               </span>
             )}
           </span>

--- a/src/renderer/src/utils/scientificName.js
+++ b/src/renderer/src/utils/scientificName.js
@@ -1,0 +1,21 @@
+/**
+ * Normalize a scientific (Latin binomial) name for display: lowercase the
+ * entire string, then capitalize the first letter only. Per ICZN/ICNafp:
+ * genus is capitalized, species/subspecies epithets are lowercase. Idempotent.
+ *
+ *   "PANTHERA LEO"       -> "Panthera leo"
+ *   "panthera leo"       -> "Panthera leo"
+ *   "Panthera Leo"       -> "Panthera leo"
+ *   "Panthera leo persica" -> "Panthera leo persica"
+ *   "Panthera sp."       -> "Panthera sp."
+ *
+ * Returns the input unchanged if it is null/undefined or not a string.
+ *
+ * @param {string | null | undefined} name
+ * @returns {string | null | undefined}
+ */
+export function formatScientificName(name) {
+  if (typeof name !== 'string' || name.length === 0) return name
+  const lower = name.toLowerCase()
+  return lower.charAt(0).toUpperCase() + lower.slice(1)
+}

--- a/test/renderer/utils/scientificName.test.js
+++ b/test/renderer/utils/scientificName.test.js
@@ -1,0 +1,53 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { formatScientificName } from '../../../src/renderer/src/utils/scientificName.js'
+
+describe('formatScientificName', () => {
+  test('leaves canonical binomial unchanged', () => {
+    assert.equal(formatScientificName('Panthera leo'), 'Panthera leo')
+  })
+
+  test('downcases all-caps input', () => {
+    assert.equal(formatScientificName('PANTHERA LEO'), 'Panthera leo')
+  })
+
+  test('capitalizes all-lowercase input', () => {
+    assert.equal(formatScientificName('panthera leo'), 'Panthera leo')
+  })
+
+  test('downcases incorrectly capitalized species epithet', () => {
+    assert.equal(formatScientificName('Panthera Leo'), 'Panthera leo')
+  })
+
+  test('handles trinomial (subspecies)', () => {
+    assert.equal(formatScientificName('PANTHERA LEO PERSICA'), 'Panthera leo persica')
+  })
+
+  test('preserves "sp." abbreviation in lowercase', () => {
+    assert.equal(formatScientificName('Panthera sp.'), 'Panthera sp.')
+    assert.equal(formatScientificName('PANTHERA SP.'), 'Panthera sp.')
+  })
+
+  test('is idempotent', () => {
+    const once = formatScientificName('PANTHERA LEO')
+    assert.equal(formatScientificName(once), once)
+  })
+
+  test('returns null for null', () => {
+    assert.equal(formatScientificName(null), null)
+  })
+
+  test('returns undefined for undefined', () => {
+    assert.equal(formatScientificName(undefined), undefined)
+  })
+
+  test('returns empty string for empty string', () => {
+    assert.equal(formatScientificName(''), '')
+  })
+
+  test('returns input unchanged for non-string types', () => {
+    assert.equal(formatScientificName(42), 42)
+    const obj = {}
+    assert.equal(formatScientificName(obj), obj)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `formatScientificName` util — lowercase then capitalize first letter — and applies it at every display site so names render as `Panthera leo` regardless of input casing (`PANTHERA LEO`, `panthera leo`, `Panthera Leo` all normalize). Display-time only; no data mutated on import.
- Removes two duplicated `capitalizeGenus` helpers in `SpeciesTooltipContent` and `BestMediaCarousel` that only fixed the first char and left `PANTHERA LEO` mis-cased.
- Fixes a latent CSS bug along the way: rows that fell back to the scientific name when no common name resolved still had the Tailwind `capitalize` class applied, which title-cased `Panthera leo` into `Panthera Leo`. Switched those spans to italic-only when showing the scientific name, capitalize-only when showing a common name.

Sites covered: SpeciesTooltipContent, BestMediaCarousel, MarkerHoverCard (Leaflet map tooltip), KpiBand threatened-species list, SpeciesDistribution (overview + sidebar), DeploymentDetailPane, SpeciesPicker, ObservationRow, CommonSpeciesFallback, SpeciesLabel, BboxLabelMinimal, activity.jsx legend, ImageDirectoriesExportModal, CamtrapDPExportModal, ExportProgressModal.

Skipped: `timeseries.jsx` and `clock.jsx` — `name`/`dataKey` props are passed but the chart Tooltip/Legend is commented out / absent, so nothing renders to the user.

## Test plan

- [x] 11 new unit tests for `formatScientificName` (canonical, all-caps, all-lowercase, mis-cased epithet, trinomial, `sp.` abbrev, idempotency, null/undefined/empty/non-string)
- [x] Full test suite still green (1108 tests pass)
- [x] ESLint clean on touched files
- [x] Manual: open a study with mixed-case taxonomic data and confirm names render as `Panthera leo` everywhere — overview species list, threatened-species popover, activity-tab map legend + marker tooltip, deployment detail pane, observation rows, bbox labels, species picker dropdown, both export modals
- [x] Manual: confirm common names still title-case correctly (e.g. `Yellow Baboon`) when present, and the scientific name in parentheses is properly formatted