### PR TITLE
feat(media, activity): move gap slider into right pane

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -224,6 +224,7 @@ const { data, fetchNextPage, hasNextPage } = useInfiniteQuery({
 | `getMediaBboxes(studyId, mediaID)`               | `media:get-bboxes`       | studyId, mediaID            | `{ data: Bbox[] }`                        |
 | `getMediaBboxesBatch(studyId, mediaIDs)`         | `media:get-bboxes-batch` | studyId, mediaID[]          | `{ data: Map<mediaID, Bbox[]> }`          |
 | `checkMediaHaveBboxes(studyId, mediaIDs)`        | `media:have-bboxes`      | studyId, mediaID[]          | `{ data: boolean }`                       |
+| `studyHasAnyBboxes(studyId)`                     | `media:study-has-any-bboxes` | studyId                 | `{ data: boolean }`                       |
 | `getBestMedia(studyId, options)`                 | `media:get-best`         | studyId, { limit? }         | `{ data: ScoredMedia[] }`                 |
 | `setMediaTimestamp(studyId, mediaID, timestamp)` | `media:set-timestamp`    | studyId, mediaID, timestamp | `{ success: boolean }`                    |
 | `setMediaFavorite(studyId, mediaID, favorite)`   | `media:set-favorite`     | studyId, mediaID, boolean   | `{ success: boolean, mediaID, favorite }` |

--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -237,6 +237,7 @@ export {
   getMediaBboxes,
   getMediaBboxesBatch,
   checkMediaHaveBboxes,
+  studyHasAnyBboxes,
   getVideoFrameDetections,
   updateMediaTimestamp,
   insertMedia,

--- a/src/main/database/queries/index.js
+++ b/src/main/database/queries/index.js
@@ -45,6 +45,7 @@ export {
   getMediaBboxes,
   getMediaBboxesBatch,
   checkMediaHaveBboxes,
+  studyHasAnyBboxes,
   getVideoFrameDetections,
   updateMediaTimestamp,
   insertMedia,

--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -176,6 +176,35 @@ export async function checkMediaHaveBboxes(dbPath, mediaIDs) {
 }
 
 /**
+ * Check if the study has any bboxes anywhere — study-wide existence check.
+ * Used to decide whether to render the "show boxes" toggle in the Media tab's
+ * right-pane display strip. Coarser than checkMediaHaveBboxes (which is
+ * scoped to a list of media IDs).
+ * @param {string} dbPath - Path to the SQLite database
+ * @returns {Promise<boolean>} - True if any observation in the study has a bbox
+ */
+export async function studyHasAnyBboxes(dbPath) {
+  const startTime = Date.now()
+  try {
+    const studyId = getStudyIdFromPath(dbPath)
+    const db = await getDrizzleDb(studyId, dbPath)
+
+    const result = await db
+      .select({ exists: sql`1` })
+      .from(observations)
+      .where(isNotNull(observations.bboxX))
+      .limit(1)
+
+    const hasBboxes = result.length > 0
+    log.info(`studyHasAnyBboxes completed in ${Date.now() - startTime}ms: ${hasBboxes}`)
+    return hasBboxes
+  } catch (error) {
+    log.error(`Error in studyHasAnyBboxes: ${error.message}`)
+    throw error
+  }
+}
+
+/**
  * Update media timestamp and propagate changes to related observations
  * Observations are updated with the same offset to preserve duration
  * @param {string} dbPath - Path to the SQLite database

--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -176,12 +176,17 @@ export async function checkMediaHaveBboxes(dbPath, mediaIDs) {
 }
 
 /**
- * Check if the study has any bboxes anywhere — study-wide existence check.
- * Used to decide whether to render the "show boxes" toggle in the Media tab's
- * right-pane display strip. Coarser than checkMediaHaveBboxes (which is
- * scoped to a list of media IDs).
+ * Check if the study has any drawable bboxes anywhere — study-wide existence
+ * check used to decide whether to render the "show boxes" toggle in the
+ * Media tab's right-pane display strip.
+ *
+ * Requires bboxWidth AND bboxHeight to be non-null, not just bboxX. Some
+ * CamtrapDP datasets record an animal's position as a point (X/Y only, no
+ * width/height) — those aren't drawable boxes so the toggle would be
+ * meaningless. Coarser than checkMediaHaveBboxes (which is scoped to a list
+ * of media IDs) but with the same drawability requirement.
  * @param {string} dbPath - Path to the SQLite database
- * @returns {Promise<boolean>} - True if any observation in the study has a bbox
+ * @returns {Promise<boolean>} - True if any observation has a drawable bbox
  */
 export async function studyHasAnyBboxes(dbPath) {
   const startTime = Date.now()
@@ -192,7 +197,7 @@ export async function studyHasAnyBboxes(dbPath) {
     const result = await db
       .select({ exists: sql`1` })
       .from(observations)
-      .where(isNotNull(observations.bboxX))
+      .where(and(isNotNull(observations.bboxWidth), isNotNull(observations.bboxHeight)))
       .limit(1)
 
     const hasBboxes = result.length > 0

--- a/src/main/ipc/media.js
+++ b/src/main/ipc/media.js
@@ -10,6 +10,7 @@ import {
   getMediaBboxes,
   getMediaBboxesBatch,
   checkMediaHaveBboxes,
+  studyHasAnyBboxes,
   getVideoFrameDetections,
   updateMediaTimestamp,
   updateMediaFavorite,
@@ -70,6 +71,23 @@ export function registerMediaIPCHandlers() {
       return { data: hasBboxes }
     } catch (error) {
       log.error('Error checking media bboxes existence:', error)
+      return { error: error.message }
+    }
+  })
+
+  // Study-wide bbox existence check — used by Media tab right-pane strip
+  ipcMain.handle('media:study-has-any-bboxes', async (_, studyId) => {
+    try {
+      const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
+      if (!dbPath || !existsSync(dbPath)) {
+        log.warn(`Database not found for study ID: ${studyId}`)
+        return { error: 'Database not found for this study' }
+      }
+
+      const hasBboxes = await studyHasAnyBboxes(dbPath)
+      return { data: hasBboxes }
+    } catch (error) {
+      log.error('Error checking study-wide bbox existence:', error)
       return { error: error.message }
     }
   })

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -94,6 +94,9 @@ const api = {
   checkMediaHaveBboxes: async (studyId, mediaIDs) => {
     return await electronAPI.ipcRenderer.invoke('media:have-bboxes', studyId, mediaIDs)
   },
+  studyHasAnyBboxes: async (studyId) => {
+    return await electronAPI.ipcRenderer.invoke('media:study-has-any-bboxes', studyId)
+  },
   getBestMedia: async (studyId, options = {}) => {
     return await electronAPI.ipcRenderer.invoke('media:get-best', studyId, options)
   },

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -15,6 +15,7 @@ import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import MarkerHoverCard from './ui/MarkerHoverCard'
 import { useTheme } from './hooks/useTheme'
 import PlaceholderMap from './ui/PlaceholderMap'
+import { SequenceGapSlider } from './ui/SequenceGapSlider'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
@@ -576,7 +577,7 @@ export default function Activity({ studyData, studyId }) {
   const [fullExtent, setFullExtent] = useState([null, null])
   const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
   const { importStatus } = useImportStatus(actualStudyId, 5000)
-  const { sequenceGap } = useSequenceGap(actualStudyId)
+  const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
 
   // Lightweight deduped deployment-location query (shared cache with the
   // Overview tab). Used to paint the skeleton map immediately while the
@@ -843,16 +844,28 @@ export default function Activity({ studyData, studyId }) {
                 />
               )}
             </div>
-            <div className="h-full overflow-auto w-xs">
+            <div className="h-full w-xs flex flex-col gap-2 min-h-0">
+              {speciesInitialized && sequenceGap !== undefined && (
+                <div className="flex items-center gap-2 px-2 py-1.5">
+                  <SequenceGapSlider
+                    value={sequenceGap}
+                    onChange={setSequenceGap}
+                    variant="compact"
+                  />
+                </div>
+              )}
               {speciesDistributionData && (
-                <SpeciesDistribution
-                  data={speciesDistributionData}
-                  taxonomicData={taxonomicData}
-                  selectedSpecies={selectedSpecies}
-                  onSpeciesChange={handleSpeciesChange}
-                  palette={palette}
-                  studyId={actualStudyId}
-                />
+                <div className="flex-1 min-h-0">
+                  <SpeciesDistribution
+                    data={speciesDistributionData}
+                    taxonomicData={taxonomicData}
+                    selectedSpecies={selectedSpecies}
+                    onSpeciesChange={handleSpeciesChange}
+                    palette={palette}
+                    studyId={actualStudyId}
+                    showHeader={false}
+                  />
+                </div>
               )}
             </div>
           </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -846,7 +846,7 @@ export default function Activity({ studyData, studyId }) {
             </div>
             <div className="h-full w-xs flex flex-col gap-2 min-h-0">
               {speciesInitialized && sequenceGap !== undefined && (
-                <div className="flex items-center gap-2 px-2 py-1.5">
+                <div className="flex items-center gap-2 px-2 h-10 flex-shrink-0">
                   <SequenceGapSlider
                     value={sequenceGap}
                     onChange={setSequenceGap}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -335,24 +335,69 @@ input::-webkit-inner-spin-button {
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15));
 }
 
-/* Radix Tooltip animations */
-[data-radix-tooltip-content][data-state='delayed-open'],
-[data-radix-tooltip-content][data-state='instant-open'] {
-  animation: tooltip-fade-in 150ms ease-out;
+/* Radix Tooltip animations — subtle slide from the trigger side + spring fade */
+[data-radix-tooltip-content][data-state='delayed-open'][data-side='top'],
+[data-radix-tooltip-content][data-state='instant-open'][data-side='top'] {
+  animation: tooltip-slide-up 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-radix-tooltip-content][data-state='delayed-open'][data-side='bottom'],
+[data-radix-tooltip-content][data-state='instant-open'][data-side='bottom'] {
+  animation: tooltip-slide-down 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-radix-tooltip-content][data-state='delayed-open'][data-side='left'],
+[data-radix-tooltip-content][data-state='instant-open'][data-side='left'] {
+  animation: tooltip-slide-left 180ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+[data-radix-tooltip-content][data-state='delayed-open'][data-side='right'],
+[data-radix-tooltip-content][data-state='instant-open'][data-side='right'] {
+  animation: tooltip-slide-right 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 [data-radix-tooltip-content][data-state='closed'] {
   animation: tooltip-fade-out 100ms ease-in;
 }
 
-@keyframes tooltip-fade-in {
+@keyframes tooltip-slide-down {
   from {
     opacity: 0;
-    transform: scale(0.95);
+    transform: translateY(-6px) scale(0.96);
   }
   to {
     opacity: 1;
-    transform: scale(1);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes tooltip-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes tooltip-slide-left {
+  from {
+    opacity: 0;
+    transform: translateX(6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes tooltip-slide-right {
+  from {
+    opacity: 0;
+    transform: translateX(-6px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
   }
 }
 
@@ -363,7 +408,7 @@ input::-webkit-inner-spin-button {
   }
   to {
     opacity: 0;
-    transform: scale(0.95);
+    transform: scale(0.96);
   }
 }
 

--- a/src/renderer/src/hooks/useShowThumbnailBboxes.js
+++ b/src/renderer/src/hooks/useShowThumbnailBboxes.js
@@ -1,0 +1,54 @@
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+const storageKey = (studyId) => `showBboxes:${studyId}`
+
+function readFromStorage(studyId) {
+  try {
+    const raw = localStorage.getItem(storageKey(studyId))
+    return raw === null ? false : JSON.parse(raw)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Per-study "show bboxes on thumbnails" toggle.
+ *
+ * Backed by localStorage (UI-only preference) and broadcast via the React
+ * Query cache so multiple consumers (Gallery, GalleryDisplayStrip) stay in
+ * sync without prop drilling.
+ *
+ * @param {string} studyId
+ * @returns {{ showThumbnailBboxes: boolean, setShowThumbnailBboxes: (next: boolean | ((prev: boolean) => boolean)) => void }}
+ */
+export function useShowThumbnailBboxes(studyId) {
+  const queryClient = useQueryClient()
+  const queryKey = useMemo(() => ['showThumbnailBboxes', studyId], [studyId])
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: () => readFromStorage(studyId),
+    enabled: !!studyId,
+    staleTime: Infinity,
+    placeholderData: false
+  })
+
+  const showThumbnailBboxes = data ?? false
+
+  const setShowThumbnailBboxes = useCallback(
+    (next) => {
+      const prev = queryClient.getQueryData(queryKey) ?? false
+      const value = typeof next === 'function' ? next(prev) : next
+      queryClient.setQueryData(queryKey, value)
+      try {
+        localStorage.setItem(storageKey(studyId), JSON.stringify(value))
+      } catch {
+        // ignore quota / disabled storage — cache update is authoritative for this session
+      }
+    },
+    [queryClient, queryKey, studyId]
+  )
+
+  return { showThumbnailBboxes, setShowThumbnailBboxes }
+}

--- a/src/renderer/src/hooks/useShowThumbnailBboxes.js
+++ b/src/renderer/src/hooks/useShowThumbnailBboxes.js
@@ -15,9 +15,14 @@ function readFromStorage(studyId) {
 /**
  * Per-study "show bboxes on thumbnails" toggle.
  *
- * Backed by localStorage (UI-only preference) and broadcast via the React
- * Query cache so multiple consumers (Gallery, GalleryDisplayStrip) stay in
- * sync without prop drilling.
+ * UI-only preference — persisted to `localStorage` under
+ * `showBboxes:${studyId}`, not the SQLite study database. Intentionally
+ * different from {@link useSequenceGap}, which round-trips through IPC to
+ * persist in the study DB; thumbnail-bbox visibility is a per-renderer
+ * display preference with no need for main-process awareness.
+ *
+ * Broadcast via the React Query cache so multiple consumers (Gallery,
+ * GalleryDisplayStrip) stay in sync without prop drilling.
  *
  * @param {string} studyId
  * @returns {{ showThumbnailBboxes: boolean, setShowThumbnailBboxes: (next: boolean | ((prev: boolean) => boolean)) => void }}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -8,6 +8,7 @@ import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 import { useImportStatus } from './hooks/import'
 import Gallery from './media/Gallery'
+import GalleryDisplayStrip from './media/GalleryDisplayStrip'
 
 // Color palette used to tint species across the Activity tab's distribution
 // pill, daily-activity radar, and timeline chart.
@@ -255,18 +256,24 @@ export default function Activity({ studyData, studyId }) {
                 />
               )}
             </div>
-            <div className="h-full overflow-auto w-xs">
+            <div className="h-full w-xs flex flex-col gap-2 min-h-0">
+              {speciesInitialized && sequenceGap !== undefined && (
+                <GalleryDisplayStrip studyId={actualStudyId} />
+              )}
               {speciesDistributionData && (
-                <SpeciesDistribution
-                  data={speciesDistributionData}
-                  taxonomicData={taxonomicData}
-                  selectedSpecies={selectedSpecies}
-                  onSpeciesChange={handleSpeciesChange}
-                  palette={palette}
-                  blankCount={blankCount}
-                  vehicleCount={vehicleCount}
-                  studyId={actualStudyId}
-                />
+                <div className="flex-1 min-h-0">
+                  <SpeciesDistribution
+                    data={speciesDistributionData}
+                    taxonomicData={taxonomicData}
+                    selectedSpecies={selectedSpecies}
+                    onSpeciesChange={handleSpeciesChange}
+                    palette={palette}
+                    blankCount={blankCount}
+                    vehicleCount={vehicleCount}
+                    studyId={actualStudyId}
+                    showHeader={false}
+                  />
+                </div>
               )}
             </div>
           </div>

--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -22,8 +22,6 @@ import {
   Layers,
   Play,
   Loader2,
-  ChevronDown,
-  ChevronUp,
   ChevronLeft,
   ChevronRight,
   Heart,
@@ -35,7 +33,6 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useQuery, useQueryClient, useMutation, useInfiniteQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router'
-import * as Tooltip from '@radix-ui/react-tooltip'
 import DeploymentLinkPill from './DeploymentLinkPill'
 import EditableBbox from '../ui/EditableBbox'
 import VideoBboxOverlay from '../ui/VideoBboxOverlay.jsx'
@@ -58,8 +55,8 @@ import {
 import { SpeciesCountLabel } from '../ui/SpeciesLabel'
 import { formatGridTimestamp } from '../utils/formatTimestamp'
 import { useSequenceGap } from '../hooks/useSequenceGap'
+import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
 import DateTimePicker from '../ui/DateTimePicker'
-import { SequenceGapSlider } from '../ui/SequenceGapSlider'
 
 function DrawingOverlay({ imageRef, containerRef, onComplete, zoomTransform }) {
   const [drawStart, setDrawStart] = useState(null)
@@ -1572,87 +1569,6 @@ function ImageModal({
 }
 
 /**
- * Collapsible control bar for gallery view options
- */
-function GalleryControls({
-  showBboxes,
-  onToggleBboxes,
-  hasBboxes,
-  sequenceGap,
-  onSequenceGapChange,
-  isExpanded,
-  onToggleExpanded
-}) {
-  // Collapsed state: tiny chevron on the right
-  if (!isExpanded) {
-    return (
-      <div className="flex items-center justify-end px-3 py-1 border-b border-border flex-shrink-0">
-        <button
-          onClick={onToggleExpanded}
-          className="p-1 text-muted-foreground hover:text-muted-foreground hover:bg-accent rounded transition-colors"
-          title="Show gallery controls"
-        >
-          <ChevronDown size={14} />
-        </button>
-      </div>
-    )
-  }
-
-  // Expanded state: full controls with chevron-up on the right
-  return (
-    <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border flex-shrink-0">
-      {/* Sequence Gap Slider */}
-      <SequenceGapSlider value={sequenceGap} onChange={onSequenceGapChange} variant="compact" />
-
-      <div className="flex items-center gap-2">
-        {/* Show Bboxes Toggle - only render if bboxes exist */}
-        {hasBboxes && (
-          <Tooltip.Root>
-            <Tooltip.Trigger asChild>
-              <button
-                onClick={onToggleBboxes}
-                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                  showBboxes
-                    ? 'bg-blue-600 text-white dark:bg-blue-500 dark:text-white hover:bg-blue-700 dark:hover:bg-blue-600'
-                    : 'bg-muted text-foreground hover:bg-accent'
-                }`}
-              >
-                {showBboxes ? <Eye size={16} /> : <EyeOff size={16} />}
-                <span>Boxes</span>
-              </button>
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content
-                side="bottom"
-                sideOffset={8}
-                align="end"
-                className="z-[10000] max-w-xs px-3 py-2 bg-gray-900 text-white text-xs rounded-md shadow-lg"
-              >
-                <p className="font-medium mb-1">Bounding Boxes</p>
-                <p className="text-muted-foreground">
-                  Show detection boxes on thumbnails highlighting where animals were identified by
-                  the AI model.
-                </p>
-                <Tooltip.Arrow className="fill-gray-900" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        )}
-
-        {/* Collapse toggle - chevron-up on the right */}
-        <button
-          onClick={onToggleExpanded}
-          className="p-1 text-muted-foreground hover:text-muted-foreground hover:bg-accent rounded transition-colors"
-          title="Hide gallery controls"
-        >
-          <ChevronUp size={14} />
-        </button>
-      </div>
-    </div>
-  )
-}
-
-/**
  * SVG overlay showing bboxes on a thumbnail
  * Handles letterboxing by calculating actual image bounds within the container.
  * Receives bbox data and refs as props from parent.
@@ -2211,21 +2127,9 @@ function Gallery({
   const { id } = useParams()
   const queryClient = useQueryClient()
 
-  // Grid controls state - persisted per study in localStorage
-  const showBboxesKey = `showBboxes:${id}`
-  const [showThumbnailBboxes, setShowThumbnailBboxes] = useState(() => {
-    const saved = localStorage.getItem(showBboxesKey)
-    return saved !== null ? JSON.parse(saved) : false
-  })
+  const { showThumbnailBboxes } = useShowThumbnailBboxes(id)
 
   const [itemWidth, setItemWidth] = useState(null)
-
-  const [controlsExpanded, setControlsExpanded] = useState(false)
-
-  // Persist showThumbnailBboxes to localStorage when it changes
-  useEffect(() => {
-    localStorage.setItem(showBboxesKey, JSON.stringify(showThumbnailBboxes))
-  }, [showThumbnailBboxes, showBboxesKey])
 
   // Auto-switch grid columns and calculate exact item width based on container width
   useEffect(() => {
@@ -2264,7 +2168,7 @@ function Gallery({
 
   // Sequence gap - uses React Query cache for cross-component sync
   // Default value is set during study import based on whether the dataset has eventIDs
-  const { sequenceGap, setSequenceGap, isLoading: isSequenceGapLoading } = useSequenceGap(id)
+  const { sequenceGap, isLoading: isSequenceGapLoading } = useSequenceGap(id)
 
   // Fetch pre-grouped sequences from main process with cursor-based pagination
   // This moves the grouping logic to the main process, keeping the client "dumb"
@@ -2328,17 +2232,6 @@ function Gallery({
     queryFn: async () => {
       const response = await window.api.getMediaBboxesBatch(id, mediaIDs)
       return response.data || {}
-    },
-    enabled: mediaIDs.length > 0 && !!id,
-    staleTime: 60000
-  })
-
-  // Check if any media have bboxes (lightweight check for showing/hiding toggle)
-  const { data: anyMediaHaveBboxes = false } = useQuery({
-    queryKey: ['mediaHaveBboxes', id, mediaIDs],
-    queryFn: async () => {
-      const response = await window.api.checkMediaHaveBboxes(id, mediaIDs)
-      return response.data || false
     },
     enabled: mediaIDs.length > 0 && !!id,
     staleTime: 60000
@@ -2583,20 +2476,6 @@ function Gallery({
             : 'flex flex-col h-full bg-card rounded border border-border overflow-hidden'
         }
       >
-        {/* Collapsible Control Bar — hidden when embedded (e.g. inside the
-            Deployments tab's detail pane, which provides its own chrome). */}
-        {!embedded && (
-          <GalleryControls
-            showBboxes={showThumbnailBboxes}
-            onToggleBboxes={() => setShowThumbnailBboxes((prev) => !prev)}
-            hasBboxes={anyMediaHaveBboxes}
-            sequenceGap={sequenceGap}
-            onSequenceGapChange={setSequenceGap}
-            isExpanded={controlsExpanded}
-            onToggleExpanded={() => setControlsExpanded((prev) => !prev)}
-          />
-        )}
-
         {/* Grid — drop horizontal padding when embedded so the first
             image cell aligns with the panel's left edge (matches the map
             in the Deployments tab). */}

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -27,7 +27,7 @@ export default function GalleryDisplayStrip({ studyId }) {
   })
 
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5">
+    <div className="flex items-center gap-2 px-2 h-10 flex-shrink-0">
       <SequenceGapSlider value={sequenceGap} onChange={setSequenceGap} variant="compact" />
       {studyHasBboxes && (
         <Tooltip.Root>

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -15,6 +15,9 @@ export default function GalleryDisplayStrip({ studyId }) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(studyId)
   const { showThumbnailBboxes, setShowThumbnailBboxes } = useShowThumbnailBboxes(studyId)
 
+  // On IPC failure we fall back to `false` (toggle hidden), which is the
+  // safer default than showing a button that does nothing — matches the
+  // resilience pattern in useSequenceGap.
   const { data: studyHasBboxes = false } = useQuery({
     queryKey: ['studyHasAnyBboxes', studyId],
     queryFn: async () => {
@@ -23,7 +26,9 @@ export default function GalleryDisplayStrip({ studyId }) {
       return response.data
     },
     enabled: !!studyId,
-    staleTime: Infinity
+    staleTime: Infinity,
+    retry: 1,
+    throwOnError: false
   })
 
   return (

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -1,0 +1,67 @@
+import { Eye, EyeOff } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { SequenceGapSlider } from '../ui/SequenceGapSlider'
+import { useSequenceGap } from '../hooks/useSequenceGap'
+import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
+
+/**
+ * Borderless display-control strip mounted above the Species panel in the
+ * Media tab's right pane. Holds the sequence-gap slider and the
+ * thumbnail-bbox toggle so they live next to the Species filters rather than
+ * above the gallery grid.
+ */
+export default function GalleryDisplayStrip({ studyId }) {
+  const { sequenceGap, setSequenceGap } = useSequenceGap(studyId)
+  const { showThumbnailBboxes, setShowThumbnailBboxes } = useShowThumbnailBboxes(studyId)
+
+  const { data: studyHasBboxes = false } = useQuery({
+    queryKey: ['studyHasAnyBboxes', studyId],
+    queryFn: async () => {
+      const response = await window.api.studyHasAnyBboxes(studyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!studyId,
+    staleTime: Infinity
+  })
+
+  return (
+    <div className="flex items-center gap-2 px-2 py-1.5">
+      <SequenceGapSlider value={sequenceGap} onChange={setSequenceGap} variant="compact" />
+      {studyHasBboxes && (
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={() => setShowThumbnailBboxes((prev) => !prev)}
+              className={`ml-auto w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+                showThumbnailBboxes
+                  ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+                  : 'text-muted-foreground hover:bg-accent'
+              }`}
+              aria-label={showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
+            >
+              {showThumbnailBboxes ? <Eye size={16} /> : <EyeOff size={16} />}
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="bottom"
+              sideOffset={10}
+              align="end"
+              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+            >
+              <p className="font-medium mb-1">
+                {showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
+              </p>
+              <p className="text-muted-foreground leading-snug">
+                Outlines AI-detected animals on each thumbnail.
+              </p>
+              <Tooltip.Arrow className="fill-popover" />
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/ui/SequenceGapSlider.jsx
+++ b/src/renderer/src/ui/SequenceGapSlider.jsx
@@ -45,6 +45,12 @@ export function SequenceGapSlider({
   // Convert null to 0 for slider display, and 0 back to null.
   const sliderValue = dragValue ?? 0
 
+  // Force-open the tooltip while the user is actively dragging the thumb so
+  // the value stays readable mid-gesture. Hover/focus continues to drive
+  // open/close through Radix the rest of the time.
+  const [isDragging, setIsDragging] = useState(false)
+  const [hoverOpen, setHoverOpen] = useState(false)
+
   const handleInput = (e) => {
     const n = Number(e.target.value)
     setDragValue(n === 0 ? null : n)
@@ -56,14 +62,14 @@ export function SequenceGapSlider({
 
   if (variant === 'compact') {
     return (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-1 min-w-0">
         <Layers
           size={16}
           className={
             dragValue !== null ? 'text-blue-500 dark:text-blue-400' : 'text-muted-foreground'
           }
         />
-        <Tooltip.Root>
+        <Tooltip.Root open={isDragging || hoverOpen} onOpenChange={setHoverOpen}>
           <Tooltip.Trigger asChild>
             <input
               type="range"
@@ -72,41 +78,43 @@ export function SequenceGapSlider({
               step="10"
               value={sliderValue}
               onChange={handleInput}
+              onPointerDown={() => setIsDragging(true)}
+              onPointerUp={() => setIsDragging(false)}
+              onPointerCancel={() => setIsDragging(false)}
               onMouseUp={commit}
               onKeyUp={commit}
               onTouchEnd={commit}
               onBlur={commit}
               disabled={disabled}
-              className="w-24 h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex-1 min-w-0 h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
               aria-label={`Sequence grouping: ${formatGapValue(dragValue)}`}
             />
           </Tooltip.Trigger>
           <Tooltip.Portal>
             <Tooltip.Content
               side="bottom"
-              sideOffset={8}
+              sideOffset={10}
               align="start"
-              className="z-[10000] max-w-xs px-3 py-2 bg-gray-900 text-white text-xs rounded-md shadow-lg"
+              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
             >
-              <p className="font-medium mb-1">Sequence Grouping</p>
-              <p className="text-muted-foreground mb-1.5">
-                Groups nearby photos/videos into sequences for easier browsing.
+              <p className="font-medium mb-1">
+                Sequence grouping
+                <span className="ml-1.5 text-blue-600 dark:text-blue-400 font-semibold tabular-nums">
+                  {formatGapValue(dragValue)}
+                </span>
               </p>
-              <ul className="text-muted-foreground space-y-0.5">
-                <li>
-                  <span className="text-white font-medium">Off:</span> Preserves original event
-                  groupings from import
-                </li>
-                <li>
-                  <span className="text-white font-medium">On:</span> Groups media taken within the
-                  specified time gap
-                </li>
-              </ul>
-              <Tooltip.Arrow className="fill-gray-900" />
+              <p className="text-muted-foreground leading-snug">
+                {dragValue === null
+                  ? 'Off — keep the original event groupings from import.'
+                  : `Group photos and videos taken within ${formatGapValue(dragValue)} of each other into a single sequence.`}
+              </p>
+              <Tooltip.Arrow className="fill-popover" />
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
-        <span className="text-xs text-muted-foreground w-12">{formatGapValue(dragValue)}</span>
+        <span className="text-xs text-muted-foreground whitespace-nowrap min-w-[3.5rem] text-right">
+          {formatGapValue(dragValue)}
+        </span>
       </div>
     )
   }

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -139,7 +139,8 @@ function SpeciesDistribution({
   palette,
   blankCount = 0,
   vehicleCount = 0,
-  studyId = null
+  studyId = null,
+  showHeader = true
 }) {
   // Append pseudo-species rows (Blank, Vehicle) when their counts are > 0.
   const displayData = useMemo(() => {
@@ -218,10 +219,12 @@ function SpeciesDistribution({
 
   return (
     <div className="w-full h-full bg-card rounded border border-border flex flex-col overflow-hidden">
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-border flex-shrink-0">
-        <span className="text-sm font-medium text-foreground">Species</span>
-        <span className="text-xs text-muted-foreground">({speciesCount})</span>
-      </div>
+      {showHeader && (
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-border flex-shrink-0">
+          <span className="text-sm font-medium text-foreground">Species</span>
+          <span className="text-xs text-muted-foreground">({speciesCount})</span>
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto px-3 myscroll" onScroll={handleScroll}>
         <div>


### PR DESCRIPTION
## Summary

- **Media tab**: replaces the collapsible toolbar above the gallery with a borderless control strip above the Species panel — gap slider + bbox toggle. Drops the Species header so rows start at the top of the card.
- **Activity tab**: mirrors the same strip (slider only — no thumbnails) and drops the Species header for visual parity.
- **Tooltips**: themed popover colors instead of the harsh dark slab; spring slide-in animation per side; gap slider tooltip stays open while dragging and shows the current value with adaptive copy.
- **State**: `showThumbnailBboxes` lifted from `Gallery` into `useShowThumbnailBboxes` (localStorage-backed React Query hook) so the strip and the grid share state without prop drilling.
- **Backend**: new `studyHasAnyBboxes` query + IPC handler so the eye toggle only renders when the study has detections at all, independent of paginated grid contents.

## Test plan

- [x] Media tab: drag slider, confirm tooltip stays open mid-drag and shows current value; release → grid regroups.
- [x] Media tab: toggle bbox eye via strip; thumbnails update; preference survives reload.
- [x] Media tab on a study with no bboxes (e.g. ENA24): eye toggle hidden.
- [x] Activity tab: slider strip present above (header-less) Species panel; no bbox toggle.
- [x] Both tabs in light + dark mode: tooltips look themed, slide in from the trigger side.
- [x] Gap slider on Activity tab stays in sync with Media tab (same `useSequenceGap` cache).
- [x] Deployments tab embedded gallery is unaffected (no toolbar to move).
- [x] Lightbox `B` keyboard shortcut still toggles the per-image bbox overlay.