### PR TITLE
feat(media): include year in grid-cell timestamp overlay

### DIFF
--- a/src/renderer/src/utils/formatTimestamp.js
+++ b/src/renderer/src/utils/formatTimestamp.js
@@ -1,5 +1,5 @@
 /**
- * Compact "MMM D, h:mm AM/PM" formatter used by the media-tab grid cell
+ * Compact "MMM D, YYYY, h:mm AM/PM" formatter used by the media-tab grid cell
  * timestamp overlay. Pure, no React, safe to unit-test.
  *
  * Uses the runtime's local timezone — camera-trap timestamps in the DB are
@@ -7,11 +7,12 @@
  * time elsewhere (e.g. inline editor timestamps).
  *
  * @param {string | number | Date} timestamp - Anything `new Date(x)` accepts.
- * @returns {string} Formatted string, e.g. "Apr 30, 2:34 PM".
+ * @returns {string} Formatted string, e.g. "Apr 30, 2026, 2:34 PM".
  */
 const FORMATTER = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
+  year: 'numeric',
   hour: 'numeric',
   minute: '2-digit'
 })

--- a/test/renderer/formatTimestamp.test.js
+++ b/test/renderer/formatTimestamp.test.js
@@ -3,19 +3,19 @@ import assert from 'node:assert/strict'
 import { formatGridTimestamp } from '../../src/renderer/src/utils/formatTimestamp.js'
 
 describe('formatGridTimestamp', () => {
-  test('renders an ISO timestamp as "MMM D, h:mm AM/PM"', () => {
+  test('renders an ISO timestamp as "MMM D, YYYY, h:mm AM/PM"', () => {
     const result = formatGridTimestamp('2026-04-30T14:34:56Z')
     // Shape only — actual hour depends on test runner's local timezone.
-    // Examples: "Apr 30, 2:34 PM", "Apr 30, 10:34 AM", "May 1, 12:34 AM".
+    // Examples: "Apr 30, 2026, 2:34 PM", "May 1, 2026, 12:34 AM".
     assert.match(
       result,
-      /^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}\s(AM|PM)$/,
+      /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}\s(AM|PM)$/,
       `unexpected shape: "${result}"`
     )
   })
 
   test('accepts a Date instance', () => {
     const result = formatGridTimestamp(new Date('2026-04-30T14:34:56Z'))
-    assert.match(result, /^[A-Z][a-z]{2} \d{1,2}, \d{1,2}:\d{2}\s(AM|PM)$/)
+    assert.match(result, /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}\s(AM|PM)$/)
   })
 })


### PR DESCRIPTION
## Summary
- The black timestamp pill at the top-left of each media grid cell (and the lightbox header, which shares the same formatter) now includes the year — e.g. `Apr 30, 2026, 2:34 PM` instead of `Apr 30, 2:34 PM`.
- Adds `year: 'numeric'` to the `Intl.DateTimeFormat` options in `src/renderer/src/utils/formatTimestamp.js` and updates the unit-test regex accordingly.

<img width="1137" height="323" alt="image" src="https://github.com/user-attachments/assets/6b129845-ac17-4789-9653-65cbffba2654" />


## Test plan
- [x] `node --test test/renderer/formatTimestamp.test.js` passes
- [x] Open the Media tab, confirm each thumbnail's timestamp overlay shows the year
- [x] Open the lightbox, confirm the header timestamp also shows the year