### PR TITLE
feat(deployments): add deployment-settings popover

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -98,6 +98,7 @@ Runs in the sequences worker thread (off the main process). Threatened species a
 | `getDeploymentLocations(studyId)`                              | `deployments:get-locations`     | studyId                           | `{ data: Deployment[] }` |
 | `getAllDeployments(studyId)`                                   | `deployments:get-all`           | studyId                           | `{ data: Deployment[] }` |
 | `getDeploymentSpecies(studyId, deploymentID)`                  | `deployments:get-species`       | studyId, deploymentID             | `{ data: { scientificName, count }[] }` |
+| `getDeploymentStats(studyId, deploymentID)`                    | `deployments:get-stats`         | studyId, deploymentID             | `{ data: { mediaCount, observationCount, blankCount } }` — `blankCount` is media-level (count of media with no real animal/human/vehicle observation), matching the species-filter popover's `BLANK_SENTINEL` count. |
 | `getDeploymentsActivity(studyId, periodCount?)`                | `deployments:get-activity`      | studyId, periodCount (optional)   | `{ data: Activity[] }`   |
 | `setDeploymentLatitude(studyId, deploymentID, latitude)`       | `deployments:set-latitude`      | studyId, deploymentID, latitude   | `{ success: boolean }`   |
 | `setDeploymentLongitude(studyId, deploymentID, longitude)`     | `deployments:set-longitude`     | studyId, deploymentID, longitude  | `{ success: boolean }`   |

