### PR TITLE
feat(media,activity): toggle filter-charts row from gap-slider strip

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -16,6 +16,7 @@ import MarkerHoverCard from './ui/MarkerHoverCard'
 import { useTheme } from './hooks/useTheme'
 import PlaceholderMap from './ui/PlaceholderMap'
 import { SequenceGapSlider } from './ui/SequenceGapSlider'
+import FilterChartsToggle from './ui/FilterChartsToggle'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
@@ -23,6 +24,7 @@ import { buildScientificToCommonMap, getMapDisplayName } from './utils/commonNam
 import { formatScientificName } from './utils/scientificName'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
+import { useShowFilterCharts } from './hooks/useShowFilterCharts'
 
 // Inject the keyframes used by the skeleton markers once per page load.
 // Guarded by an id check so HMR / multiple SpeciesMap mounts don't re-append
@@ -578,6 +580,7 @@ export default function Activity({ studyData, studyId }) {
   const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
+  const { showFilterCharts } = useShowFilterCharts(actualStudyId)
 
   // Lightweight deduped deployment-location query (shared cache with the
   // Overview tab). Used to paint the skeleton map immediately while the
@@ -806,7 +809,7 @@ export default function Activity({ studyData, studyId }) {
           Error: {speciesDistributionError.message}
         </div>
       ) : (
-        <div className="flex flex-col h-full gap-4">
+        <div className="flex flex-col h-full">
           {/* First row - takes remaining space */}
           <div className="flex flex-row gap-4 flex-1 min-h-0">
             {/* Species Distribution - left side */}
@@ -852,6 +855,15 @@ export default function Activity({ studyData, studyId }) {
                     onChange={setSequenceGap}
                     variant="compact"
                   />
+                  <div className="ml-auto flex items-center gap-1">
+                    <FilterChartsToggle
+                      studyId={actualStudyId}
+                      // Optimistic while timeseries is loading — hide only
+                      // once we've confirmed the study has no timestamps
+                      // (ENA24, Biome Health Project, etc).
+                      hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
+                    />
+                  </div>
                 </div>
               )}
               {speciesDistributionData && (
@@ -870,16 +882,23 @@ export default function Activity({ studyData, studyId }) {
             </div>
           </div>
 
-          {/* Second row — always reserves 130px of layout space so the map
-              row above doesn't snap smaller when the filters finally mount.
-              The borders + children only render once inputs have settled
-              (speciesInitialized && sequenceGap !== undefined), which
-              prevents the empty bordered flash and the double-fire of
-              timeseries / daily-activity as queryKey inputs stabilize
-              (mirrors media.jsx's b5c4dca guard). */}
-          <div className="w-full h-[130px] flex-shrink-0">
+          {/* Second row — wrapper is always mounted so the height/opacity/
+              margin transition can run in both directions when the filter-
+              charts toggle flips. Inner contents stay gated on
+              speciesInitialized && sequenceGap !== undefined to prevent the
+              empty-bordered flash and the double-fire of timeseries /
+              daily-activity queries as queryKey inputs stabilize. Default
+              OFF; when off, the map above grows to reclaim the 130px. */}
+          <div
+            className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
+              showFilterCharts && hasTemporalData
+                ? 'h-[130px] opacity-100 mt-4'
+                : 'h-0 opacity-0 mt-0'
+            }`}
+            aria-hidden={!(showFilterCharts && hasTemporalData)}
+          >
             {speciesInitialized && sequenceGap !== undefined && (
-              <div className="w-full flex h-full gap-3">
+              <div className="w-full flex h-[130px] gap-3">
                 <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
                   <DailyActivityRadar
                     activityData={dailyActivityData}

--- a/src/renderer/src/hooks/useShowFilterCharts.js
+++ b/src/renderer/src/hooks/useShowFilterCharts.js
@@ -1,0 +1,56 @@
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+const storageKey = (studyId) => `showFilterCharts:${studyId}`
+
+function readFromStorage(studyId) {
+  try {
+    const raw = localStorage.getItem(storageKey(studyId))
+    return raw === null ? false : JSON.parse(raw)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Per-study toggle for the bottom-row filter charts (Clock + Timeline) shown
+ * on the Media and Activity tabs. When false, the bottom row is hidden and
+ * the main content (Gallery / Map) reclaims that vertical space.
+ *
+ * Same shape as {@link useShowThumbnailBboxes}: persisted to localStorage
+ * under `showFilterCharts:${studyId}` and broadcast through the React Query
+ * cache so the Media and Activity tabs stay in sync without prop drilling.
+ *
+ * @param {string} studyId
+ * @returns {{ showFilterCharts: boolean, setShowFilterCharts: (next: boolean | ((prev: boolean) => boolean)) => void }}
+ */
+export function useShowFilterCharts(studyId) {
+  const queryClient = useQueryClient()
+  const queryKey = useMemo(() => ['showFilterCharts', studyId], [studyId])
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: () => readFromStorage(studyId),
+    enabled: !!studyId,
+    staleTime: Infinity,
+    placeholderData: false
+  })
+
+  const showFilterCharts = data ?? false
+
+  const setShowFilterCharts = useCallback(
+    (next) => {
+      const prev = queryClient.getQueryData(queryKey) ?? false
+      const value = typeof next === 'function' ? next(prev) : next
+      queryClient.setQueryData(queryKey, value)
+      try {
+        localStorage.setItem(storageKey(studyId), JSON.stringify(value))
+      } catch {
+        // ignore quota / disabled storage — cache update is authoritative for this session
+      }
+    },
+    [queryClient, queryKey, studyId]
+  )
+
+  return { showFilterCharts, setShowFilterCharts }
+}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -6,6 +6,7 @@ import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
+import { useShowFilterCharts } from './hooks/useShowFilterCharts'
 import { useImportStatus } from './hooks/import'
 import Gallery from './media/Gallery'
 import GalleryDisplayStrip from './media/GalleryDisplayStrip'
@@ -38,6 +39,7 @@ export default function Activity({ studyData, studyId }) {
 
   // Sequence gap - uses React Query for sync across components
   const { sequenceGap } = useSequenceGap(actualStudyId)
+  const { showFilterCharts } = useShowFilterCharts(actualStudyId)
 
   const taxonomicData = studyData?.taxonomic || null
 
@@ -239,7 +241,7 @@ export default function Activity({ studyData, studyId }) {
           Error: {speciesDistributionError.message}
         </div>
       ) : (
-        <div className="flex flex-col h-full gap-4">
+        <div className="flex flex-col h-full">
           {/* First row - takes remaining space */}
           <div className="flex flex-row gap-4 flex-1 min-h-0">
             {/* Species Distribution - left side */}
@@ -258,7 +260,14 @@ export default function Activity({ studyData, studyId }) {
             </div>
             <div className="h-full w-xs flex flex-col gap-2 min-h-0">
               {speciesInitialized && sequenceGap !== undefined && (
-                <GalleryDisplayStrip studyId={actualStudyId} />
+                <GalleryDisplayStrip
+                  studyId={actualStudyId}
+                  // Stay optimistic while the timeseries query is still in
+                  // flight so the toggle doesn't briefly disappear on mount
+                  // for studies that DO have timestamps; only hide it once
+                  // we've confirmed the study has none.
+                  hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
+                />
               )}
               {speciesDistributionData && (
                 <div className="flex-1 min-h-0">
@@ -278,36 +287,48 @@ export default function Activity({ studyData, studyId }) {
             </div>
           </div>
 
-          {/* Second row - fixed height with timeline and clock.
-              Hidden entirely until species + sequenceGap are settled so the
-              bordered containers don't appear empty during the initial load. */}
-          {speciesInitialized && sequenceGap !== undefined && (
-            <div className="w-full flex h-[130px] flex-shrink-0 gap-3">
-              <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
-                <DailyActivityRadar
-                  activityData={dailyActivityData}
-                  selectedSpecies={selectedSpecies}
-                  palette={palette}
-                />
-                <div className="absolute w-full h-full flex items-center justify-center">
-                  <CircularTimeFilter
-                    onChange={handleTimeRangeChange}
-                    startTime={timeRange.start}
-                    endTime={timeRange.end}
+          {/* Second row - timeline + clock. Wrapper is always mounted so
+              the height/opacity/margin transition can run in both directions
+              when the filter-charts toggle flips. Inner contents still gated
+              on species + sequenceGap so the bordered boxes don't flash empty
+              during initial load. Default OFF; when off, the row collapses
+              and the gallery reclaims the 130px. */}
+          <div
+            className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
+              showFilterCharts && hasTemporalData
+                ? 'h-[130px] opacity-100 mt-4'
+                : 'h-0 opacity-0 mt-0'
+            }`}
+            aria-hidden={!(showFilterCharts && hasTemporalData)}
+          >
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-[130px] gap-3">
+                <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
+                  <DailyActivityRadar
+                    activityData={dailyActivityData}
+                    selectedSpecies={selectedSpecies}
+                    palette={palette}
+                  />
+                  <div className="absolute w-full h-full flex items-center justify-center">
+                    <CircularTimeFilter
+                      onChange={handleTimeRangeChange}
+                      startTime={timeRange.start}
+                      endTime={timeRange.end}
+                    />
+                  </div>
+                </div>
+                <div className="flex-grow rounded px-2 border border-border">
+                  <TimelineChart
+                    timeseriesData={timeseriesData}
+                    selectedSpecies={selectedSpecies}
+                    dateRange={[dateRange[0] ?? fullExtent[0], dateRange[1] ?? fullExtent[1]]}
+                    setDateRange={setDateRange}
+                    palette={palette}
                   />
                 </div>
               </div>
-              <div className="flex-grow rounded px-2 border border-border">
-                <TimelineChart
-                  timeseriesData={timeseriesData}
-                  selectedSpecies={selectedSpecies}
-                  dateRange={[dateRange[0] ?? fullExtent[0], dateRange[1] ?? fullExtent[1]]}
-                  setDateRange={setDateRange}
-                  palette={palette}
-                />
-              </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -2,16 +2,20 @@ import { Eye, EyeOff } from 'lucide-react'
 import { useQuery } from '@tanstack/react-query'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { SequenceGapSlider } from '../ui/SequenceGapSlider'
+import FilterChartsToggle from '../ui/FilterChartsToggle'
 import { useSequenceGap } from '../hooks/useSequenceGap'
 import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
 
 /**
  * Borderless display-control strip mounted above the Species panel in the
- * Media tab's right pane. Holds the sequence-gap slider and the
- * thumbnail-bbox toggle so they live next to the Species filters rather than
- * above the gallery grid.
+ * Media tab's right pane. Holds the sequence-gap slider, the thumbnail-bbox
+ * toggle, and the filter-charts toggle so they live next to the Species
+ * filters rather than above the gallery grid.
+ *
+ * `hasTemporalData` is forwarded to {@link FilterChartsToggle} so studies
+ * without media timestamps don't show a toggle that can't do anything.
  */
-export default function GalleryDisplayStrip({ studyId }) {
+export default function GalleryDisplayStrip({ studyId, hasTemporalData }) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(studyId)
   const { showThumbnailBboxes, setShowThumbnailBboxes } = useShowThumbnailBboxes(studyId)
 
@@ -34,39 +38,42 @@ export default function GalleryDisplayStrip({ studyId }) {
   return (
     <div className="flex items-center gap-2 px-2 h-10 flex-shrink-0">
       <SequenceGapSlider value={sequenceGap} onChange={setSequenceGap} variant="compact" />
-      {studyHasBboxes && (
-        <Tooltip.Root>
-          <Tooltip.Trigger asChild>
-            <button
-              onClick={() => setShowThumbnailBboxes((prev) => !prev)}
-              className={`ml-auto w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
-                showThumbnailBboxes
-                  ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
-                  : 'text-muted-foreground hover:bg-accent'
-              }`}
-              aria-label={showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
-            >
-              {showThumbnailBboxes ? <Eye size={16} /> : <EyeOff size={16} />}
-            </button>
-          </Tooltip.Trigger>
-          <Tooltip.Portal>
-            <Tooltip.Content
-              side="bottom"
-              sideOffset={10}
-              align="end"
-              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
-            >
-              <p className="font-medium mb-1">
-                {showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
-              </p>
-              <p className="text-muted-foreground leading-snug">
-                Outlines AI-detected animals on each thumbnail.
-              </p>
-              <Tooltip.Arrow className="fill-popover" />
-            </Tooltip.Content>
-          </Tooltip.Portal>
-        </Tooltip.Root>
-      )}
+      <div className="ml-auto flex items-center gap-1">
+        {studyHasBboxes && (
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <button
+                onClick={() => setShowThumbnailBboxes((prev) => !prev)}
+                className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+                  showThumbnailBboxes
+                    ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+                    : 'text-muted-foreground hover:bg-accent'
+                }`}
+                aria-label={showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
+              >
+                {showThumbnailBboxes ? <Eye size={16} /> : <EyeOff size={16} />}
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="bottom"
+                sideOffset={10}
+                align="end"
+                className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              >
+                <p className="font-medium mb-1">
+                  {showThumbnailBboxes ? 'Hide bounding boxes' : 'Show bounding boxes'}
+                </p>
+                <p className="text-muted-foreground leading-snug">
+                  Outlines AI-detected animals on each thumbnail.
+                </p>
+                <Tooltip.Arrow className="fill-popover" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )}
+        <FilterChartsToggle studyId={studyId} hasTemporalData={hasTemporalData} />
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -1,0 +1,57 @@
+import { SlidersHorizontal } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { useShowFilterCharts } from '../hooks/useShowFilterCharts'
+
+/**
+ * Toggle button for the bottom-row filter charts (Clock + Timeline) on the
+ * Media and Activity tabs. State is per-study and shared between both tabs
+ * via {@link useShowFilterCharts}.
+ *
+ * Hidden entirely when `hasTemporalData === false` — studies whose media
+ * rows have no timestamps (e.g. ENA24, Biome Health Project) can never
+ * populate the Clock or Timeline, so the toggle would be meaningless.
+ * Passing `true` or omitting the prop keeps the button visible (the latter
+ * lets callers stay optimistic while the timeseries query is still loading).
+ *
+ * Visual treatment mirrors the bbox toggle in GalleryDisplayStrip so the
+ * two icons read as a coherent set in the gap-slider strip.
+ */
+export default function FilterChartsToggle({ studyId, hasTemporalData = true }) {
+  const { showFilterCharts, setShowFilterCharts } = useShowFilterCharts(studyId)
+
+  if (!hasTemporalData) return null
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <button
+          onClick={() => setShowFilterCharts((prev) => !prev)}
+          className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+            showFilterCharts
+              ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+              : 'text-muted-foreground hover:bg-accent'
+          }`}
+          aria-label={showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
+        >
+          <SlidersHorizontal size={16} />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          side="bottom"
+          sideOffset={10}
+          align="end"
+          className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+        >
+          <p className="font-medium mb-1">
+            {showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
+          </p>
+          <p className="text-muted-foreground leading-snug">
+            Daily-activity clock and timeline filters.
+          </p>
+          <Tooltip.Arrow className="fill-popover" />
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  )
+}


### PR DESCRIPTION
## Summary

Adds a `SlidersHorizontal` button to the gap-slider strip on both the Media and Activity tabs. It collapses the bottom-row filter charts (daily-activity clock + timeline), letting the gallery / map reclaim the 130px.

<img width="345" height="73" alt="image" src="https://github.com/user-attachments/assets/ec92ae5c-ac45-4ceb-aa6f-575d8a470ab2" />


- **Behavior:** per-study toggle, shared between Media and Activity, default OFF, persisted to `localStorage` under `showFilterCharts:<studyId>` (mirroring `useShowThumbnailBboxes`)
- **Transition:** 300ms height + opacity + margin ease-in-out, two-way smooth (children stay mounted; the timeseries / daily-activity queries already run regardless)
- **No-timestamp studies:** the toggle is hidden entirely for studies whose media rows have no timestamps (verified locally on `ENA24 Detection` — 0/9676 with `timestamp` — and `Biome Health Project Maasai Mara 2018` — 0/37075). Parents pass `hasTemporalData || timeseriesQueryData === undefined` so the button doesn't flash off during the initial load for studies that do have timestamps.
- **Defense in depth:** the wrapper's visible state is also ANDed with `hasTemporalData`, so a stale `localStorage` "ON" can't force-show an empty row.

## Files

- `src/renderer/src/hooks/useShowFilterCharts.js` *(new)* — mirrors `useShowThumbnailBboxes`
- `src/renderer/src/ui/FilterChartsToggle.jsx` *(new)* — `hasTemporalData` prop, returns `null` when explicitly `false`
- `src/renderer/src/media/GalleryDisplayStrip.jsx` — wraps both display buttons in a single right-aligned group; forwards `hasTemporalData`
- `src/renderer/src/media.jsx`, `src/renderer/src/activity.jsx` — drop the parent flex `gap-4` (now a `mt-4` on the animated row), wire the hook + transition

## Test plan

- [x] Open a study WITH timestamps (e.g. `Demo - Kruger`, `MUNTJAC_ANTWERP`): SlidersHorizontal button appears in the Media strip (right of the bbox eye) and in the Activity strip; default OFF, bottom row not rendered
- [x] Click the icon: row slides in over 300ms; click again, slides out
- [x] Toggle on Media → switch to Activity → state preserved; reload app → state persists per study
- [x] Hover icon → tooltip reads "Show filter charts" / "Hide filter charts" + "Daily-activity clock and timeline filters."
- [x] Open `ENA24 Detection` or `Biome Health Project Maasai Mara 2018`: SlidersHorizontal button is NOT visible in either tab strip; bottom row stays collapsed even if `localStorage` previously had `showFilterCharts:<studyId> = true`
- [x] `npm test` passes (1241 tests confirmed locally)