### PR TITLE
chore: hide Leaflet attribution prefix on all maps

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -11,6 +11,7 @@ import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import ActivityMapContextMenu from './ui/ActivityMapContextMenu'
 import CircularTimeFilter, { DailyActivityRadar } from './ui/clock'
+import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import MarkerHoverCard from './ui/MarkerHoverCard'
 import PlaceholderMap from './ui/PlaceholderMap'
 import SpeciesDistribution from './ui/speciesDistribution'
@@ -410,6 +411,7 @@ const SpeciesMap = ({
         boundsOptions={boundsOptions}
         className="rounded w-full h-full border border-gray-200"
       >
+        <HideLeafletAttribution />
         <MapContextMenuController onContextMenu={setContextMenu} mapRef={mapRef} />
         <LayersControl position="topright">
           <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>

--- a/src/renderer/src/deployments.jsx
+++ b/src/renderer/src/deployments.jsx
@@ -10,6 +10,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useSearchParams } from 'react-router'
 import { useImportStatus } from '@renderer/hooks/import'
+import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import SkeletonDeploymentsList from './ui/SkeletonDeploymentsList'
 import { resolveSelectedDeployment, withDeploymentParam } from './deployments/urlState'
 import DeploymentDetailPane from './deployments/DeploymentDetailPane'
@@ -358,6 +359,7 @@ function LocationMap({
         style={{ height: '100%', width: '100%' }}
         ref={mapRef}
       >
+        <HideLeafletAttribution />
         <LayersControl position="topright">
           <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>
             <TileLayer

--- a/src/renderer/src/models/MapPane.jsx
+++ b/src/renderer/src/models/MapPane.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react'
 import { MapContainer, TileLayer, GeoJSON, useMap } from 'react-leaflet'
 import L from 'leaflet'
+import HideLeafletAttribution from '../ui/HideLeafletAttribution'
 import { getRegion } from './regions'
 
 const geojsonCache = new Map()
@@ -122,12 +123,14 @@ export default function MapPane({ modelZoo, selectedId, onSelect }) {
         maxBoundsViscosity={1.0}
         style={{ height: '100%', width: '100%' }}
       >
+        <HideLeafletAttribution />
         <TileLayer
           noWrap={true}
           bounds={[
             [-90, -180],
             [90, 180]
           ]}
+          attribution='&copy; <a href="https://www.esri.com">Esri</a>'
           url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
         />
         {regionalModels.map((m) => {

--- a/src/renderer/src/overview.jsx
+++ b/src/renderer/src/overview.jsx
@@ -5,6 +5,7 @@ import { LayersControl, MapContainer, TileLayer, Marker, Popup, useMap } from 'r
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { Camera, MapPin } from 'lucide-react'
+import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import PlaceholderMap from './ui/PlaceholderMap'
 import { useImportStatus } from '@renderer/hooks/import'
 import { useQuery } from '@tanstack/react-query'
@@ -162,6 +163,7 @@ function DeploymentMap({ deployments, studyId }) {
         boundsOptions={{ padding: [30, 30] }}
         style={{ height: '100%', width: '100%' }}
       >
+        <HideLeafletAttribution />
         <LayersControl position="topright">
           <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>
             <TileLayer

--- a/src/renderer/src/ui/HideLeafletAttribution.jsx
+++ b/src/renderer/src/ui/HideLeafletAttribution.jsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+import { useMap } from 'react-leaflet'
+
+export default function HideLeafletAttribution() {
+  const map = useMap()
+  useEffect(() => {
+    map.attributionControl?.setPrefix(false)
+  }, [map])
+  return null
+}

--- a/src/renderer/src/ui/PlaceholderMap.jsx
+++ b/src/renderer/src/ui/PlaceholderMap.jsx
@@ -1,6 +1,7 @@
 import { MapPin } from 'lucide-react'
 import { MapContainer, TileLayer } from 'react-leaflet'
 import { Link } from 'react-router'
+import HideLeafletAttribution from './HideLeafletAttribution'
 
 /**
  * PlaceholderMap - Shows a world map with an overlay message when deployment coordinates are missing.
@@ -22,6 +23,7 @@ function PlaceholderMap({ title, description, linkTo, linkText, studyId, icon: I
         zoomControl={true}
         scrollWheelZoom={true}
       >
+        <HideLeafletAttribution />
         <TileLayer
           attribution='&copy; <a href="https://www.esri.com">Esri</a>'
           url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"


### PR DESCRIPTION
## Summary
- Adds a small `HideLeafletAttribution` helper component (`useMap` + `setPrefix(false)`) and drops it inside all five `MapContainer` instances (activity, overview, deployments, model selection pane, placeholder map).
- Esri and OpenStreetMap credits are preserved; only the "Leaflet" prefix is hidden.
- Also adds the missing `attribution='© Esri'` to the model-selection `MapPane` TileLayer for consistency.

## Test plan
- [x] Open the Activity, Overview, Deployments, and AI model-selection views — verify each map shows only the tile attribution (e.g. "© Esri" / "© OpenStreetMap contributors") with no leading "Leaflet | ".
- [x] Switch baselayers (Satellite ↔ Street Map) on Activity/Overview/Deployments and confirm attribution swaps as before.
- [x] Open a study with no deployment coordinates to render `PlaceholderMap` and confirm the same behavior.