--- a/docs/specs/2026-05-06-deployment-settings-popover-design.md
+++ b/docs/specs/2026-05-06-deployment-settings-popover-design.md
@@ -1,0 +1,300 @@
+# Deployment settings popover
+
+**Date:** 2026-05-06
+**Status:** Design — approved
+**Area:** renderer (`src/renderer/src/deployments/DeploymentDetailPane.jsx`, new `DeploymentSettingsPopover.jsx`); main (new `deployments:get-stats` IPC handler)
+
+## Summary
+
+Add a small popover, opened from a new gear icon in the `DeploymentDetailPane`
+header, that surfaces deployment + camera context for the currently selected
+deployment alongside three at-a-glance counts (media, observations, blank
+rate). Read-only for v1; row layout chosen so v2 can add inline editing
+without restructuring.
+
+## Motivation
+
+When a researcher selects a deployment in the Deployments tab, the bottom
+pane shows the media gallery for that deployment but only the editable
+location name in its header. Other context — start/end dates, camera
+identifiers, total media and observation counts, share of blank captures —
+is either invisible or only computable by scrolling/filtering the gallery.
+
+Surfacing this in a single gear-icon popover gives the user fast,
+non-disruptive access without leaving the gallery view, and creates a home
+for the deployment-edit affordances we will want later (correcting camera
+ID, adjusting deployment dates, etc.).
+
+## Goals
+
+- New gear-icon button in the `DeploymentDetailPane` header, sitting
+  alongside `LocationPopover` and `SpeciesFilterButton`.
+- Dropdown popover (~320px wide) opens beneath the icon; click-outside
+  closes it. Same interaction pattern as the adjacent `SpeciesFilterButton`
+  popover and `LocationPopover`.
+- Three sections: Stats, Camera (conditional), Deployment.
+- Stats section renders Media and Observations as tiles plus a derived
+  Blank-rate row with a thin progress bar.
+- Counts are fetched lazily on first open, cached per
+  `(studyId, deploymentID)`.
+- Layout designed so future inline editing (v2) drops in without
+  structural changes.
+
+## Non-goals
+
+- **Editing.** All fields are read-only in v1. The hover-to-edit
+  affordance per row is a planned v2 extension; it is not implemented now.
+- **Reuse outside the Deployments tab.** The `ImageModal` and
+  `DeploymentLinkPill` (used in Best Captures and elsewhere) are
+  separate concerns; this popover is scoped to the deployment-detail
+  pane only.
+- **New deployment-metadata fields** (height, bait, person, feature
+  type). Adding these would require schema changes and is out of scope.
+- **`coordinateUncertainty`.** The field is in the schema but
+  unpopulated across all 17 surveyed studies; not displayed.
+
+## Survey of existing data
+
+Field-population rates across the 17 studies in the user's local
+`biowatch-data/studies/` directory:
+
+| Field                   | Coverage          | Decision                                                |
+|-------------------------|-------------------|---------------------------------------------------------|
+| `deploymentStart`/`End` | ~94% of studies   | Show; em-dash when null. Duration row hidden if either null. |
+| `locationID`            | ~100%             | Not displayed (internal grouping key, not user context). |
+| `locationName`          | ~94%              | Not displayed (already in pane header via `EditableLocationName`). |
+| `latitude`/`longitude`  | ~70%              | Not displayed (already in `LocationPopover`).           |
+| `cameraModel`           | ~0% (3 rows total)| Show only when populated; whole Camera section hidden if both camera fields null. |
+| `cameraID`              | ~25% (3 studies)  | Same — show when populated.                             |
+| `coordinateUncertainty` | ~0%               | **Dropped** from spec.                                  |
+
+## Layout
+
+The pane header today (`DeploymentDetailPane.jsx:37–68`):
+
+```
+[ Editable location name ]   [📍 LocationPopover] [▽ SpeciesFilter] [× Close]
+```
+
+Becomes:
+
+```
+[ Editable location name ]   [📍] [▽] [⚙ Settings] [× Close]
+```
+
+Gear icon sits between `SpeciesFilterButton` and the close button. 16px
+lucide `Settings` icon, same hover treatment as siblings (`p-1
+hover:bg-gray-100 rounded text-gray-500 hover:text-gray-700`).
+
+Popover uses the floating-panel pattern already in
+`DeploymentDetailPane.jsx:150–183` for the species filter:
+`absolute right-0 top-full mt-1 w-80 bg-white border border-gray-200
+rounded-lg shadow-lg z-[1100]`. Outside-click closes it via the same
+`mousedown` listener pattern.
+
+## Popover content
+
+```
+┌──────────────────────────────────────┐
+│ STATS                                │
+│ ┌────────────┐  ┌────────────┐      │
+│ │   1,432    │  │   2,108    │      │
+│ │   MEDIA    │  │OBSERVATIONS│      │
+│ └────────────┘  └────────────┘      │
+│                                      │
+│ BLANK RATE              14.8%  (312) │
+│ ████░░░░░░░░░░░░░░░░░░░░░░░░░░░░    │
+│                                      │
+│ CAMERA                               │
+│ ID                       CTPC_001_T1 │
+│ Model                              — │
+│                                      │
+│ DEPLOYMENT                           │
+│ Start                 2024-08-01 06:14│
+│ End                   2024-08-21 18:30│
+│ Duration                      20 days │
+└──────────────────────────────────────┘
+```
+
+### Stats section (always shown)
+
+- **Media** tile and **Observations** tile in a 2-column grid. Light
+  gray background (`bg-gray-50`), 1px border, 6px radius, padding ~8px.
+  Numbers ~18px / 600 weight; uppercase 10px label below.
+- **Blank rate** row beneath the tiles:
+  - Label `BLANK RATE` (uppercase, 11px, gray-500) on the left.
+  - Right-aligned value: `XX.X%` in foreground color, count in parens
+    in lighter gray — `14.8% (312)`.
+  - 6px-tall progress bar (gray-200 background, gray-400 fill) under
+    the row, width = `blankCount / mediaCount * 100%`.
+  - When `mediaCount === 0`: rate row reads `— (0)`, bar is empty.
+  - **`blankCount` is media-level** (count of media with no real
+    animal/human/vehicle observation), to match the existing
+    `BLANK_SENTINEL` count shown in the species-filter popover. See
+    Data flow below.
+- Counts render `0` for true zeros. While loading, render `—` for all
+  three numbers and an empty progress bar.
+
+### Camera section (conditional)
+
+- **Hidden entirely** when both `cameraModel` and `cameraID` are null
+  or empty.
+- When at least one is set: section header `CAMERA`, then two rows.
+  Each row: gray-500 label on the left, foreground value on the right.
+  Em-dash (gray-400) for the unset field.
+- Order: `ID`, then `Model`. (ID is the more frequently populated and
+  user-recognizable field.)
+
+### Deployment section (always shown)
+
+- Section header `DEPLOYMENT`, three rows: `Start`, `End`, `Duration`.
+- `Start` / `End`: rendered with the same formatter the app already
+  uses for deployment dates (`overview.jsx:138`'s `formatDate` —
+  `toLocaleDateString('en-US', { year: 'numeric', month: 'short', day:
+  'numeric' })` → e.g. `Aug 1, 2024`). Time-of-day is intentionally
+  omitted to match existing convention; if camera-trap deployments turn
+  out to need minute precision in the popover, switch to
+  `toLocaleString()` in a follow-up. Em-dash when the underlying field
+  is null.
+- `Duration`: derived from start + end, integer days
+  (`Math.round((end - start) / 86400000)`). Suffix `day` if 1, else
+  `days`. If the rounded difference is 0 (sub-day deployment), show
+  `< 1 day`. If either start or end is null, the row is omitted (not
+  shown as `—`).
+
+## Component architecture
+
+New file: `src/renderer/src/deployments/DeploymentSettingsPopover.jsx`,
+sibling to `LocationPopover.jsx`. Self-contained: button + popover +
+data fetch.
+
+```jsx
+function DeploymentSettingsPopover({ studyId, deployment }) {
+  const [isOpen, setIsOpen] = useState(false)
+  // outside-click handler — same shape as SpeciesFilterButton
+  // useQuery for stats, enabled: isOpen
+  // render button + (isOpen && <PopoverPanel ...>)
+}
+```
+
+Mounted from `DeploymentDetailPane.jsx` (line 47, in the right-side
+button cluster):
+
+```jsx
+<LocationPopover ... />
+<SpeciesFilterButton ... />
+<DeploymentSettingsPopover studyId={studyId} deployment={deployment} />
+<button onClick={onClose} ...><X size={16} /></button>
+```
+
+### Why a separate file (not inline in `DeploymentDetailPane.jsx`)
+
+`DeploymentDetailPane.jsx` already inlines the `SpeciesFilterButton`
+component (262 lines). Adding a third inline component would push the
+file past readable size and conflate three distinct concerns.
+`LocationPopover` already has its own file; this matches that pattern.
+
+## Data flow
+
+### Inputs already available
+
+The pane receives the full `deployment` row as a prop. That gives us
+`deploymentStart`, `deploymentEnd`, `cameraModel`, `cameraID`,
+`locationID`, `locationName`, `latitude`, `longitude` — no new fetch
+required for the metadata sections.
+
+### New IPC handler: `deployments:get-stats`
+
+Signature:
+
+```js
+ipcMain.handle('deployments:get-stats', async (_event, studyId, deploymentID) => {
+  // returns { mediaCount, observationCount, blankCount }
+})
+```
+
+Implementation: three counts run concurrently with `Promise.all`:
+
+- **`mediaCount`** — `SELECT COUNT(*) FROM media WHERE deploymentID = ?`.
+  New small query helper (e.g.
+  `getMediaCountForDeployment(dbPath, deploymentID)`) added to
+  `src/main/database/queries/deployments.js`.
+- **`observationCount`** — `SELECT COUNT(*) FROM observations WHERE
+  deploymentID = ?`. New small query helper (e.g.
+  `getObservationCountForDeployment(dbPath, deploymentID)`) in the
+  same file.
+- **`blankCount`** — reuse the existing
+  `getBlankMediaCountForDeployment(dbPath, deploymentID)` already in
+  `src/main/database/queries/deployments.js:183`. This counts **media**
+  with no real (non-blank, non-vehicle) observation — the same
+  definition the species-filter popover uses for `BLANK_SENTINEL`.
+
+Indexes available — `idx_media_deploymentID`,
+`idx_observations_deploymentID`, and `idx_observations_blank_cover`
+(`mediaID, scientificName, observationType` — a covering index for
+the blank-media subquery). `EXPLAIN QUERY PLAN` confirms the blank
+subquery uses `idx_observations_blank_cover`. Measured directly: all
+three counts together return in ~10–20 ms on the largest sampled
+deployment (10,518 media inside a 4.6 GB study DB with ~1.9M
+observations). No caching or precomputation needed.
+
+Preload exposure: `window.api.getDeploymentStats(studyId, deploymentID)`
+in `src/preload/index.js`, following the existing
+`getDeploymentSpecies` pattern.
+
+### Renderer fetch
+
+```js
+const { data: stats } = useQuery({
+  queryKey: ['deploymentStats', studyId, deploymentID],
+  queryFn: async () => {
+    const response = await window.api.getDeploymentStats(studyId, deploymentID)
+    if (response.error) throw new Error(response.error)
+    return response.data
+  },
+  enabled: isOpen && !!studyId && !!deploymentID,
+  staleTime: Infinity,
+})
+```
+
+Same pattern as `SpeciesFilterButton` — lazy on first open, cached for
+the lifetime of the React Query cache. Counts only change on import,
+which already invalidates broader caches.
+
+## Edge cases
+
+- **Empty deployment (zero media, zero observations).** Tiles show `0`,
+  blank-rate row shows `— (0)`, bar empty. Camera section hidden if
+  empty. Deployment section shown normally.
+- **`BLANK_SENTINEL` in renderer code.** The sentinel is a
+  renderer-only marker (`src/shared/constants.js:10`) — the database
+  stores actual blank-media as media rows with no qualifying
+  observation. The popover's `blankCount` comes from
+  `getBlankMediaCountForDeployment`, so the sentinel never enters
+  the path.
+- **Deployment with only start, no end (open-ended deployment).**
+  Start row shows the date, End row shows `—`, Duration row omitted.
+- **Studies that have neither dates nor coords (e.g.,
+  `ca9faf6c…`).** Stats still render. Camera section hidden. Deployment
+  section shows three em-dashes (Duration row omitted).
+
+## Future-editability hook
+
+In v2, each row in the Camera and Deployment sections gains a hover
+affordance to edit its value, matching `EditableLocationName`'s
+inline-input pattern. The current row layout (gray label left, value
+right) accommodates this without restructuring — only the value cell
+swaps to an input on edit.
+
+## File touch list
+
+- `src/renderer/src/deployments/DeploymentDetailPane.jsx` — import and
+  mount `DeploymentSettingsPopover` in the header button cluster.
+- `src/renderer/src/deployments/DeploymentSettingsPopover.jsx` — **new**.
+- `src/main/ipc/deployments.js` — register
+  `deployments:get-stats` handler.
+- `src/preload/index.js` — expose `getDeploymentStats(studyId,
+  deploymentID)`.
+- `docs/ipc-api.md` — document the new handler.
+- `docs/database-schema.md` — no schema change; only update if we
+  document the queries.

