### PR TITLE
fix(import): GBIF/Demo extract into persistent study dir, not /tmp

### DIFF
--- a/src/main/ipc/import.js
+++ b/src/main/ipc/import.js
@@ -28,7 +28,7 @@ import { extractZip, downloadFile } from '../services/download.ts'
 import { getGbifTitle } from '../../shared/gbifTitles.js'
 
 // Module-level state for tracking active imports (for cancellation)
-let activeGbifImport = null // { abortController, studyId, datasetKey, downloadDir }
+let activeGbifImport = null // { abortController, studyId, datasetKey, tmpDownloadDir }
 let activeLilaImport = null // { abortController, studyId, datasetId }
 
 /**
@@ -284,6 +284,13 @@ export function registerImportIPCHandlers() {
 
   ipcMain.handle('import:download-demo', async () => {
     const datasetTitle = 'Demo - Kruger National Park'
+    // Same persistent-extract layout as the GBIF handler — see comments
+    // there. id is generated up front so the study dir path is known before
+    // we extract.
+    const id = crypto.randomUUID()
+    const tmpDownloadDir = join(app.getPath('temp'), `biowatch-demo-${id}`)
+    const studyPath = getStudyPath(app.getPath('userData'), id)
+    const extractPath = join(studyPath, 'source')
 
     try {
       log.info('Downloading and importing demo dataset')
@@ -297,16 +304,12 @@ export function registerImportIPCHandlers() {
         downloadProgress: { percent: 0, downloadedBytes: 0, totalBytes: 0 }
       })
 
-      // Create a temp directory for the downloaded file
-      const downloadDir = join(app.getPath('temp'), 'camtrap-demo')
-      if (!existsSync(downloadDir)) {
-        mkdirSync(downloadDir, { recursive: true })
-      }
+      mkdirSync(tmpDownloadDir, { recursive: true })
+      mkdirSync(studyPath, { recursive: true })
 
       const demoDatasetUrl =
         'https://github.com/earthtoolsmaker/biowatch/releases/download/v1.7.2/camtrapdp-demo-dataset.zip'
-      const zipPath = join(downloadDir, 'demo-dataset.zip')
-      const extractPath = join(downloadDir, 'extracted')
+      const zipPath = join(tmpDownloadDir, 'demo-dataset.zip')
 
       log.info(`Downloading demo dataset from ${demoDatasetUrl} to ${zipPath}`)
       await downloadFile(demoDatasetUrl, zipPath, (progress) => {
@@ -332,28 +335,8 @@ export function registerImportIPCHandlers() {
         datasetTitle
       })
 
-      // Create extraction directory if it doesn't exist
-      if (!existsSync(extractPath)) {
-        mkdirSync(extractPath, { recursive: true })
-      } else {
-        // Clean the extraction directory first to avoid conflicts
-        const files = readdirSync(extractPath)
-        for (const file of files) {
-          const filePath = join(extractPath, file)
-          if (statSync(filePath).isDirectory()) {
-            await new Promise((resolve, reject) => {
-              const rmProcess = spawn('rm', ['-rf', filePath])
-              rmProcess.on('close', (code) => {
-                if (code === 0) resolve()
-                else reject(new Error(`Failed to delete directory: ${filePath}`))
-              })
-              rmProcess.on('error', reject)
-            })
-          } else {
-            unlinkSync(filePath)
-          }
-        }
-      }
+      // Fresh study UUID → extractPath is always empty here.
+      mkdirSync(extractPath, { recursive: true })
 
       // Extract the zip file
       await extractZip(zipPath, extractPath)
@@ -399,7 +382,6 @@ export function registerImportIPCHandlers() {
         datasetTitle
       })
 
-      const id = crypto.randomUUID()
       const { data, synthesized } = await importCamTrapDataset(
         camtrapDpDirPath,
         id,
@@ -419,7 +401,8 @@ export function registerImportIPCHandlers() {
             }
           })
         },
-        { nameOverride: datasetTitle }
+        // See GBIF handler for rationale on importFolderOverride: null.
+        { nameOverride: datasetTitle, importFolderOverride: null }
       )
 
       const result = {
@@ -432,36 +415,15 @@ export function registerImportIPCHandlers() {
         synthesized
       }
 
-      log.info('Cleaning up temporary files after successful import...')
+      log.info('Cleaning up temporary download files after successful import...')
 
       try {
-        if (existsSync(zipPath)) {
-          unlinkSync(zipPath)
-          log.info(`Deleted zip file: ${zipPath}`)
+        if (existsSync(tmpDownloadDir)) {
+          rmSync(tmpDownloadDir, { recursive: true, force: true })
+          log.info(`Deleted temp download dir: ${tmpDownloadDir}`)
         }
       } catch (error) {
-        log.warn(`Failed to delete zip file: ${error.message}`)
-      }
-
-      try {
-        await new Promise((resolve) => {
-          const rmProcess = spawn('rm', ['-rf', extractPath])
-          rmProcess.on('close', (code) => {
-            if (code === 0) {
-              log.info(`Deleted extraction directory: ${extractPath}`)
-              resolve()
-            } else {
-              log.warn(`Failed to delete extraction directory, exit code: ${code}`)
-              resolve()
-            }
-          })
-          rmProcess.on('error', (err) => {
-            log.warn(`Error during extraction directory cleanup: ${err.message}`)
-            resolve()
-          })
-        })
-      } catch (error) {
-        log.warn(`Failed to cleanup extraction directory: ${error.message}`)
+        log.warn(`Failed to delete temp download dir: ${error.message}`)
       }
 
       // Stage 3: Complete
@@ -476,6 +438,19 @@ export function registerImportIPCHandlers() {
       return result
     } catch (error) {
       log.error('Error downloading or importing demo dataset:', error)
+
+      try {
+        await cleanupStudy(id)
+      } catch (e) {
+        log.warn('Error cleaning up failed study:', e.message)
+      }
+      try {
+        if (existsSync(tmpDownloadDir)) {
+          rmSync(tmpDownloadDir, { recursive: true, force: true })
+        }
+      } catch (e) {
+        log.warn('Error cleaning up temp download dir:', e.message)
+      }
 
       sendDemoImportProgress({
         stage: 'error',
@@ -497,9 +472,15 @@ export function registerImportIPCHandlers() {
     const abortController = new AbortController()
     const signal = abortController.signal
     const id = crypto.randomUUID()
-    const downloadDir = join(app.getPath('temp'), `gbif-${datasetKey}`)
+    // Zip lands in /tmp (ephemeral, removed post-extract). Extracted contents
+    // go under the persistent study dir so bundled media survive the import —
+    // media.filePath rows reference these JPGs after import completes, and
+    // /tmp would be wiped on reboot or by a success-path cleanup.
+    const tmpDownloadDir = join(app.getPath('temp'), `biowatch-gbif-${id}`)
+    const studyPath = getStudyPath(app.getPath('userData'), id)
+    const extractPath = join(studyPath, 'source')
 
-    activeGbifImport = { abortController, studyId: id, datasetKey, downloadDir }
+    activeGbifImport = { abortController, studyId: id, datasetKey, tmpDownloadDir }
 
     try {
       log.info(`Downloading and importing GBIF dataset: ${datasetKey}`)
@@ -536,13 +517,15 @@ export function registerImportIPCHandlers() {
       const downloadUrl = camtrapEndpoint.url
       log.info(`Found download URL: ${downloadUrl}`)
 
-      // Create a temp directory for the downloaded file
-      if (!existsSync(downloadDir)) {
-        mkdirSync(downloadDir, { recursive: true })
+      // Create the temp download dir (zip only) and the persistent study dir.
+      if (!existsSync(tmpDownloadDir)) {
+        mkdirSync(tmpDownloadDir, { recursive: true })
+      }
+      if (!existsSync(studyPath)) {
+        mkdirSync(studyPath, { recursive: true })
       }
 
-      const zipPath = join(downloadDir, 'gbif-dataset.zip')
-      const extractPath = join(downloadDir, 'extracted')
+      const zipPath = join(tmpDownloadDir, 'gbif-dataset.zip')
 
       // Stage 1: Downloading
       sendGbifImportProgress({
@@ -588,27 +571,9 @@ export function registerImportIPCHandlers() {
         datasetTitle
       })
 
-      // Create extraction directory if it doesn't exist
-      if (!existsSync(extractPath)) {
-        mkdirSync(extractPath, { recursive: true })
-      } else {
-        const files = readdirSync(extractPath)
-        for (const file of files) {
-          const filePath = join(extractPath, file)
-          if (statSync(filePath).isDirectory()) {
-            await new Promise((resolve, reject) => {
-              const rmProcess = spawn('rm', ['-rf', filePath])
-              rmProcess.on('close', (code) => {
-                if (code === 0) resolve()
-                else reject(new Error(`Failed to delete directory: ${filePath}`))
-              })
-              rmProcess.on('error', reject)
-            })
-          } else {
-            unlinkSync(filePath)
-          }
-        }
-      }
+      // The extract dir lives under a freshly minted study UUID, so it's
+      // always empty here — no need to clean stale contents.
+      mkdirSync(extractPath, { recursive: true })
 
       // Extract the zip file
       await extractZip(zipPath, extractPath, signal)
@@ -677,7 +642,10 @@ export function registerImportIPCHandlers() {
             }
           })
         },
-        { signal, nameOverride: datasetTitle }
+        // importFolderOverride: null — the package directory's basename is
+        // dataset-internal (e.g. "national_monitoring") and not user-meaningful.
+        // Falling back to studyName in the Sources tab reads better.
+        { signal, nameOverride: datasetTitle, importFolderOverride: null }
       )
 
       const result = {
@@ -690,36 +658,19 @@ export function registerImportIPCHandlers() {
         synthesized
       }
 
-      log.info('Cleaning up temporary files after successful import...')
+      log.info('Cleaning up temporary download files after successful import...')
 
+      // Drop the temp download dir (just the zip). The extracted tree under
+      // the study dir is intentionally retained — media.filePath rows point
+      // into it. Study deletion (study:delete-database) wipes the whole
+      // study dir, including this tree.
       try {
-        if (existsSync(zipPath)) {
-          unlinkSync(zipPath)
-          log.info(`Deleted zip file: ${zipPath}`)
+        if (existsSync(tmpDownloadDir)) {
+          rmSync(tmpDownloadDir, { recursive: true, force: true })
+          log.info(`Deleted temp download dir: ${tmpDownloadDir}`)
         }
       } catch (error) {
-        log.warn(`Failed to delete zip file: ${error.message}`)
-      }
-
-      try {
-        await new Promise((resolve) => {
-          const rmProcess = spawn('rm', ['-rf', extractPath])
-          rmProcess.on('close', (code) => {
-            if (code === 0) {
-              log.info(`Deleted extraction directory: ${extractPath}`)
-              resolve()
-            } else {
-              log.warn(`Failed to delete extraction directory, exit code: ${code}`)
-              resolve()
-            }
-          })
-          rmProcess.on('error', (err) => {
-            log.warn(`Error during extraction directory cleanup: ${err.message}`)
-            resolve()
-          })
-        })
-      } catch (error) {
-        log.warn(`Failed to cleanup extraction directory: ${error.message}`)
+        log.warn(`Failed to delete temp download dir: ${error.message}`)
       }
 
       // Stage 4: Complete
@@ -737,13 +688,15 @@ export function registerImportIPCHandlers() {
     } catch (error) {
       if (error.name === 'AbortError') {
         log.info(`GBIF import cancelled by user: ${datasetKey}`)
+        // cleanupStudy nukes the study dir (extractPath included). Also drop
+        // the temp download dir.
         await cleanupStudy(id)
         try {
-          if (existsSync(downloadDir)) {
-            rmSync(downloadDir, { recursive: true, force: true })
+          if (existsSync(tmpDownloadDir)) {
+            rmSync(tmpDownloadDir, { recursive: true, force: true })
           }
         } catch (e) {
-          log.warn('Error cleaning up download directory:', e.message)
+          log.warn('Error cleaning up temp download dir:', e.message)
         }
         sendGbifImportProgress({
           stage: 'cancelled',
@@ -756,6 +709,20 @@ export function registerImportIPCHandlers() {
       }
 
       log.error('Error downloading or importing GBIF dataset:', error)
+      // Same cleanup on non-cancel failures: avoid leaving a half-imported
+      // study dir + orphaned zip behind.
+      try {
+        await cleanupStudy(id)
+      } catch (e) {
+        log.warn('Error cleaning up failed study:', e.message)
+      }
+      try {
+        if (existsSync(tmpDownloadDir)) {
+          rmSync(tmpDownloadDir, { recursive: true, force: true })
+        }
+      } catch (e) {
+        log.warn('Error cleaning up temp download dir:', e.message)
+      }
 
       sendGbifImportProgress({
         stage: 'error',

--- a/src/main/services/import/parsers/camtrapDP.js
+++ b/src/main/services/import/parsers/camtrapDP.js
@@ -42,6 +42,7 @@ export function stripSynthLocationID(locationID) {
  * @param {function} onProgress - Optional callback for progress updates
  * @param {Object} options - Optional import options
  * @param {string} [options.nameOverride] - Override the dataset name (instead of using name from datapackage.json)
+ * @param {string|null} [options.importFolderOverride] - Override the importFolder stamped on media rows. Pass null to leave it empty (e.g. for GBIF/demo imports whose package directory is a temp path that gets cleaned up post-import). Omit to default to directoryPath (spec D3 for local picks).
  * @returns {Promise<Object>} - Object containing dbPath and name
  */
 export async function importCamTrapDataset(directoryPath, id, onProgress = null, options = {}) {
@@ -63,6 +64,7 @@ export async function importCamTrapDataset(directoryPath, id, onProgress = null,
  * @param {function} onProgress - Optional callback for progress updates
  * @param {Object} options - Optional import options
  * @param {string} [options.nameOverride] - Override the dataset name (instead of using name from datapackage.json)
+ * @param {string|null} [options.importFolderOverride] - See importCamTrapDataset.
  * @returns {Promise<Object>} - Object containing dbPath and data
  */
 export async function importCamTrapDatasetWithPath(
@@ -72,6 +74,8 @@ export async function importCamTrapDatasetWithPath(
   onProgress = null,
   options = {}
 ) {
+  const importFolderForMedia =
+    'importFolderOverride' in options ? options.importFolderOverride : directoryPath
   log.info('Starting CamTrap dataset import')
   // Create database in the specified biowatch-data directory
   const dbPath = path.join(biowatchDataPath, 'studies', id, 'study.db')
@@ -193,6 +197,7 @@ export async function importCamTrapDatasetWithPath(
         name,
         columns,
         directoryPath,
+        importFolderForMedia,
         (batchProgress) => {
           if (onProgress) {
             onProgress({
@@ -431,6 +436,7 @@ async function insertCSVData(
   tableName,
   columns,
   directoryPath,
+  importFolderForMedia,
   onProgress = null,
   signal = null,
   rowFilter = null
@@ -460,7 +466,14 @@ async function insertCSVData(
         throw new DOMException('Import cancelled', 'AbortError')
       }
 
-      const transformedRow = transformRowToSchema(row, tableName, columns, directoryPath, pathCache)
+      const transformedRow = transformRowToSchema(
+        row,
+        tableName,
+        columns,
+        directoryPath,
+        pathCache,
+        importFolderForMedia
+      )
       if (transformedRow && (!rowFilter || rowFilter(transformedRow))) {
         // Create bulk inserter on first row (need column names from transformed data)
         if (!inserter) {
@@ -516,13 +529,20 @@ async function insertCSVData(
  * @param {string} directoryPath - Path to the CamTrapDP directory
  * @returns {Object|null} - Transformed row data or null if invalid
  */
-function transformRowToSchema(row, tableName, columns, directoryPath, pathCache) {
+function transformRowToSchema(
+  row,
+  tableName,
+  columns,
+  directoryPath,
+  pathCache,
+  importFolderForMedia
+) {
   try {
     switch (tableName) {
       case 'deployments':
         return transformDeploymentRow(row)
       case 'media':
-        return transformMediaRow(row, directoryPath, pathCache)
+        return transformMediaRow(row, directoryPath, pathCache, importFolderForMedia)
       case 'observations':
         return transformObservationRow(row)
       default:
@@ -591,7 +611,7 @@ function transformDeploymentRow(row) {
 /**
  * Transform media CSV row to media schema
  */
-function transformMediaRow(row, directoryPath, pathCache) {
+function transformMediaRow(row, directoryPath, pathCache, importFolderForMedia) {
   const mediaID = row.mediaID || row.media_id
 
   // Skip rows without required primary key
@@ -627,7 +647,10 @@ function transformMediaRow(row, directoryPath, pathCache) {
     favorite,
     // Stamp the absolute package directory so the Sources tab can group by it.
     // Per spec D3: importFolder = "absolute package directory path" for CamtrapDP imports.
-    importFolder: directoryPath
+    // Callers (GBIF, demo) that extract into an ephemeral temp dir override this
+    // with null so the Sources tab falls back to the study name instead of
+    // showing a soon-to-be-deleted /tmp path.
+    importFolder: importFolderForMedia
   }
 }
 

--- a/test/integration/import/camtrapDP-importFolder-override.test.js
+++ b/test/integration/import/camtrapDP-importFolder-override.test.js
@@ -1,0 +1,97 @@
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import Database from 'better-sqlite3'
+
+import { importCamTrapDatasetWithPath } from '../../../src/main/services/import/parsers/camtrapDP.js'
+
+let testBiowatchDataPath
+let testCamTrapDataPath
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    const log = electronLog.default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    // electron-log not available in test environment
+  }
+
+  testBiowatchDataPath = join(
+    tmpdir(),
+    'biowatch-camtrap-importFolder-override-test',
+    Date.now().toString()
+  )
+  mkdirSync(testBiowatchDataPath, { recursive: true })
+  testCamTrapDataPath = join(process.cwd(), 'test', 'data', 'camtrap-derive-location-id')
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+function readImportFolders(dbPath) {
+  const db = new Database(dbPath, { readonly: true })
+  try {
+    return db
+      .prepare('SELECT DISTINCT importFolder FROM media')
+      .all()
+      .map((r) => r.importFolder)
+  } finally {
+    db.close()
+  }
+}
+
+// Regression coverage for the GBIF/Demo "extracted /tmp path leaks into Sources tab"
+// bug. The handlers that download into a non-package-spec'd location pass
+// importFolderOverride to suppress the directoryPath stamp on media.importFolder;
+// silently dropping the option (e.g. by refactoring insertCSVData →
+// transformRowToSchema → transformMediaRow) would re-introduce the bug.
+describe('CamTrap-DP importFolderOverride option', () => {
+  test('default: media.importFolder is stamped with directoryPath (spec D3)', async () => {
+    const studyId = 'importfolder-default'
+    await importCamTrapDatasetWithPath(testCamTrapDataPath, testBiowatchDataPath, studyId)
+
+    const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
+    const folders = readImportFolders(dbPath)
+
+    assert.equal(folders.length, 1, 'all media rows should share one importFolder')
+    assert.equal(
+      folders[0],
+      testCamTrapDataPath,
+      'importFolder should be the package directory path'
+    )
+  })
+
+  test('importFolderOverride: null leaves media.importFolder NULL', async () => {
+    const studyId = 'importfolder-null'
+    await importCamTrapDatasetWithPath(testCamTrapDataPath, testBiowatchDataPath, studyId, null, {
+      importFolderOverride: null
+    })
+
+    const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
+    const folders = readImportFolders(dbPath)
+
+    assert.equal(folders.length, 1, 'all media rows should share one importFolder value')
+    assert.equal(folders[0], null, 'importFolder should be NULL — Sources falls back to studyName')
+  })
+
+  test('importFolderOverride: custom string is honored verbatim', async () => {
+    const studyId = 'importfolder-custom'
+    const custom = 'gbif:13101e81-bc62-4553-9fd9-c5c8eb3fb9ab'
+    await importCamTrapDatasetWithPath(testCamTrapDataPath, testBiowatchDataPath, studyId, null, {
+      importFolderOverride: custom
+    })
+
+    const dbPath = join(testBiowatchDataPath, 'studies', studyId, 'study.db')
+    const folders = readImportFolders(dbPath)
+
+    assert.equal(folders.length, 1)
+    assert.equal(folders[0], custom)
+  })
+})


### PR DESCRIPTION
## Summary

- GBIF and demo handlers used to extract their CamTrap-DP zip into `/tmp/...` and `rm -rf` the extracted tree on success. Any `media.filePath` row that resolved against that tree (bundled-media datasets, or the `parent`-strategy fallback in `transformFilePathField`) ended up pointing at a deleted file the moment the import finished.
- PR #508 then began stamping the package directory onto `media.importFolder`, so the Sources tab started rendering the now-dead `/tmp/gbif-<uuid>/extracted` path as the source row label, basename `extracted`.
- This PR moves extraction to `<userData>/biowatch-data/studies/<id>/source/` so the tree survives. `cleanupStudy()` and `study:delete-database` both already wipe the study directory recursively, so cancel/error/delete teardown is unchanged. Only the temp zip dir is cleaned on success.
- Adds `options.importFolderOverride` on `importCamTrapDataset`. GBIF + Demo callers pass `null` to leave `media.importFolder` empty — the package basename (`national_monitoring`, etc.) isn't user-meaningful, and the Sources row reads cleaner falling back to `studyName`. Local CamtrapDP picks (`extractor.js`) keep the spec-D3 behavior.

Out of scope (deliberately): the Sources tab "Local"/"Remote" badge. For metadata-only GBIF packages like Alpine Tundra Rodents (134 MB media.csv, zero JPGs in the zip, `filePublic: false`), `media.filePath` resolves to a fallback local path — so "Local" is technically accurate, even though the underlying images aren't actually fetchable. The right follow-up there is detecting "no resolvable media" at import time and surfacing that as a distinct UI signal, not papering over it with a Remote badge that doesn't match what's stored.

## Test plan

- [x] `npm test` (1211/1211 passing locally on this branch)
- [x] Re-import a URL-referenced GBIF dataset (e.g. Muntjac Antwerp / agouti.eu) — Sources shows the dataset title (not "extracted"), Remote badge intact, gallery thumbnails load from HTTPS as before.
- [x] Import the demo dataset — extracted tree lives under `<userData>/biowatch-data/studies/<id>/source/`, gallery loads, deleting the study from the UI removes the tree from disk.
- [x] Cancel an in-flight GBIF import mid-extract — study dir + temp zip dir both gone.
- [x] Existing studies imported before this PR are unchanged (no migration needed); legacy `media.importFolder = /tmp/...` rows on those studies remain dead and should be cleaned by re-importing.