### PR TITLE
fix(species-distribution): clarify selected row and avoid italic clip

### DIFF
--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -63,9 +63,11 @@ function SpeciesRow({
 
   const rowContent = (
     <div
-      className={`cursor-pointer group hover:bg-blue-50 transition-colors py-2 -mx-3 px-3 first:pt-3 last:pb-3 dark:hover:bg-blue-500/15 ${
-        isFirstPseudo ? 'border-t border-border mt-1 pt-3' : ''
-      }`}
+      className={`cursor-pointer group transition-colors py-2 -mx-3 px-3 first:pt-3 last:pb-3 ${
+        isSelected
+          ? 'bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+          : 'hover:bg-blue-50 dark:hover:bg-blue-500/15'
+      } ${isFirstPseudo ? 'border-t border-border mt-1 pt-3' : ''}`}
       onClick={() => onToggle(species)}
     >
       <div className="flex justify-between mb-1 items-center cursor-pointer gap-2">
@@ -75,7 +77,7 @@ function SpeciesRow({
             style={{ backgroundColor: isSelected ? color : null }}
           ></div>
           <span
-            className={`text-sm truncate ${
+            className={`text-sm truncate pr-1 ${
               isPseudoEntry
                 ? 'text-muted-foreground italic'
                 : showScientificInItalic


### PR DESCRIPTION
## Summary
- Selected species rows now carry a persistent blue tint (matching the existing hover palette); hover deepens it. Makes the active selection obvious at a glance instead of relying on the 2px dot alone.
- Added `pr-1` inside the truncating label so trailing italic glyphs aren't clipped by `overflow: hidden` on long scientific names.

Applies to both the Media and Activity tabs (shared `SpeciesDistribution` component).

## Test plan
- [x] Media tab: select / deselect species, confirm selected rows show a blue background in both light and dark modes
- [x] Activity tab: same as above
- [x] Verify long binomials no longer clip the trailing italic letter
- [x] Verify hover state still works on unselected rows and deepens on selected rows