### PR TITLE
Restyle pseudo species with hover-card descriptions

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -876,6 +876,7 @@ export default function Activity({ studyData, studyId }) {
                     palette={palette}
                     studyId={actualStudyId}
                     showHeader={false}
+                    hidePseudoSpecies
                   />
                 </div>
               )}

--- a/src/renderer/src/ui/PseudoSpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/PseudoSpeciesTooltipContent.jsx
@@ -1,0 +1,16 @@
+/**
+ * Compact text-only hover card shown for pseudo-species rows in the
+ * species list (Blank, Vehicle, processing labels). No image area —
+ * the goal is to explain what the bucket means.
+ */
+export default function PseudoSpeciesTooltipContent({ entry }) {
+  if (!entry) return null
+  return (
+    <div className="w-[280px] bg-card rounded-lg shadow-xl border border-border overflow-hidden">
+      <div className="px-3 py-2.5">
+        <p className="text-sm font-medium text-foreground mb-1.5">{entry.label}</p>
+        <p className="text-[12px] text-muted-foreground leading-snug">{entry.description}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -1,23 +1,18 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import * as HoverCard from '@radix-ui/react-hover-card'
-import {
-  sortSpeciesHumansLast,
-  isBlank,
-  isVehicle,
-  BLANK_SENTINEL,
-  VEHICLE_SENTINEL
-} from '../utils/speciesUtils'
+import { sortSpeciesHumansLast, BLANK_SENTINEL, VEHICLE_SENTINEL } from '../utils/speciesUtils'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
+import PseudoSpeciesTooltipContent from './PseudoSpeciesTooltipContent'
 import { buildScientificToCommonMap, useCommonName } from '../utils/commonNames'
 import { formatScientificName } from '../utils/scientificName'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
+import { getPseudoSpeciesEntry } from '../../../shared/pseudoSpecies.js'
 
 function SpeciesRow({
   species,
   index,
-  isBlankEntry,
-  isVehicleEntry,
+  pseudoEntry,
   isFirstPseudo,
   storedCommonName,
   selectedSpecies,
@@ -28,7 +23,7 @@ function SpeciesRow({
   onToggle,
   scrollSignal
 }) {
-  const isPseudoEntry = isBlankEntry || isVehicleEntry
+  const isPseudoEntry = !!pseudoEntry
   const [hoverOpen, setHoverOpen] = useState(false)
   // Close any open card when the parent list scrolls — Radix HoverCard tracks
   // its trigger, so without this the card "rides along" with the row, which
@@ -40,11 +35,9 @@ function SpeciesRow({
   const resolved = useCommonName(isPseudoEntry ? null : species.scientificName, {
     storedCommonName
   })
-  const displayName = isBlankEntry
-    ? 'Blank'
-    : isVehicleEntry
-      ? 'Vehicle'
-      : resolved || formatScientificName(species.scientificName)
+  const displayName = isPseudoEntry
+    ? pseudoEntry.label
+    : resolved || formatScientificName(species.scientificName)
 
   const isSelected = selectedSpecies.some((s) => s.scientificName === species.scientificName)
   const colorIndex = selectedSpecies.findIndex((s) => s.scientificName === species.scientificName)
@@ -59,7 +52,7 @@ function SpeciesRow({
   const studyImage = isPseudoEntry ? null : speciesImageMap[species.scientificName]
   const tooltipImageData =
     studyImage || (info?.imageUrl ? { scientificName: species.scientificName } : null)
-  const enableTooltip = studyId && !!tooltipImageData
+  const enableSpeciesTooltip = !isPseudoEntry && studyId && !!tooltipImageData
 
   const rowContent = (
     <div
@@ -77,7 +70,7 @@ function SpeciesRow({
           <span
             className={`text-sm truncate ${
               isPseudoEntry
-                ? 'text-muted-foreground italic'
+                ? 'text-foreground'
                 : showScientificInItalic
                   ? 'text-foreground capitalize'
                   : 'text-foreground italic'
@@ -107,7 +100,7 @@ function SpeciesRow({
     </div>
   )
 
-  if (enableTooltip) {
+  if (isPseudoEntry || enableSpeciesTooltip) {
     return (
       <HoverCard.Root
         key={species.scientificName || index}
@@ -126,7 +119,11 @@ function SpeciesRow({
             collisionPadding={16}
             className="z-[10000]"
           >
-            <SpeciesTooltipContent imageData={tooltipImageData} studyId={studyId} />
+            {isPseudoEntry ? (
+              <PseudoSpeciesTooltipContent entry={pseudoEntry} />
+            ) : (
+              <SpeciesTooltipContent imageData={tooltipImageData} studyId={studyId} />
+            )}
           </HoverCard.Content>
         </HoverCard.Portal>
       </HoverCard.Root>
@@ -145,10 +142,22 @@ function SpeciesDistribution({
   blankCount = 0,
   vehicleCount = 0,
   studyId = null,
-  showHeader = true
+  showHeader = true,
+  hidePseudoSpecies = false
 }) {
-  // Append pseudo-species rows (Blank, Vehicle) when their counts are > 0.
+  // Real-species view of the upstream data — strips out literal pseudo
+  // labels like "Vehicle" or "blurred" that ride along in scientificName.
+  // Used both for the bar-normalization denominator and as the rendered
+  // list when the caller opts out of pseudo rows (Activity tab).
+  const realSpeciesData = useMemo(
+    () => data.filter((d) => !getPseudoSpeciesEntry(d.scientificName)),
+    [data]
+  )
+
+  // Append pseudo-species rows (Blank, Vehicle) when their counts are > 0
+  // and the caller hasn't opted out.
   const displayData = useMemo(() => {
+    if (hidePseudoSpecies) return realSpeciesData
     let result = data
     if (vehicleCount > 0) {
       result = [...result, { scientificName: VEHICLE_SENTINEL, count: vehicleCount }]
@@ -157,14 +166,12 @@ function SpeciesDistribution({
       result = [...result, { scientificName: BLANK_SENTINEL, count: blankCount }]
     }
     return result
-  }, [data, blankCount, vehicleCount])
+  }, [data, realSpeciesData, blankCount, vehicleCount, hidePseudoSpecies])
 
   // Normalize bar widths against species-only counts so the bars match
-  // between the Media and Activity tabs. Media adds pseudo-rows for
-  // Blank/Vehicle which would otherwise inflate the denominator and shrink
-  // the species bars relative to Activity. Pseudo-rows render no bar (see
-  // SpeciesRow), so they don't need to participate in this sum.
-  const totalCount = data.reduce((sum, item) => sum + item.count, 0)
+  // between the Media and Activity tabs. Pseudo rows (Blank/Vehicle/
+  // processing labels) render no bar — they don't participate in this sum.
+  const totalCount = realSpeciesData.reduce((sum, item) => sum + item.count, 0)
 
   // Fetch best image per species for hover tooltips (only when studyId is provided)
   const { data: bestImagesData } = useQuery({
@@ -240,16 +247,17 @@ function SpeciesDistribution({
         <div>
           {(() => {
             const sorted = sortSpeciesHumansLast(displayData)
+            // Pre-resolve pseudo-species entries once per row so we can also
+            // compute the divider position (first pseudo row) in the same pass.
+            const pseudoEntries = sorted.map((s) => getPseudoSpeciesEntry(s.scientificName))
             // Index of the first pseudo-row in the sorted list; used to render a
-            // divider between real species and Blank/Vehicle. Only show the
-            // divider when there's at least one real species above it.
-            const firstPseudoIndex = sorted.findIndex(
-              (s) => isBlank(s.scientificName) || isVehicle(s.scientificName)
-            )
+            // divider between real species and pseudo entries (Blank, Vehicle,
+            // processing labels). Only show the divider when there's at least
+            // one real species above it.
+            const firstPseudoIndex = pseudoEntries.findIndex((e) => e !== null)
             return sorted.map((species, index) => {
-              const isBlankEntry = isBlank(species.scientificName)
-              const isVehicleEntry = isVehicle(species.scientificName)
-              const isPseudo = isBlankEntry || isVehicleEntry
+              const pseudoEntry = pseudoEntries[index]
+              const isPseudo = !!pseudoEntry
               const isFirstPseudo = isPseudo && index === firstPseudoIndex && index > 0
               const storedCommonName = isPseudo
                 ? null
@@ -259,8 +267,7 @@ function SpeciesDistribution({
                   key={species.scientificName || index}
                   species={species}
                   index={index}
-                  isBlankEntry={isBlankEntry}
-                  isVehicleEntry={isVehicleEntry}
+                  pseudoEntry={pseudoEntry}
                   isFirstPseudo={isFirstPseudo}
                   scrollSignal={scrollSignal}
                   storedCommonName={storedCommonName}

--- a/src/shared/pseudoSpecies.js
+++ b/src/shared/pseudoSpecies.js
@@ -1,0 +1,90 @@
+/**
+ * Registry of pseudo-species: rows that show up in the species list but
+ * aren't real biological observations. Two flavors live here:
+ *
+ *   1. Sentinels (Blank, Vehicle) — synthetic scientificName values the
+ *      filter pipeline manufactures so the UI can treat empty media and
+ *      vehicle observations as filterable buckets.
+ *   2. Processing labels (problem, blurred, ignore, misfire, setup_pickup,
+ *      unclassifiable) — strings reviewers attach to frames that aren't
+ *      usable observations (broken camera, blurred image, deliberate skip).
+ *
+ * Both groups render with the same "pseudo" row style: no italic, not
+ * muted, with a hover card describing what the bucket represents.
+ */
+
+import { BLANK_SENTINEL, VEHICLE_SENTINEL } from './constants.js'
+
+const VEHICLE_PSEUDO = {
+  label: 'Vehicle',
+  description:
+    'Cars, trucks, motorbikes, bicycles, and other vehicles that triggered the camera. Useful for measuring human activity captured incidentally on roads or trails.'
+}
+
+const REGISTRY = {
+  [BLANK_SENTINEL]: {
+    label: 'Blank',
+    description:
+      'Captures where no animals were recorded — empty frames triggered by motion, wind, or false detections. These often make up most of a camera-trap dataset.'
+  },
+  // Sentinel + common literal labels datasets use for the vehicle bucket all
+  // share one description. Matching is case-insensitive (see lookup below).
+  [VEHICLE_SENTINEL]: VEHICLE_PSEUDO,
+  vehicle: VEHICLE_PSEUDO,
+  car: VEHICLE_PSEUDO,
+  truck: VEHICLE_PSEUDO,
+  motorcycle: VEHICLE_PSEUDO,
+  bike: VEHICLE_PSEUDO,
+  bicycle: VEHICLE_PSEUDO,
+  problem: {
+    label: 'Problem',
+    description:
+      'Captures marked by reviewers as unusable due to camera malfunction — obstructed lens, broken trigger, or sensor failure.'
+  },
+  blurred: {
+    label: 'Blurred',
+    description:
+      'Captures too unclear to identify — motion blur, fog, condensation, or focus issues make the content unreadable.'
+  },
+  ignore: {
+    label: 'Ignore',
+    description:
+      'Captures a reviewer deliberately skipped — test shots, calibration frames, or other non-data triggers.'
+  },
+  misfire: {
+    label: 'Misfire',
+    description:
+      'False triggers — moving vegetation, falling leaves, shadows, or other non-subject motion that set off the camera.'
+  },
+  setup_pickup: {
+    label: 'Setup / Pickup',
+    description:
+      'Captures taken while installing or retrieving the camera, typically showing the field team or empty scenes.'
+  },
+  unclassifiable: {
+    label: 'Unclassifiable',
+    description:
+      "Captures showing something, but the species can't be determined — too distant, too obscured, or visually ambiguous."
+  }
+}
+
+/**
+ * Look up the pseudo-species entry for a given scientificName.
+ * Sentinels match exactly; processing labels match case-insensitively after trim.
+ * @param {string} scientificName
+ * @returns {{ label: string, description: string } | null}
+ */
+export function getPseudoSpeciesEntry(scientificName) {
+  if (!scientificName || typeof scientificName !== 'string') return null
+  if (REGISTRY[scientificName]) return REGISTRY[scientificName]
+  const normalized = scientificName.trim().toLowerCase()
+  return REGISTRY[normalized] || null
+}
+
+/**
+ * @param {string} scientificName
+ * @returns {boolean}
+ */
+export function isPseudoSpecies(scientificName) {
+  return getPseudoSpeciesEntry(scientificName) !== null
+}


### PR DESCRIPTION
## Summary
- Pseudo rows in the species list (Blank, Vehicle, processing labels like `problem`/`blurred`/`ignore`/`misfire`/`setup_pickup`/`unclassifiable`) now render as straight, non-muted text with a compact hover card describing what the bucket represents.
- Centralized pseudo detection in a new `src/shared/pseudoSpecies.js` registry — also catches literal vehicle labels (`Vehicle`, `car`, `truck`, ...) that real datasets store on the observation, so they fall below the divider like the synthesized sentinel does.
- Bar-width normalization now ignores pseudo rows entirely — a literal "Vehicle" entry can no longer shrink real-species bars.
- Activity tab: hide pseudo entries via a new `hidePseudoSpecies` prop. Media tab keeps showing them.

## Test plan
- [x] Open the **Media** tab on a study that has blank and vehicle media → both rows appear below the divider, no italic / no muted text, hovering shows the explanatory card.
- [x] Hover the processing labels (if present in your study) → also styled as pseudo with their own descriptions.
- [x] On the **Seattle(ish) camera traps** study, confirm the literal "Vehicle" row sits below the divider (previously above).
- [x] Open the **Activity** tab → no pseudo entries appear in the species list at all.
- [x] Verify species bar widths on Media still match Activity for the same real species.