### PR TITLE
row based warning and blocking

### DIFF
--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -250,8 +250,12 @@ export default function DeploymentsImportPreviewModal({
               will update
             </span>
             <span className="inline-flex items-center gap-1">
+              <span className="inline-block w-3 h-3 rounded-sm bg-red-50 dark:bg-red-500/10 border border-red-300/60 dark:border-red-500/30" />
+              row blocked by warning
+            </span>
+            <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-500/5 border border-amber-300/60 dark:border-amber-500/30" />
-              warning row blocked
+              cell warning
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-muted/40 dark:bg-muted/30 border border-border" />
@@ -271,7 +275,7 @@ export default function DeploymentsImportPreviewModal({
               disabled={!canApply}
               className="px-3 py-1.5 text-xs bg-blue-500 hover:bg-blue-600 text-white rounded disabled:opacity-50 disabled:hover:bg-blue-500"
             >
-              {isApplying ? 'Applying…' : `Apply (${preview.applyCount})`}
+              {isApplying ? 'Applying…' : `Apply (${applyCount})`}
             </button>
           </div>
         </div>

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -5,7 +5,8 @@ import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
   countRowsBlockedByWarnings,
-  EDITABLE_DEPLOYMENT_IMPORT_KEYS
+  EDITABLE_DEPLOYMENT_IMPORT_KEYS,
+  getDeploymentsCsvImportRowClassName
 } from './deploymentsImportPreviewModel'
 
 const EDITABLE_KEYS = EDITABLE_DEPLOYMENT_IMPORT_KEYS
@@ -56,16 +57,7 @@ function CellContent({ col }) {
 }
 
 function rowBackgroundClass(row) {
-  if (row.rowState === 'skipped') {
-    return 'bg-muted/40 dark:bg-muted/30 opacity-60'
-  }
-  const hasChange = EDITABLE_KEYS.some((k) => row.columns[k]?.state === 'change')
-  if (hasChange) return 'bg-green-50 dark:bg-green-500/10'
-  // Any column with a warning counts — including readonly mismatches on
-  // locationID — so the visual matches what the warnings filter selects.
-  const hasWarning = Object.values(row.columns).some((c) => c?.state === 'warning')
-  if (hasWarning) return 'bg-amber-50 dark:bg-amber-500/5'
-  return ''
+  return getDeploymentsCsvImportRowClassName(row)
 }
 
 function renderGutter(row) {

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -2,8 +2,12 @@ import { X, AlertTriangle, Ban, ArrowRight, ArrowLeftRight } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
+import {
+  buildDeploymentsCsvApplyPlan,
+  EDITABLE_DEPLOYMENT_IMPORT_KEYS
+} from './deploymentsImportPreviewModel'
 
-const EDITABLE_KEYS = ['locationName', 'latitude', 'longitude']
+const EDITABLE_KEYS = EDITABLE_DEPLOYMENT_IMPORT_KEYS
 
 function CellContent({ col }) {
   if (col.state === 'warning') {
@@ -100,22 +104,7 @@ export default function DeploymentsImportPreviewModal({
   }, [onCancel, isApplying])
 
   const applyPlan = useMemo(() => {
-    if (!preview) return []
-    const plan = []
-    for (const row of preview.rows) {
-      if (row.rowState !== 'normal') continue
-      const fields = {}
-      for (const key of EDITABLE_KEYS) {
-        const col = row.columns[key]
-        if (col.state === 'change') {
-          fields[key] = col.appliedValue
-        }
-      }
-      if (Object.keys(fields).length > 0) {
-        plan.push({ deploymentID: row.deploymentID, fields })
-      }
-    }
-    return plan
+    return buildDeploymentsCsvApplyPlan(preview)
   }, [preview])
 
   const filteredRows = useMemo(() => {

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -4,6 +4,7 @@ import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
+  countRowsBlockedByWarnings,
   EDITABLE_DEPLOYMENT_IMPORT_KEYS
 } from './deploymentsImportPreviewModel'
 
@@ -132,13 +133,7 @@ export default function DeploymentsImportPreviewModal({
   // warnings-filter tile when there's nothing to show, and to label it
   // honestly: cellWarningCount is per-cell, this is per-row.
   const rowsWithWarningCount = useMemo(() => {
-    if (!preview) return 0
-    let n = 0
-    for (const row of preview.rows) {
-      if (row.rowState !== 'normal') continue
-      if (Object.values(row.columns).some((c) => c?.state === 'warning')) n++
-    }
-    return n
+    return countRowsBlockedByWarnings(preview)
   }, [preview])
 
   if (!preview) return null
@@ -199,7 +194,7 @@ export default function DeploymentsImportPreviewModal({
             title={
               filter === 'warnings'
                 ? 'Click to show all rows'
-                : 'Click to show only rows with cell warnings'
+                : 'Click to show only rows blocked by warnings'
             }
             className={`inline-flex items-center gap-1 px-2 py-1 rounded border transition-colors disabled:cursor-default disabled:opacity-60 ${
               filter === 'warnings'
@@ -207,8 +202,8 @@ export default function DeploymentsImportPreviewModal({
                 : 'border-transparent hover:bg-accent text-amber-700 dark:text-amber-300'
             }`}
           >
-            <AlertTriangle size={12} /> {preview.cellWarningCount}{' '}
-            {preview.cellWarningCount === 1 ? 'cell' : 'cells'} skipped
+            <AlertTriangle size={12} /> {rowsWithWarningCount}{' '}
+            {rowsWithWarningCount === 1 ? 'row' : 'rows'} blocked by warnings
           </button>
           <button
             onClick={() => toggleFilter('skipped')}
@@ -263,7 +258,7 @@ export default function DeploymentsImportPreviewModal({
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-500/5 border border-amber-300/60 dark:border-amber-500/30" />
-              cell warning
+              warning row blocked
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-muted/40 dark:bg-muted/30 border border-border" />

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -130,7 +130,8 @@ export default function DeploymentsImportPreviewModal({
 
   if (!preview) return null
 
-  const canApply = preview.applyCount > 0 && !isApplying
+  const applyCount = applyPlan.length
+  const canApply = applyCount > 0 && !isApplying
 
   const handleBackdropMouseDown = (e) => {
     if (e.target === e.currentTarget && !isApplying) onCancel()
@@ -165,7 +166,7 @@ export default function DeploymentsImportPreviewModal({
         <div className="flex items-center gap-2 px-4 py-2 border-b border-border text-xs">
           <button
             onClick={() => toggleFilter('updated')}
-            disabled={preview.applyCount === 0}
+            disabled={applyCount === 0}
             title={
               filter === 'updated'
                 ? 'Click to show all rows'
@@ -177,8 +178,8 @@ export default function DeploymentsImportPreviewModal({
                 : 'border-transparent hover:bg-accent text-green-700 dark:text-green-300'
             }`}
           >
-            <ArrowLeftRight size={12} /> {preview.applyCount}{' '}
-            {preview.applyCount === 1 ? 'row' : 'rows'} will update
+            <ArrowLeftRight size={12} /> {applyCount} {applyCount === 1 ? 'row' : 'rows'} will
+            update
           </button>
           <button
             onClick={() => toggleFilter('warnings')}

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -4,6 +4,16 @@ export function rowHasWarning(row) {
   return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
 }
 
+export function countRowsBlockedByWarnings(preview) {
+  if (!preview) return 0
+  let count = 0
+  for (const row of preview.rows || []) {
+    if (row.rowState !== 'normal') continue
+    if (rowHasWarning(row)) count++
+  }
+  return count
+}
+
 export function buildDeploymentsCsvApplyPlan(preview) {
   if (!preview) return []
 

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -1,0 +1,27 @@
+export const EDITABLE_DEPLOYMENT_IMPORT_KEYS = ['locationName', 'latitude', 'longitude']
+
+export function rowHasWarning(row) {
+  return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
+}
+
+export function buildDeploymentsCsvApplyPlan(preview) {
+  if (!preview) return []
+
+  const plan = []
+  for (const row of preview.rows || []) {
+    if (row.rowState !== 'normal') continue
+    if (rowHasWarning(row)) continue
+
+    const fields = {}
+    for (const key of EDITABLE_DEPLOYMENT_IMPORT_KEYS) {
+      const col = row.columns[key]
+      if (col.state === 'change') {
+        fields[key] = col.appliedValue
+      }
+    }
+    if (Object.keys(fields).length > 0) {
+      plan.push({ deploymentID: row.deploymentID, fields })
+    }
+  }
+  return plan
+}

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -4,6 +4,19 @@ export function rowHasWarning(row) {
   return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
 }
 
+export function rowHasEditableChange(row) {
+  return EDITABLE_DEPLOYMENT_IMPORT_KEYS.some((key) => row?.columns?.[key]?.state === 'change')
+}
+
+export function getDeploymentsCsvImportRowClassName(row) {
+  if (row?.rowState === 'skipped') {
+    return 'bg-muted/40 dark:bg-muted/30 opacity-60'
+  }
+  if (rowHasWarning(row)) return 'bg-red-50 dark:bg-red-500/10'
+  if (rowHasEditableChange(row)) return 'bg-green-50 dark:bg-green-500/10'
+  return ''
+}
+
 export function countRowsBlockedByWarnings(preview) {
   if (!preview) return 0
   let count = 0

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -1,0 +1,53 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildDeploymentsCsvApplyPlan } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
+
+describe('buildDeploymentsCsvApplyPlan', () => {
+  test('blocks all editable changes in rows that have any warning cell', () => {
+    const preview = {
+      rows: [
+        {
+          rowState: 'normal',
+          deploymentID: 'CAM_001',
+          columns: {
+            deploymentID: { state: 'readonly' },
+            locationID: { state: 'warning', warning: 'locationID is read-only.' },
+            locationName: {
+              state: 'change',
+              appliedValue: 'Ridge South'
+            },
+            latitude: {
+              state: 'change',
+              appliedValue: 45.5
+            },
+            longitude: { state: 'unchanged' }
+          }
+        },
+        {
+          rowState: 'normal',
+          deploymentID: 'CAM_002',
+          columns: {
+            deploymentID: { state: 'readonly' },
+            locationID: { state: 'readonly' },
+            locationName: { state: 'unchanged' },
+            latitude: {
+              state: 'change',
+              appliedValue: 46.25
+            },
+            longitude: { state: 'unchanged' }
+          }
+        }
+      ]
+    }
+
+    assert.deepEqual(buildDeploymentsCsvApplyPlan(preview), [
+      {
+        deploymentID: 'CAM_002',
+        fields: {
+          latitude: 46.25
+        }
+      }
+    ])
+  })
+})

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 
 import {
   buildDeploymentsCsvApplyPlan,
-  countRowsBlockedByWarnings
+  countRowsBlockedByWarnings,
+  getDeploymentsCsvImportRowClassName
 } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
 
 describe('buildDeploymentsCsvApplyPlan', () => {
@@ -52,6 +53,31 @@ describe('buildDeploymentsCsvApplyPlan', () => {
         }
       }
     ])
+  })
+})
+
+describe('getDeploymentsCsvImportRowClassName', () => {
+  test('uses red highlighting for normal rows blocked by warnings', () => {
+    const className = getDeploymentsCsvImportRowClassName({
+      rowState: 'normal',
+      columns: {
+        locationID: { state: 'warning' },
+        latitude: { state: 'change' }
+      }
+    })
+
+    assert.match(className, /bg-red/)
+  })
+
+  test('keeps green highlighting for clean rows that will update', () => {
+    const className = getDeploymentsCsvImportRowClassName({
+      rowState: 'normal',
+      columns: {
+        latitude: { state: 'change' }
+      }
+    })
+
+    assert.match(className, /bg-green/)
   })
 })
 

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -1,7 +1,10 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { buildDeploymentsCsvApplyPlan } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
+import {
+  buildDeploymentsCsvApplyPlan,
+  countRowsBlockedByWarnings
+} from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
 
 describe('buildDeploymentsCsvApplyPlan', () => {
   test('blocks all editable changes in rows that have any warning cell', () => {
@@ -49,5 +52,41 @@ describe('buildDeploymentsCsvApplyPlan', () => {
         }
       }
     ])
+  })
+})
+
+describe('countRowsBlockedByWarnings', () => {
+  test('counts normal rows with warning cells, not warning cells', () => {
+    const preview = {
+      rows: [
+        {
+          rowState: 'normal',
+          columns: {
+            locationID: { state: 'warning' },
+            latitude: { state: 'warning' }
+          }
+        },
+        {
+          rowState: 'normal',
+          columns: {
+            latitude: { state: 'warning' }
+          }
+        },
+        {
+          rowState: 'skipped',
+          columns: {
+            deploymentID: { state: 'readonly' }
+          }
+        },
+        {
+          rowState: 'normal',
+          columns: {
+            latitude: { state: 'change' }
+          }
+        }
+      ]
+    }
+
+    assert.equal(countRowsBlockedByWarnings(preview), 2)
   })
 })


### PR DESCRIPTION
This updates the validation behavior from cell-level skipping to row-level blocking: if a row has any warning, the entire row is excluded from apply.

The preview counts, row highlighting, legend, and Apply button enablement logic have been updated accordingly.