### PR TITLE
perf(overview): move getBestImagePerSpecies off the main thread

### DIFF
--- a/src/main/ipc/species.js
+++ b/src/main/ipc/species.js
@@ -9,8 +9,7 @@ import { getStudyDatabasePath } from '../services/paths.js'
 import {
   getSpeciesDistribution,
   getVehicleMediaCount,
-  getDistinctSpecies,
-  getBestImagePerSpecies
+  getDistinctSpecies
 } from '../database/index.js'
 import { runInWorker } from '../services/sequences/runInWorker.js'
 
@@ -85,7 +84,12 @@ export function registerSpeciesIPCHandlers() {
     }
   })
 
-  // Get best image per species for hover tooltips
+  // Get best image per species for hover tooltips. Dispatched to the
+  // sequences worker because the multi-CTE scoring scan, and even the
+  // no-bbox short-circuit probe, are O(observations) and block the main
+  // event loop for ~1-2s on large studies — which (since IPC replies are
+  // delivered on main) makes sibling queries like the Overview KPI band
+  // appear frozen even though their own work has already finished.
   ipcMain.handle('species:get-best-images', async (_, studyId) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
@@ -94,7 +98,7 @@ export function registerSpeciesIPCHandlers() {
         return { error: 'Database not found for this study' }
       }
 
-      const bestImages = await getBestImagePerSpecies(dbPath)
+      const bestImages = await runInWorker({ type: 'best-images-per-species', dbPath })
       return { data: bestImages }
     } catch (error) {
       log.error('Error getting best images per species:', error)

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -20,6 +20,7 @@ import {
   getSequenceAwareHeatmapSQL,
   getSequenceAwareDailyActivitySQL,
   getBestMedia,
+  getBestImagePerSpecies,
   getBlankMediaCount,
   getDeploymentsActivity,
   getOverviewStats
@@ -127,6 +128,16 @@ async function run() {
       // favorites CTE and the (potentially heavy) auto-scored CTE. See
       // src/main/database/queries/best-media.js for the query pipeline.
       return getBestMedia(dbPath, workerData.options || {})
+    }
+    case 'best-images-per-species': {
+      // Overview tab's species-distribution hover tooltips. Two SQLite paths,
+      // both expensive on large studies: the full multi-CTE scoring CTE
+      // (~440-840ms on 209k obs / 49k bbox), and — counter-intuitively — the
+      // no-bbox short-circuit probe, which has to scan the entire observations
+      // table looking for a non-null bboxX (~1.3-1.7s cold on 2.7-4M obs
+      // studies that turn out to have no bboxes at all). Off-thread so the
+      // main process keeps responding to other IPC during that window.
+      return getBestImagePerSpecies(dbPath)
     }
     case 'pagination': {
       // Gallery paginated sequences. Studies with long event-grouped sequences


### PR DESCRIPTION
## Summary

- The `species:get-best-images` IPC handler ran the heavy `getBestImagePerSpecies` query **synchronously on the main thread** via better-sqlite3.
- On large studies that monopolises the Node event loop for ~1.3–1.7 s (cold, no-bbox studies — the short-circuit probe still has to scan the whole observations table) or ~0.4–0.8 s (bbox-bearing studies, full scoring CTE).
- Because IPC replies are delivered on main, that stall queues the *worker* replies for sibling queries like `getOverviewStats`, so the KPI band appears frozen on Overview load even though its own work has already finished.
- Fix: dispatch through `runInWorker`, same pattern as `media:get-best`, `species:get-blank-count`, `deployments:get-activity`, and `overview:get-stats`. Query body unchanged.

## Scope

`getBestImagePerSpecies` powers per-species hover-tooltip thumbnails and is called from three tabs:

- Overview — `src/renderer/src/overview/SpeciesDistribution.jsx`
- Activity and Media — both render `src/renderer/src/ui/speciesDistribution.jsx`

All three were paying the same main-thread freeze on first open of a large study. The IPC channel name is unchanged, so all three benefit transparently.

## Timings (`time` wall-clock, `posix_fadvise(DONTNEED)` between WARM/COLD)

| study (obs / bbox)         | path                                | WARM    | COLD    |
| -------------------------- | ----------------------------------- | ------- | ------- |
| 1378cb43 (4.0 M / 0)       | `getBestImagePerSpecies` probe      | 0.21 s  | 1.31 s  |
| 64294958 (2.7 M / 0)       | `getBestImagePerSpecies` probe      | 0.16 s  | 1.71 s  |
| 931c0685 (210 k / 49 k)    | `getBestImagePerSpecies` full CTE   | 0.44 s  | 0.84 s  |

After the move these costs are off-thread; the main event loop stays responsive while the worker runs, so the KPI band renders as soon as its own (already-fast) worker reply lands.

## Test plan

- [x] `npm test` (10/10 in `test/main/database/queries/bestMedia.test.js` — both the no-bbox short-circuit and the full scoring CTE)
- [x] `npm run build` (worker bundle includes the new `'best-images-per-species'` case)
- [x] `npm run lint` (0 errors; pre-existing warnings unchanged)
- [x] Manual: open Overview tab on a large study (e.g. 1378cb43), confirm KPI band populates without the multi-second freeze
- [ ] Manual: open Activity and Media tabs on a large study, confirm species list / tooltips render without UI freeze