### PR TITLE
feat(SpeciesPicker): browse mode on bbox-label click

### DIFF
--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -234,6 +234,19 @@ function ImageModal({
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState(null)
   const [selectedObservationId, setSelectedObservationId] = useState(null)
+  // Browse-mode trigger for the species picker: { id, epoch }. The id names
+  // which observation should open in browse mode (dropdown open with full
+  // study list, current species highlighted); the epoch increments on every
+  // label click so a re-click on the already-selected bbox forces the picker
+  // to remount and re-trigger. Cleared by an effect whenever id falls out of
+  // sync with selectedObservationId, so non-label selection paths never
+  // inherit browse mode.
+  const [pickerBrowse, setPickerBrowse] = useState({ id: null, epoch: 0 })
+  useEffect(() => {
+    if (pickerBrowse.id !== null && pickerBrowse.id !== selectedObservationId) {
+      setPickerBrowse((prev) => ({ id: null, epoch: prev.epoch }))
+    }
+  }, [pickerBrowse.id, selectedObservationId])
   const [showShortcuts, setShowShortcuts] = useState(false)
   // Draw mode state for creating new bboxes
   const [isDrawMode, setIsDrawMode] = useState(false)
@@ -1468,7 +1481,13 @@ function ImageModal({
                               bbox={bbox}
                               isSelected={bbox.observationID === selectedObservationId}
                               isValidated={bbox.classificationMethod === 'human'}
-                              onClick={() => setSelectedObservationId(bbox.observationID)}
+                              onClick={() => {
+                                setSelectedObservationId(bbox.observationID)
+                                setPickerBrowse((prev) => ({
+                                  id: bbox.observationID,
+                                  epoch: prev.epoch + 1
+                                }))
+                              }}
                             />
                           ))}
                         </div>
@@ -1494,6 +1513,8 @@ function ImageModal({
               mediaId={media?.mediaID}
               selectedObservationId={selectedObservationId}
               onSelectObservation={setSelectedObservationId}
+              pickerBrowseObservationId={pickerBrowse.id}
+              pickerBrowseEpoch={pickerBrowse.epoch}
               onUpdateClassification={handleClassificationUpdate}
               onDeleteObservation={handleDeleteObservation}
               onDrawRectangle={() => {

--- a/src/renderer/src/ui/ObservationRail.jsx
+++ b/src/renderer/src/ui/ObservationRail.jsx
@@ -34,7 +34,9 @@ export default function ObservationRail({
   onDrawRectangle,
   onAddWholeImage,
   showShortcuts = false,
-  isLoading = false
+  isLoading = false,
+  pickerBrowseObservationId = null,
+  pickerBrowseEpoch = 0
 }) {
   const mode = getMediaMode(observations)
 
@@ -142,6 +144,8 @@ export default function ObservationRail({
                 }
                 onDelete={() => onDeleteObservation(obs.observationID)}
                 autoFocusPicker={userInteracted}
+                initialBrowse={obs.observationID === pickerBrowseObservationId}
+                browseEpoch={pickerBrowseEpoch}
               />
             ))}
           </div>

--- a/src/renderer/src/ui/ObservationRow.jsx
+++ b/src/renderer/src/ui/ObservationRow.jsx
@@ -40,7 +40,9 @@ export default function ObservationRow({
   onSelect,
   onUpdateClassification,
   onDelete,
-  autoFocusPicker = true
+  autoFocusPicker = true,
+  initialBrowse = false,
+  browseEpoch = 0
 }) {
   const rowRef = useRef(null)
 
@@ -145,10 +147,16 @@ export default function ObservationRow({
       {isSelected && (
         <div className="px-3 pb-3 pt-1 space-y-3" onClick={(e) => e.stopPropagation()}>
           <SpeciesPicker
+            // Remount on each label-click epoch when this row is the browse
+            // target, so a re-click on the already-selected bbox re-triggers
+            // browse mode (otherwise the picker's mount-time state ignores
+            // updated props).
+            key={initialBrowse ? `browse-${browseEpoch}` : 'normal'}
             studyId={studyId}
             currentScientificName={observation.scientificName}
             onSelect={handleSpeciesSelect}
             autoFocus={autoFocusPicker}
+            initialBrowse={initialBrowse}
           />
 
           <div>

--- a/src/renderer/src/ui/SpeciesPicker.jsx
+++ b/src/renderer/src/ui/SpeciesPicker.jsx
@@ -13,6 +13,9 @@ import { resolveCommonName } from '../../../shared/commonNames/index.js'
  *    and the bundled dictionary (3+ chars).
  *  - Keyboard navigation: ↑/↓ moves highlight, Enter commits.
  *  - Custom-species fallback when the query has no results.
+ *  - Browse mode (`initialBrowse`): on mount, dropdown is open with the empty
+ *    query showing the full study species list and the current species
+ *    pre-highlighted. Ends on first keystroke, Escape, or pick.
  *
  * Saves are committal: clicking a result or pressing Enter calls
  * onSelect(scientificName, commonName) and the parent collapses the picker.
@@ -21,11 +24,13 @@ export default function SpeciesPicker({
   studyId,
   currentScientificName,
   onSelect,
-  autoFocus = true
+  autoFocus = true,
+  initialBrowse = false
 }) {
   const [searchTerm, setSearchTerm] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
   const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const [browseOpen, setBrowseOpen] = useState(initialBrowse)
   const inputRef = useRef(null)
   const rowRefs = useRef([])
 
@@ -39,18 +44,27 @@ export default function SpeciesPicker({
   })
 
   useEffect(() => {
-    if (autoFocus && inputRef.current) inputRef.current.focus()
-  }, [autoFocus])
+    if ((autoFocus || initialBrowse) && inputRef.current) inputRef.current.focus()
+  }, [autoFocus, initialBrowse])
 
   useEffect(() => {
     const handle = setTimeout(() => setDebouncedSearch(searchTerm), 150)
     return () => clearTimeout(handle)
   }, [searchTerm])
 
-  const results = useMemo(
-    () => searchSpecies(debouncedSearch, speciesList),
-    [debouncedSearch, speciesList]
-  )
+  const results = useMemo(() => {
+    const base = searchSpecies(debouncedSearch, speciesList)
+    // In browse mode with an empty query, pin the current species to the top
+    // so it acts as a clear "this is what's set" anchor with alternatives
+    // listed below. Once the user types, fall back to natural relevance order
+    // — pinning would otherwise fight the search ranking.
+    if (!browseOpen || debouncedSearch.trim().length > 0 || !currentScientificName) {
+      return base
+    }
+    const idx = base.findIndex((s) => s.scientificName === currentScientificName)
+    if (idx <= 0) return base
+    return [base[idx], ...base.slice(0, idx), ...base.slice(idx + 1)]
+  }, [debouncedSearch, speciesList, browseOpen, currentScientificName])
 
   const customSpeciesQuery = useMemo(
     () => debouncedSearch.trim().replace(/\s+/g, ' '),
@@ -58,9 +72,18 @@ export default function SpeciesPicker({
   )
 
   useEffect(() => {
-    setHighlightedIndex(results.length > 0 ? 0 : -1)
     rowRefs.current.length = results.length
-  }, [results])
+    if (results.length === 0) {
+      setHighlightedIndex(-1)
+      return
+    }
+    if (browseOpen && currentScientificName) {
+      const idx = results.findIndex((s) => s.scientificName === currentScientificName)
+      setHighlightedIndex(idx >= 0 ? idx : 0)
+      return
+    }
+    setHighlightedIndex(0)
+  }, [results, browseOpen, currentScientificName])
 
   useEffect(() => {
     if (highlightedIndex < 0) return
@@ -74,6 +97,7 @@ export default function SpeciesPicker({
   const handleSelect = (scientificName, commonName) => {
     setSearchTerm('')
     setDebouncedSearch('')
+    setBrowseOpen(false)
     onSelect(scientificName, commonName)
     if (inputRef.current) inputRef.current.focus()
   }
@@ -85,7 +109,10 @@ export default function SpeciesPicker({
         ref={inputRef}
         type="text"
         value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
+        onChange={(e) => {
+          setSearchTerm(e.target.value)
+          setBrowseOpen(false)
+        }}
         onKeyDown={(e) => {
           if (e.key === 'Backspace' || e.key === 'Delete') {
             e.stopPropagation()
@@ -96,6 +123,11 @@ export default function SpeciesPicker({
             if (searchTerm.length > 0) {
               // First Esc: clear the search query (collapses the dropdown).
               setSearchTerm('')
+              setBrowseOpen(false)
+            } else if (browseOpen) {
+              // Browse-mode dropdown is open with empty input — close it
+              // before letting subsequent Escape blur the input.
+              setBrowseOpen(false)
             } else {
               // Second Esc (empty search): blur so the modal handler can act.
               e.currentTarget.blur()
@@ -131,7 +163,7 @@ export default function SpeciesPicker({
         className="w-full pl-7 pr-2 py-1.5 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-gray-400 focus:border-transparent"
       />
 
-      {debouncedSearch.trim().length > 0 && (
+      {(debouncedSearch.trim().length > 0 || browseOpen) && (
         <div className="absolute left-0 right-0 top-full mt-1 z-20 max-h-52 overflow-y-auto border border-gray-200 rounded bg-white shadow-lg">
           {results.map((species, index) => (
             <button


### PR DESCRIPTION
## Summary
- Clicking a bbox label opens the species picker with the dropdown expanded and the current species pinned at the top of the study list — so the label feels editable and the current pick is the visible anchor.
- Re-clicking the label of an already-selected bbox re-triggers the browse view (each click bumps an epoch counter that re-keys the picker, forcing a fresh mount).
- Browse mode ends on the first keystroke, Escape, or a successful pick — typing falls back to the existing fuzzy-search ranking.
- Non-label selection paths (rail click, bbox-rect click, Tab nav, undo) still mount the picker in its original empty-input state; an effect clears the browse trigger whenever it falls out of sync with the selected observation.

## Test plan
- [x] Click a bbox label on a not-yet-selected bbox → dropdown opens, current species at row 0, input focused.
- [x] Click the bbox rectangle first to select, then click its label → dropdown re-opens in browse mode (re-click works on already-selected bbox).
- [x] Click the same bbox label twice → dropdown re-opens fresh on the second click.
- [x] Type in the input → dropdown switches to filtered fuzzy results in natural relevance order (no pinning).
- [x] Escape with empty input in browse mode → dropdown closes, input keeps focus.
- [x] Select a row in the rail or click the bbox rectangle → picker mounts with empty input and dropdown closed (current behavior preserved).