--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -217,6 +217,9 @@ export {
   insertDeployments,
   getDeploymentsActivity,
   getSpeciesForDeployment,
+  getMediaCountForDeployment,
+  getObservationCountForDeployment,
+  getBlankMediaCountForDeployment,
   // Species
   getSpeciesDistribution,
   getBlankMediaCount,

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -98,7 +98,11 @@ export async function getAllDeployments(dbPath) {
         locationID: deployments.locationID,
         locationName: deployments.locationName,
         latitude: deployments.latitude,
-        longitude: deployments.longitude
+        longitude: deployments.longitude,
+        deploymentStart: deployments.deploymentStart,
+        deploymentEnd: deployments.deploymentEnd,
+        cameraID: deployments.cameraID,
+        cameraModel: deployments.cameraModel
       })
       .from(deployments)
 

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -229,6 +229,46 @@ export async function getVehicleMediaCountForDeployment(dbPath, deploymentID) {
 }
 
 /**
+ * Total media count at a single deployment.
+ *
+ * @param {string} dbPath - Path to the SQLite database
+ * @param {string} deploymentID
+ * @returns {Promise<number>}
+ */
+export async function getMediaCountForDeployment(dbPath, deploymentID) {
+  const studyId = getStudyIdFromPath(dbPath)
+  const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
+
+  const result = await db
+    .select({ count: count().as('count') })
+    .from(media)
+    .where(eq(media.deploymentID, deploymentID))
+    .get()
+
+  return Number(result?.count || 0)
+}
+
+/**
+ * Total observation count at a single deployment (including blanks).
+ *
+ * @param {string} dbPath - Path to the SQLite database
+ * @param {string} deploymentID
+ * @returns {Promise<number>}
+ */
+export async function getObservationCountForDeployment(dbPath, deploymentID) {
+  const studyId = getStudyIdFromPath(dbPath)
+  const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
+
+  const result = await db
+    .select({ count: count().as('count') })
+    .from(observations)
+    .where(eq(observations.deploymentID, deploymentID))
+    .get()
+
+  return Number(result?.count || 0)
+}
+
+/**
  * Get activity data (observation counts) per location over time periods
  * @param {string} dbPath - Path to the SQLite database
  * @returns {Promise<Object>} - Activity data with periods and counts per location

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -18,7 +18,10 @@ export {
   getLocationsActivity,
   insertDeployments,
   getDeploymentsActivity,
-  getSpeciesForDeployment
+  getSpeciesForDeployment,
+  getMediaCountForDeployment,
+  getObservationCountForDeployment,
+  getBlankMediaCountForDeployment
 } from './deployments.js'
 
 // Species

--- a/src/main/ipc/deployments.js
+++ b/src/main/ipc/deployments.js
@@ -13,7 +13,10 @@ import {
   closeStudyDatabase,
   getDeploymentLocations,
   getAllDeployments,
-  getSpeciesForDeployment
+  getSpeciesForDeployment,
+  getMediaCountForDeployment,
+  getObservationCountForDeployment,
+  getBlankMediaCountForDeployment
 } from '../database/index.js'
 import { runInWorker } from '../services/sequences/runInWorker.js'
 
@@ -74,6 +77,30 @@ export function registerDeploymentsIPCHandlers() {
       return { data: result }
     } catch (error) {
       log.error('Error getting species for deployment:', error)
+      return { error: error.message }
+    }
+  })
+
+  // At-a-glance stats for a single deployment — used by the deployment
+  // settings popover. blankCount is media-level (matches the BLANK_SENTINEL
+  // count shown in the species-filter popover).
+  ipcMain.handle('deployments:get-stats', async (_, studyId, deploymentID) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const [mediaCount, observationCount, blankCount] = await Promise.all([
+        getMediaCountForDeployment(dbPath, deploymentID),
+        getObservationCountForDeployment(dbPath, deploymentID),
+        getBlankMediaCountForDeployment(dbPath, deploymentID)
+      ])
+
+      return { data: { mediaCount, observationCount, blankCount } }
+    } catch (error) {
+      log.error('Error getting deployment stats:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -42,6 +42,9 @@ const api = {
   getDeploymentSpecies: async (studyId, deploymentID) => {
     return await electronAPI.ipcRenderer.invoke('deployments:get-species', studyId, deploymentID)
   },
+  getDeploymentStats: async (studyId, deploymentID) => {
+    return await electronAPI.ipcRenderer.invoke('deployments:get-stats', studyId, deploymentID)
+  },
   deleteStudyDatabase: async (studyId) => {
     return await electronAPI.ipcRenderer.invoke('study:delete-database', studyId)
   },

--- a/src/renderer/src/deployments/DeploymentDetailPane.jsx
+++ b/src/renderer/src/deployments/DeploymentDetailPane.jsx
@@ -5,6 +5,7 @@ import * as HoverCard from '@radix-ui/react-hover-card'
 import DeploymentMediaGallery from '../media/DeploymentMediaGallery'
 import EditableLocationName from './EditableLocationName'
 import LocationPopover from './LocationPopover'
+import DeploymentSettingsPopover from './DeploymentSettingsPopover'
 import SpeciesTooltipContent from '../ui/SpeciesTooltipContent'
 import { resolveCommonName } from '../../../shared/commonNames/index.js'
 import { formatScientificName } from '../utils/scientificName'
@@ -56,6 +57,7 @@ export default function DeploymentDetailPane({
             selectedSpecies={selectedSpecies}
             onChange={setSelectedSpecies}
           />
+          <DeploymentSettingsPopover studyId={studyId} deployment={deployment} />
           <button
             onClick={onClose}
             className="p-1 hover:bg-gray-100 rounded text-gray-500 hover:text-gray-700"

--- a/src/renderer/src/deployments/DeploymentSettingsPopover.jsx
+++ b/src/renderer/src/deployments/DeploymentSettingsPopover.jsx
@@ -32,7 +32,7 @@ export default function DeploymentSettingsPopover({ studyId, deployment }) {
     return () => window.removeEventListener('mousedown', onDown)
   }, [isOpen])
 
-  const { data: stats, isLoading } = useQuery({
+  const { data: stats } = useQuery({
     queryKey: ['deploymentStats', studyId, deployment.deploymentID],
     queryFn: async () => {
       const response = await window.api.getDeploymentStats(studyId, deployment.deploymentID)
@@ -59,7 +59,7 @@ export default function DeploymentSettingsPopover({ studyId, deployment }) {
           ref={popoverRef}
           className="absolute right-0 top-full mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-[1100] p-4"
         >
-          <StatsSection stats={stats} isLoading={isLoading} />
+          <StatsSection stats={stats} />
           <CameraSection deployment={deployment} />
           <DeploymentSection deployment={deployment} />
         </div>
@@ -68,15 +68,13 @@ export default function DeploymentSettingsPopover({ studyId, deployment }) {
   )
 }
 
-function StatsSection({ stats, isLoading }) {
+function StatsSection({ stats }) {
   const mediaCount = stats?.mediaCount
   const observationCount = stats?.observationCount
   const blankCount = stats?.blankCount
 
   const blankRate =
-    mediaCount && mediaCount > 0 && typeof blankCount === 'number'
-      ? (blankCount / mediaCount) * 100
-      : null
+    mediaCount > 0 && typeof blankCount === 'number' ? (blankCount / mediaCount) * 100 : null
 
   return (
     <div className="mb-3">
@@ -85,23 +83,21 @@ function StatsSection({ stats, isLoading }) {
       </div>
 
       <div className="grid grid-cols-2 gap-2 mb-3">
-        <Tile value={isLoading ? '—' : formatCount(mediaCount)} label="Media" />
-        <Tile value={isLoading ? '—' : formatCount(observationCount)} label="Observations" />
+        <Tile value={formatCount(mediaCount)} label="Media" />
+        <Tile value={formatCount(observationCount)} label="Observations" />
       </div>
 
       <div className="flex items-baseline justify-between text-[11px] text-gray-500 mb-1">
         <span className="uppercase tracking-wide">Blank rate</span>
         <span className="text-gray-900 font-medium">
           {blankRate === null ? '—' : `${blankRate.toFixed(1)}%`}{' '}
-          <span className="text-gray-400 font-normal">
-            ({isLoading ? '—' : formatCount(blankCount)})
-          </span>
+          <span className="text-gray-400 font-normal">({formatCount(blankCount)})</span>
         </span>
       </div>
       <div className="h-1.5 bg-gray-200 rounded-sm overflow-hidden">
         <div
           className="h-full bg-gray-400"
-          style={{ width: blankRate === null ? '0%' : `${blankRate}%` }}
+          style={{ width: blankRate === null ? '0%' : `${Math.min(blankRate, 100)}%` }}
         />
       </div>
     </div>
@@ -171,7 +167,9 @@ function formatCount(n) {
 // dialect as the rest of the app (e.g. "Aug 1, 2024").
 function formatDate(s) {
   if (!s) return null
-  return new Date(s).toLocaleDateString('en-US', {
+  const d = new Date(s)
+  if (Number.isNaN(d.getTime())) return null
+  return d.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric'

--- a/src/renderer/src/deployments/DeploymentSettingsPopover.jsx
+++ b/src/renderer/src/deployments/DeploymentSettingsPopover.jsx
@@ -1,0 +1,191 @@
+import { Settings } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+
+/**
+ * Gear-icon popover in the DeploymentDetailPane header. Shows at-a-glance
+ * stats (media, observations, blank rate), camera identifiers, and
+ * deployment dates/duration for the currently selected deployment.
+ *
+ * Read-only for v1. Row layout (label-left / value-right) is structured
+ * so future inline editing drops in without restructuring.
+ */
+export default function DeploymentSettingsPopover({ studyId, deployment }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const popoverRef = useRef(null)
+  const buttonRef = useRef(null)
+
+  // Outside-click closes the popover. Same pattern as SpeciesFilterButton.
+  useEffect(() => {
+    if (!isOpen) return
+    const onDown = (e) => {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(e.target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    window.addEventListener('mousedown', onDown)
+    return () => window.removeEventListener('mousedown', onDown)
+  }, [isOpen])
+
+  const { data: stats, isLoading } = useQuery({
+    queryKey: ['deploymentStats', studyId, deployment.deploymentID],
+    queryFn: async () => {
+      const response = await window.api.getDeploymentStats(studyId, deployment.deploymentID)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: isOpen && !!studyId && !!deployment.deploymentID,
+    staleTime: Infinity
+  })
+
+  return (
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        onClick={() => setIsOpen((v) => !v)}
+        className="p-1 rounded text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+        title="Deployment settings"
+        aria-label="Deployment settings"
+      >
+        <Settings size={16} />
+      </button>
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          className="absolute right-0 top-full mt-1 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-[1100] p-4"
+        >
+          <StatsSection stats={stats} isLoading={isLoading} />
+          <CameraSection deployment={deployment} />
+          <DeploymentSection deployment={deployment} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function StatsSection({ stats, isLoading }) {
+  const mediaCount = stats?.mediaCount
+  const observationCount = stats?.observationCount
+  const blankCount = stats?.blankCount
+
+  const blankRate =
+    mediaCount && mediaCount > 0 && typeof blankCount === 'number'
+      ? (blankCount / mediaCount) * 100
+      : null
+
+  return (
+    <div className="mb-3">
+      <div className="text-[11px] font-semibold text-gray-700 uppercase tracking-wide mb-2">
+        Stats
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 mb-3">
+        <Tile value={isLoading ? '—' : formatCount(mediaCount)} label="Media" />
+        <Tile value={isLoading ? '—' : formatCount(observationCount)} label="Observations" />
+      </div>
+
+      <div className="flex items-baseline justify-between text-[11px] text-gray-500 mb-1">
+        <span className="uppercase tracking-wide">Blank rate</span>
+        <span className="text-gray-900 font-medium">
+          {blankRate === null ? '—' : `${blankRate.toFixed(1)}%`}{' '}
+          <span className="text-gray-400 font-normal">
+            ({isLoading ? '—' : formatCount(blankCount)})
+          </span>
+        </span>
+      </div>
+      <div className="h-1.5 bg-gray-200 rounded-sm overflow-hidden">
+        <div
+          className="h-full bg-gray-400"
+          style={{ width: blankRate === null ? '0%' : `${blankRate}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function CameraSection({ deployment }) {
+  const id = deployment.cameraID
+  const model = deployment.cameraModel
+  const hasAny = (id && id !== '') || (model && model !== '')
+  if (!hasAny) return null
+
+  return (
+    <div className="mb-3">
+      <div className="text-[11px] font-semibold text-gray-700 uppercase tracking-wide mb-1.5">
+        Camera
+      </div>
+      <Row label="ID" value={id} />
+      <Row label="Model" value={model} />
+    </div>
+  )
+}
+
+function DeploymentSection({ deployment }) {
+  const start = deployment.deploymentStart
+  const end = deployment.deploymentEnd
+  const duration = formatDuration(start, end)
+
+  return (
+    <div>
+      <div className="text-[11px] font-semibold text-gray-700 uppercase tracking-wide mb-1.5">
+        Deployment
+      </div>
+      <Row label="Start" value={formatDate(start)} />
+      <Row label="End" value={formatDate(end)} />
+      {duration !== null && <Row label="Duration" value={duration} />}
+    </div>
+  )
+}
+
+function Tile({ value, label }) {
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-md p-2 text-center">
+      <div className="text-lg font-semibold text-gray-900 tabular-nums">{value}</div>
+      <div className="text-[10px] text-gray-500 uppercase tracking-wide">{label}</div>
+    </div>
+  )
+}
+
+function Row({ label, value }) {
+  const display = value && value !== '' ? value : '—'
+  const isEmpty = display === '—'
+  return (
+    <div className="flex justify-between text-[13px] leading-7">
+      <span className="text-gray-500">{label}</span>
+      <span className={isEmpty ? 'text-gray-400' : 'text-gray-900'}>{display}</span>
+    </div>
+  )
+}
+
+function formatCount(n) {
+  if (typeof n !== 'number') return '—'
+  return n.toLocaleString()
+}
+
+// Match overview.jsx:138's formatDate so the popover speaks the same date
+// dialect as the rest of the app (e.g. "Aug 1, 2024").
+function formatDate(s) {
+  if (!s) return null
+  return new Date(s).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  })
+}
+
+const ONE_DAY_MS = 86_400_000
+
+function formatDuration(start, end) {
+  if (!start || !end) return null
+  const ms = new Date(end).getTime() - new Date(start).getTime()
+  if (!Number.isFinite(ms) || ms < 0) return null
+  const days = Math.round(ms / ONE_DAY_MS)
+  if (days === 0) return '< 1 day'
+  if (days === 1) return '1 day'
+  return `${days} days`
+}

--- a/test/main/database/deploymentStats.test.js
+++ b/test/main/database/deploymentStats.test.js
@@ -1,0 +1,203 @@
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+
+import {
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations,
+  getMediaCountForDeployment,
+  getObservationCountForDeployment,
+  getBlankMediaCountForDeployment
+} from '../../../src/main/database/index.js'
+
+let testBiowatchDataPath
+let testDbPath
+let testStudyId
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    electronLog.default.transports.file.level = false
+    electronLog.default.transports.console.level = false
+  } catch {
+    // ok in non-electron envs
+  }
+  testStudyId = `test-deploy-stats-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-deploy-stats', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+async function seed(dbPath) {
+  const manager = await createImageDirectoryDatabase(dbPath)
+
+  await insertDeployments(manager, {
+    deploy001: {
+      deploymentID: 'deploy001',
+      locationID: 'loc001',
+      locationName: 'Site A',
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-01-10T00:00:00Z'),
+      latitude: 0,
+      longitude: 0
+    },
+    deploy002: {
+      deploymentID: 'deploy002',
+      locationID: 'loc002',
+      locationName: 'Site B',
+      deploymentStart: DateTime.fromISO('2024-02-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-02-02T00:00:00Z'),
+      latitude: 0,
+      longitude: 0
+    },
+    deploy003: {
+      deploymentID: 'deploy003',
+      locationID: 'loc003',
+      locationName: 'Site C',
+      deploymentStart: DateTime.fromISO('2024-03-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-03-02T00:00:00Z'),
+      latitude: 0,
+      longitude: 0
+    }
+  })
+
+  await insertMedia(manager, {
+    'm1.jpg': {
+      mediaID: 'm1',
+      deploymentID: 'deploy001',
+      timestamp: DateTime.fromISO('2024-01-02T10:00:00Z'),
+      filePath: 'm1.jpg',
+      fileName: 'm1.jpg',
+      importFolder: '.',
+      folderName: '.'
+    },
+    'm2.jpg': {
+      mediaID: 'm2',
+      deploymentID: 'deploy001',
+      timestamp: DateTime.fromISO('2024-01-03T10:00:00Z'),
+      filePath: 'm2.jpg',
+      fileName: 'm2.jpg',
+      importFolder: '.',
+      folderName: '.'
+    },
+    'm3.jpg': {
+      mediaID: 'm3',
+      deploymentID: 'deploy001',
+      timestamp: DateTime.fromISO('2024-01-04T10:00:00Z'),
+      filePath: 'm3.jpg',
+      fileName: 'm3.jpg',
+      importFolder: '.',
+      folderName: '.'
+    },
+    'm4.jpg': {
+      mediaID: 'm4',
+      deploymentID: 'deploy002',
+      timestamp: DateTime.fromISO('2024-02-01T10:00:00Z'),
+      filePath: 'm4.jpg',
+      fileName: 'm4.jpg',
+      importFolder: '.',
+      folderName: '.'
+    }
+  })
+
+  await insertObservations(manager, [
+    {
+      observationID: 'o1',
+      mediaID: 'm1',
+      deploymentID: 'deploy001',
+      eventStart: DateTime.fromISO('2024-01-02T10:00:00Z'),
+      eventEnd: DateTime.fromISO('2024-01-02T10:00:30Z'),
+      scientificName: 'Cervus elaphus',
+      count: 1
+    },
+    {
+      observationID: 'o2',
+      mediaID: 'm1',
+      deploymentID: 'deploy001',
+      eventStart: DateTime.fromISO('2024-01-02T10:00:00Z'),
+      eventEnd: DateTime.fromISO('2024-01-02T10:00:30Z'),
+      scientificName: 'Vulpes vulpes',
+      count: 1
+    },
+    {
+      observationID: 'o3',
+      mediaID: 'm2',
+      deploymentID: 'deploy001',
+      eventStart: DateTime.fromISO('2024-01-03T10:00:00Z'),
+      eventEnd: DateTime.fromISO('2024-01-03T10:00:30Z'),
+      scientificName: 'Sus scrofa',
+      count: 1
+    },
+    {
+      observationID: 'o4',
+      mediaID: 'm3',
+      deploymentID: 'deploy001',
+      eventStart: DateTime.fromISO('2024-01-04T10:00:00Z'),
+      eventEnd: DateTime.fromISO('2024-01-04T10:00:30Z'),
+      scientificName: '',
+      count: 0
+    },
+    {
+      observationID: 'o5',
+      mediaID: 'm4',
+      deploymentID: 'deploy002',
+      eventStart: DateTime.fromISO('2024-02-01T10:00:00Z'),
+      eventEnd: DateTime.fromISO('2024-02-01T10:00:30Z'),
+      scientificName: 'Capreolus capreolus',
+      count: 1
+    }
+  ])
+
+  return manager
+}
+
+describe('getMediaCountForDeployment', () => {
+  test('returns the number of media for a deployment', async () => {
+    await seed(testDbPath)
+    assert.equal(await getMediaCountForDeployment(testDbPath, 'deploy001'), 3)
+    assert.equal(await getMediaCountForDeployment(testDbPath, 'deploy002'), 1)
+  })
+
+  test('returns 0 for a deployment with no media', async () => {
+    await seed(testDbPath)
+    assert.equal(await getMediaCountForDeployment(testDbPath, 'deploy003'), 0)
+  })
+
+  test('returns 0 for an unknown deploymentID', async () => {
+    await seed(testDbPath)
+    assert.equal(await getMediaCountForDeployment(testDbPath, 'does-not-exist'), 0)
+  })
+})
+
+describe('getObservationCountForDeployment', () => {
+  test('returns the total observations (including blanks) for a deployment', async () => {
+    await seed(testDbPath)
+    assert.equal(await getObservationCountForDeployment(testDbPath, 'deploy001'), 4)
+    assert.equal(await getObservationCountForDeployment(testDbPath, 'deploy002'), 1)
+  })
+
+  test('returns 0 for a deployment with no observations', async () => {
+    await seed(testDbPath)
+    assert.equal(await getObservationCountForDeployment(testDbPath, 'deploy003'), 0)
+  })
+})
+
+describe('getBlankMediaCountForDeployment (existing helper, contract-locked here)', () => {
+  test('counts media that have no real (named-species or vehicle) observation', async () => {
+    await seed(testDbPath)
+    assert.equal(await getBlankMediaCountForDeployment(testDbPath, 'deploy001'), 1)
+    assert.equal(await getBlankMediaCountForDeployment(testDbPath, 'deploy002'), 0)
+    assert.equal(await getBlankMediaCountForDeployment(testDbPath, 'deploy003'), 0)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a gear-icon popover in the `DeploymentDetailPane` header that surfaces three at-a-glance counts (Media, Observations, Blank rate) and the deployment's camera + start/end metadata for the currently selected deployment.
- Read-only for v1; row layout chosen so future inline editing drops in without restructuring. Camera section hides itself when both `cameraID` and `cameraModel` are null/empty (the common case across surveyed studies).
- Driven by a new `deployments:get-stats` IPC handler that fans three count queries — `media`, `observations`, and the existing media-level `blank` definition — over `Promise.all`. Two new tiny query helpers (`getMediaCountForDeployment`, `getObservationCountForDeployment`) added to `database/queries/deployments.js`; existing `getBlankMediaCountForDeployment` reused so the "blank" semantic matches the species-filter popover. Measured ~10–20 ms total on the worst-case deployment (10,518 media inside a 4.6 GB study DB).
- Also fixes `getAllDeployments` to include `deploymentStart`, `deploymentEnd`, `cameraID`, `cameraModel` in its projection so the popover (which reads them from the deployment row passed down by the pane) renders populated values instead of em-dashes.
- Spec + measurements: `docs/specs/2026-05-06-deployment-settings-popover-design.md`. New IPC handler row added to `docs/ipc-api.md`.

<img width="556" height="398" alt="image" src="https://github.com/user-attachments/assets/c113583d-2761-4cb5-b4f5-81b71c02b38b" />


## Test plan
- [x] `npm test` — 1,160 tests pass, including new `test/main/database/deploymentStats.test.js` (six new tests covering both new helpers and contract-locking the existing blank-media helper)
- [x] `npm run lint` — no new errors/warnings in changed files
- [x] `npm run format:check` — clean
- [x] Manual: open the Deployments tab, click a deployment, click the new gear icon — popover opens with stats and metadata
- [x] Manual: deployment with no camera info → Camera section hidden entirely
- [x] Manual: deployment with zero media → Stats tiles show `0`, blank-rate row reads `— (0)`
- [x] Manual: open-ended deployment (no `deploymentEnd`) → End row shows `—`, Duration row hidden