### PR TITLE
feat(activity): export species distribution map as PNG

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,7 @@ src/
 │   ├── media/               # Media subcomponents shared with the Deployments tab
 │   │   ├── Gallery.jsx               # Sequence grid + ImageModal + bbox editor
 │   │   └── DeploymentMediaGallery.jsx # Deployment-scoped wrapper around Gallery
-│   ├── activity.jsx         # Temporal analysis
+│   ├── activity.jsx         # Temporal analysis (right-click map → Save as PNG via html-to-image)
 │   ├── models/              # AI Models tab (split-view map + cards)
 │   │   ├── index.jsx                  # MlZoo top-level (responsive split/stacked)
 │   │   ├── MapPane.jsx                # Leaflet map + region overlays + worldwide chip

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -444,6 +444,22 @@ function generateDataPackage(studyId, studyName, metadata) {
 }
 ```
 
+## Activity Map PNG Export
+
+Saves the Activity tab's species distribution map (Leaflet basemap + pie chart markers + legend) as a PNG file. Triggered from a right-click context menu on the map.
+
+**Flow:**
+
+1. Renderer (`src/renderer/src/activity.jsx` → `SpeciesMap`) listens for Leaflet's `contextmenu` event via a `useMapEvents` controller.
+2. Right-click renders a small fixed-position menu (`src/renderer/src/ui/ActivityMapContextMenu.jsx`) with **Save map as PNG…**.
+3. On click, `html-to-image` rasterises `map.getContainer()` at `pixelRatio: 2` with a filter that strips the zoom and layer-toggle controls (attribution stays for OSM/Esri compliance).
+4. The base64 PNG data URL is sent to main via `window.api.exportActivityMapPng({ dataUrl, defaultFilename })`.
+5. Main (`src/main/ipc/activity.js`) shows `dialog.showSaveDialog`, then `fs.promises.writeFile`s the decoded buffer.
+
+**Default filename:** `activity-map-<study-slug>-<YYYY-MM-DD>.png`, written to the OS Downloads folder unless the user picks elsewhere.
+
+**Tile CORS:** both `<TileLayer>` components in `SpeciesMap` set `crossOrigin=""` so the Esri World_Imagery and OSM tiles can be rendered onto the canvas without tainting it.
+
 ## Image Directory Export
 
 Organizes images into species-named folders.

--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -115,6 +115,14 @@ Runs in the sequences worker thread (off the main process). Threatened species a
 | ------------------------------- | ------------------------ | ---------- | ---------------------- |
 | `getLocationsActivity(studyId)` | `locations:get-activity` | studyId    | `{ data: Activity[] }` |
 
+### Activity Map Export
+
+| Method                                                  | Channel                    | Parameters                  | Returns                                                                |
+| ------------------------------------------------------- | -------------------------- | --------------------------- | ---------------------------------------------------------------------- |
+| `exportActivityMapPng({ dataUrl, defaultFilename })`    | `activity:export-map-png`  | base64 PNG data URL, name   | `{ success: true, filePath } \| { cancelled: true } \| { success: false, error }` |
+
+The renderer captures the Leaflet map container with `html-to-image` (`pixelRatio: 2`, `crossOrigin=""` set on the tile layers so the canvas isn't tainted) and passes a `data:image/png;base64,…` URL plus a default filename. Main shows a save dialog (default location: Downloads) and writes the decoded buffer to disk. Triggered from the Activity tab's right-click context menu on the map.
+
 ### Sequence-Aware Species Counts
 
 These endpoints perform sequence grouping and counting in the main thread, returning pre-computed results. This avoids transferring raw media-level data to the renderer and keeps computation off the UI thread.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "ffmpeg-static": "^5.3.0",
         "fuse.js": "^7.3.0",
         "geo-tz": "^8.1.4",
+        "html-to-image": "^1.11.13",
         "js-yaml": "^4.1.1",
         "leaflet": "^1.9.4",
         "linebyline": "^1.3.0",
@@ -8617,6 +8618,12 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "ffmpeg-static": "^5.3.0",
     "fuse.js": "^7.3.0",
     "geo-tz": "^8.1.4",
+    "html-to-image": "^1.11.13",
     "js-yaml": "^4.1.1",
     "leaflet": "^1.9.4",
     "linebyline": "^1.3.0",

--- a/src/main/ipc/activity.js
+++ b/src/main/ipc/activity.js
@@ -2,9 +2,10 @@
  * Activity-related IPC handlers
  */
 
-import { app, ipcMain } from 'electron'
+import { app, dialog, ipcMain } from 'electron'
 import log from 'electron-log'
-import { existsSync } from 'fs'
+import { existsSync, promises as fsp } from 'fs'
+import path from 'path'
 import { getStudyDatabasePath } from '../services/paths.js'
 import { getLocationsActivity } from '../database/index.js'
 
@@ -25,6 +26,33 @@ export function registerActivityIPCHandlers() {
     } catch (error) {
       log.error('Error getting locations activity:', error)
       return { error: error.message }
+    }
+  })
+
+  ipcMain.handle('activity:export-map-png', async (_, { dataUrl, defaultFilename }) => {
+    try {
+      const downloadsPath = app.getPath('downloads')
+      const safeName = defaultFilename || `activity-map-${Date.now()}.png`
+      const result = await dialog.showSaveDialog({
+        title: 'Save Activity Map',
+        defaultPath: path.join(downloadsPath, safeName),
+        filters: [{ name: 'PNG Image', extensions: ['png'] }]
+      })
+
+      if (result.canceled || !result.filePath) {
+        return { cancelled: true }
+      }
+
+      const base64 = (dataUrl || '').replace(/^data:image\/png;base64,/, '')
+      if (!base64) {
+        return { success: false, error: 'Empty image payload' }
+      }
+
+      await fsp.writeFile(result.filePath, Buffer.from(base64, 'base64'))
+      return { success: true, filePath: result.filePath }
+    } catch (error) {
+      log.error('Error exporting activity map PNG:', error)
+      return { success: false, error: error.message }
     }
   })
 }

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -384,6 +384,14 @@ const api = {
     return await electronAPI.ipcRenderer.invoke('diagnostics:export')
   },
 
+  // Activity tab — export the rendered Leaflet map as a PNG file
+  exportActivityMapPng: async ({ dataUrl, defaultFilename }) => {
+    return await electronAPI.ipcRenderer.invoke('activity:export-map-png', {
+      dataUrl,
+      defaultFilename
+    })
+  },
+
   // Settings → Info tab
   getChangelog: async (limit = 3) => {
     return await electronAPI.ipcRenderer.invoke('info:get-changelog', limit)

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -6,7 +6,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: cached-image: https: http:; media-src 'self' local-file: https: http:"
+      content="default-src 'self'; connect-src 'self' http://localhost:* https://fonts.gstatic.com https://api.gbif.org https://server.arcgisonline.com https://*.tile.openstreetmap.org; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: local-file: cached-image: https: http:; media-src 'self' local-file: https: http:"
     />
   </head>
 

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -1,12 +1,15 @@
+import * as htmlToImage from 'html-to-image'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import { MapPin } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { LayersControl, MapContainer, Marker, TileLayer, useMap } from 'react-leaflet'
+import { LayersControl, MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import ActivityMapContextMenu from './ui/ActivityMapContextMenu'
 import CircularTimeFilter, { DailyActivityRadar } from './ui/clock'
 import MarkerHoverCard from './ui/MarkerHoverCard'
 import PlaceholderMap from './ui/PlaceholderMap'
@@ -51,6 +54,32 @@ function LayerChangeHandler({ onLayerChange }) {
   return null
 }
 
+// Bridges Leaflet's right-click event to React state in the parent
+// SpeciesMap, and keeps a ref to the map instance so the export handler
+// can read it after the menu has closed (which would otherwise drop the
+// reference if it were stored alongside the menu position).
+function MapContextMenuController({ onContextMenu, mapRef }) {
+  const map = useMapEvents({
+    contextmenu(e) {
+      e.originalEvent.preventDefault()
+      onContextMenu({
+        x: e.originalEvent.clientX,
+        y: e.originalEvent.clientY
+      })
+    }
+  })
+  useEffect(() => {
+    mapRef.current = map
+  }, [map, mapRef])
+  return null
+}
+
+const slugifyForFilename = (s) =>
+  (s || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
 // SpeciesMap component.
 //
 // Renders the leaflet map in two progressive modes so the user sees something
@@ -76,6 +105,7 @@ const SpeciesMap = ({
   palette,
   geoKey,
   studyId,
+  studyName,
   scientificToCommon
 }) => {
   // Persist map layer selection per study
@@ -88,6 +118,57 @@ const SpeciesMap = ({
   useEffect(() => {
     localStorage.setItem(mapLayerKey, selectedLayer)
   }, [selectedLayer, mapLayerKey])
+
+  // Right-click context menu for "Save map as PNG…"
+  const mapRef = useRef(null)
+  const [contextMenu, setContextMenu] = useState(null)
+
+  const handleSavePng = useCallback(async () => {
+    const map = mapRef.current
+    if (!map) return
+    const container = map.getContainer()
+    const slug = slugifyForFilename(studyName) || slugifyForFilename(studyId) || 'study'
+    const date = new Date().toISOString().slice(0, 10)
+    const defaultFilename = `activity-map-${slug}-${date}.png`
+    toast.loading('Preparing map image…', { id: 'activity-map-export' })
+    try {
+      const dataUrl = await htmlToImage.toPng(container, {
+        pixelRatio: 2,
+        // skipFonts avoids html-to-image fetching @import url(fonts.googleapis.com)
+        // through CSP `connect-src` — fonts in the export fall back to system UI fonts,
+        // which is fine for the tile labels and our own legend text.
+        skipFonts: true,
+        // Strip Leaflet's UI controls from the export. Attribution stays
+        // (legal requirement for OSM/Esri).
+        filter: (node) => {
+          const cl = node.classList
+          if (!cl) return true
+          if (cl.contains('leaflet-control-zoom')) return false
+          if (cl.contains('leaflet-control-layers')) return false
+          return true
+        }
+      })
+      const result = await window.api.exportActivityMapPng({ dataUrl, defaultFilename })
+      if (result?.cancelled) {
+        toast.dismiss('activity-map-export')
+      } else if (result?.success) {
+        toast.success('Map saved', {
+          id: 'activity-map-export',
+          description: result.filePath
+        })
+      } else {
+        toast.error('Export failed', {
+          id: 'activity-map-export',
+          description: result?.error || 'Unknown error'
+        })
+      }
+    } catch (error) {
+      toast.error('Export failed', {
+        id: 'activity-map-export',
+        description: error.message
+      })
+    }
+  }, [studyId, studyName])
   // Function to create a pie chart icon
   const createPieChartIcon = (counts) => {
     const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
@@ -323,129 +404,146 @@ const SpeciesMap = ({
   }
 
   return (
-    <MapContainer
-      bounds={bounds}
-      boundsOptions={boundsOptions}
-      className="rounded w-full h-full border border-gray-200"
-    >
-      <LayersControl position="topright">
-        <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>
-          <TileLayer
-            attribution='&copy; <a href="https://www.esri.com">Esri</a>'
-            url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
-          />
-        </LayersControl.BaseLayer>
+    <>
+      <MapContainer
+        bounds={bounds}
+        boundsOptions={boundsOptions}
+        className="rounded w-full h-full border border-gray-200"
+      >
+        <MapContextMenuController onContextMenu={setContextMenu} mapRef={mapRef} />
+        <LayersControl position="topright">
+          <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>
+            <TileLayer
+              attribution='&copy; <a href="https://www.esri.com">Esri</a>'
+              url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+              crossOrigin=""
+            />
+          </LayersControl.BaseLayer>
 
-        <LayersControl.BaseLayer name="Street Map" checked={selectedLayer === 'Street Map'}>
-          <TileLayer
-            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          />
-        </LayersControl.BaseLayer>
+          <LayersControl.BaseLayer name="Street Map" checked={selectedLayer === 'Street Map'}>
+            <TileLayer
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              crossOrigin=""
+            />
+          </LayersControl.BaseLayer>
 
-        <LayersControl.Overlay name="Species Distribution" checked={true}>
-          {skeletonMode ? (
-            <MarkerClusterGroup
-              key={`skeleton:${skeletonPoints.length}`}
-              chunkedLoading
-              showCoverageOnHover={false}
-              spiderfyOnEveryZoom={false}
-              maxClusterRadius={100}
-              animateAddingMarkers={false}
-              iconCreateFunction={createSkeletonClusterIcon}
-            >
-              {skeletonPoints.map((point, index) => (
-                <Marker
-                  key={`skeleton-${index}`}
-                  position={[point.lat, point.lng]}
-                  icon={skeletonDotIcon}
-                />
-              ))}
-            </MarkerClusterGroup>
-          ) : (
-            <MarkerClusterGroup
-              key={`pies:${geoKey}`}
-              chunkedLoading
-              showCoverageOnHover={false}
-              spiderfyOnEveryZoom={false}
-              maxClusterRadius={100}
-              animateAddingMarkers={false}
-              iconCreateFunction={(cluster) => {
-                // Get all markers in this cluster
-                const markers = cluster.getAllChildMarkers()
+          <LayersControl.Overlay name="Species Distribution" checked={true}>
+            {skeletonMode ? (
+              <MarkerClusterGroup
+                key={`skeleton:${skeletonPoints.length}`}
+                chunkedLoading
+                showCoverageOnHover={false}
+                spiderfyOnEveryZoom={false}
+                maxClusterRadius={100}
+                animateAddingMarkers={false}
+                iconCreateFunction={createSkeletonClusterIcon}
+              >
+                {skeletonPoints.map((point, index) => (
+                  <Marker
+                    key={`skeleton-${index}`}
+                    position={[point.lat, point.lng]}
+                    icon={skeletonDotIcon}
+                  />
+                ))}
+              </MarkerClusterGroup>
+            ) : (
+              <MarkerClusterGroup
+                key={`pies:${geoKey}`}
+                chunkedLoading
+                showCoverageOnHover={false}
+                spiderfyOnEveryZoom={false}
+                maxClusterRadius={100}
+                animateAddingMarkers={false}
+                iconCreateFunction={(cluster) => {
+                  // Get all markers in this cluster
+                  const markers = cluster.getAllChildMarkers()
 
-                // Combine counts from all markers
-                const combinedCounts = {}
+                  // Combine counts from all markers
+                  const combinedCounts = {}
 
-                // First, initialize counts for all selected species to ensure consistent ordering
-                selectedSpecies.forEach((species) => {
-                  combinedCounts[species.scientificName] = 0
-                })
-
-                // Then add actual counts from markers
-                markers.forEach((marker) => {
-                  Object.entries(marker.options.counts).forEach(([species, count]) => {
-                    // Only add species that are in our selectedSpecies list
-                    if (selectedSpecies.some((s) => s.scientificName === species)) {
-                      combinedCounts[species] += count
-                    }
+                  // First, initialize counts for all selected species to ensure consistent ordering
+                  selectedSpecies.forEach((species) => {
+                    combinedCounts[species.scientificName] = 0
                   })
-                })
 
-                // Filter out species with zero counts to avoid empty slices
-                const filteredCounts = Object.fromEntries(
-                  Object.entries(combinedCounts).filter(([, count]) => count > 0)
-                )
+                  // Then add actual counts from markers
+                  markers.forEach((marker) => {
+                    Object.entries(marker.options.counts).forEach(([species, count]) => {
+                      // Only add species that are in our selectedSpecies list
+                      if (selectedSpecies.some((s) => s.scientificName === species)) {
+                        combinedCounts[species] += count
+                      }
+                    })
+                  })
 
-                // Bind tooltip to cluster. Same beside-the-pie behavior as
-                // individual markers — see the per-marker bindTooltip above.
-                const tooltipHtml = createTooltipContent(filteredCounts)
-                cluster.unbindTooltip()
-                cluster.bindTooltip(tooltipHtml, {
-                  direction: 'auto',
-                  offset: [0, 0],
-                  opacity: 1,
-                  className: 'species-map-tooltip'
-                })
+                  // Filter out species with zero counts to avoid empty slices
+                  const filteredCounts = Object.fromEntries(
+                    Object.entries(combinedCounts).filter(([, count]) => count > 0)
+                  )
 
-                return createPieChartIcon(filteredCounts)
-              }}
-            >
-              {locationPoints.map((point, index) => (
-                <PieChartMarker key={index} point={point} icon={createPieChartIcon(point.counts)} />
-              ))}
-            </MarkerClusterGroup>
-          )}
-        </LayersControl.Overlay>
+                  // Bind tooltip to cluster. Same beside-the-pie behavior as
+                  // individual markers — see the per-marker bindTooltip above.
+                  const tooltipHtml = createTooltipContent(filteredCounts)
+                  cluster.unbindTooltip()
+                  cluster.bindTooltip(tooltipHtml, {
+                    direction: 'auto',
+                    offset: [0, 0],
+                    opacity: 1,
+                    className: 'species-map-tooltip'
+                  })
 
-        {/* Add a legend */}
-        <div className="absolute bottom-5 right-5 bg-white p-2 rounded shadow-md z-[1000] flex flex-col gap-2">
-          {selectedSpecies.map((species, index) => {
-            const common = getMapDisplayName(species.scientificName, scientificToCommon)
-            const showSci = common && common !== species.scientificName
-            return (
-              <div key={index} className="flex items-start gap-2">
-                <div
-                  className="w-3 h-3 rounded-full mt-0.5 flex-shrink-0"
-                  style={{ backgroundColor: palette[index % palette.length] }}
-                ></div>
-                <div className="flex flex-col min-w-0 leading-tight">
-                  <span className={`text-xs ${common ? 'capitalize' : 'italic'}`}>
-                    {common || formatScientificName(species.scientificName)}
-                  </span>
-                  {showSci && (
-                    <span className="text-[10px] text-gray-500 italic">
-                      {formatScientificName(species.scientificName)}
+                  return createPieChartIcon(filteredCounts)
+                }}
+              >
+                {locationPoints.map((point, index) => (
+                  <PieChartMarker
+                    key={index}
+                    point={point}
+                    icon={createPieChartIcon(point.counts)}
+                  />
+                ))}
+              </MarkerClusterGroup>
+            )}
+          </LayersControl.Overlay>
+
+          {/* Add a legend */}
+          <div className="absolute bottom-5 right-5 bg-white p-2 rounded shadow-md z-[1000] flex flex-col gap-2">
+            {selectedSpecies.map((species, index) => {
+              const common = getMapDisplayName(species.scientificName, scientificToCommon)
+              const showSci = common && common !== species.scientificName
+              return (
+                <div key={index} className="flex items-start gap-2">
+                  <div
+                    className="w-3 h-3 rounded-full mt-0.5 flex-shrink-0"
+                    style={{ backgroundColor: palette[index % palette.length] }}
+                  ></div>
+                  <div className="flex flex-col min-w-0 leading-tight">
+                    <span className={`text-xs ${common ? 'capitalize' : 'italic'}`}>
+                      {common || formatScientificName(species.scientificName)}
                     </span>
-                  )}
+                    {showSci && (
+                      <span className="text-[10px] text-gray-500 italic">
+                        {formatScientificName(species.scientificName)}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )
-          })}
-        </div>
-      </LayersControl>
-      <LayerChangeHandler onLayerChange={setSelectedLayer} />
-    </MapContainer>
+              )
+            })}
+          </div>
+        </LayersControl>
+        <LayerChangeHandler onLayerChange={setSelectedLayer} />
+      </MapContainer>
+      {contextMenu && (
+        <ActivityMapContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onSave={handleSavePng}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </>
   )
 }
 
@@ -716,6 +814,7 @@ export default function Activity({ studyData, studyId }) {
                     selectedSpecies={selectedSpecies}
                     palette={palette}
                     studyId={actualStudyId}
+                    studyName={studyData?.name}
                     geoKey={geoKey}
                     scientificToCommon={scientificToCommon}
                   />

--- a/src/renderer/src/ui/ActivityMapContextMenu.jsx
+++ b/src/renderer/src/ui/ActivityMapContextMenu.jsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+import { Download } from 'lucide-react'
+
+export default function ActivityMapContextMenu({ x, y, onSave, onClose }) {
+  useEffect(() => {
+    const handleClickOutside = () => onClose()
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('click', handleClickOutside)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed z-[2000] bg-white rounded-md shadow-lg border border-gray-200 py-1"
+      style={{ top: y, left: x }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        onClick={() => {
+          onSave()
+          onClose()
+        }}
+        className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 w-full text-left"
+      >
+        <Download className="h-4 w-4" />
+        Save map as PNG…
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Right-click the Activity tab's map → **Save map as PNG…** opens a native save dialog and writes the current view (default name `activity-map-<study-slug>-<date>.png`).
- Capture uses `html-to-image` at `pixelRatio: 2`, filtering out the zoom and layers controls; attribution stays in the export to honour OSM/Esri terms.
- `crossOrigin=""` on both `<TileLayer>`s + CSP `connect-src` widened to `https://server.arcgisonline.com` and `https://*.tile.openstreetmap.org` so the canvas isn't tainted; `skipFonts: true` avoids refetching Google Fonts through CSP.

## Test plan
- [x] Open a study with deployment locations and ≥1 selected species in the Activity tab.
- [x] Right-click the map → context menu appears at the cursor; click outside or press Escape dismisses it.
- [x] Click **Save map as PNG…** → save dialog opens with a sensible default filename in Downloads.
- [x] Saved PNG shows tiles, pie markers, legend, and attribution; no zoom or layer-toggle controls.
- [x] Repeat after panning/zooming → exported image matches the on-screen view.
- [x] Repeat with the Street Map base layer selected → tiles still render.
- [x] Cancel the save dialog → no file written, no error toast.