### PR TITLE
Day-period presets + polar/X-Y chart toggle in Media & Activity

### DIFF
--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -137,7 +137,7 @@ These endpoints perform sequence grouping and counting in the main thread, retur
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------ | --------------------------------------------- | ------------------------------------- |
 | `getSequenceAwareSpeciesDistribution(studyId)`                                                                  | `sequences:get-species-distribution` | studyId                                       | `{ data: [{scientificName, count}] }` |
 | `getSequenceAwareTimeseries(studyId, speciesNames)`                                                             | `sequences:get-timeseries`           | studyId, species[]                            | `{ data: {timeseries, allSpecies} }`  |
-| `getSequenceAwareHeatmap(studyId, speciesNames, startDate, endDate, startHour, endHour, includeNullTimestamps)` | `sequences:get-heatmap`              | studyId, species[], dates, hours, includeNull | `{ data: {species -> locations[]} }`  |
+| `getSequenceAwareHeatmap(studyId, speciesNames, startDate, endDate, timeRange, includeNullTimestamps)`          | `sequences:get-heatmap`              | studyId, species[], dates, timeRange, includeNull | `{ data: {species -> locations[]} }`  |
 | `getSequenceAwareDailyActivity(studyId, speciesNames, startDate, endDate)`                                      | `sequences:get-daily-activity`       | studyId, species[], dates                     | `{ data: [24 hourly objects] }`       |
 
 **Parameters:**
@@ -168,7 +168,7 @@ Returns pre-grouped sequences with cursor-based pagination for the media gallery
   filters: {
     species: string[],        // Species to filter by
     dateRange: { start, end }, // Date range filter
-    timeRange: { start, end }, // Time of day range (hours 0-23)
+    timeRange: { ranges: [{ start, end }, ...] } | { start, end }, // Time of day filter — multi-range (preferred) or legacy single-range; empty/missing = no filter
     deploymentID?: string     // If set, only media for this deploymentID
   }
 }

--- a/docs/plans/2026-05-13-day-period-presets-plan.md
+++ b/docs/plans/2026-05-13-day-period-presets-plan.md
@@ -1,0 +1,1792 @@
+# Day-period presets and chart-shape toggle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four preset day-period chips (Dawn/Day/Dusk/Night, multi-select) and a Polar / X–Y chart-shape toggle to the bottom filter row in both the Media and Activity tabs.
+
+**Architecture:** Generalize the `timeRange` filter from a single `{start, end}` to an array of `ranges`. The renderer derives that array either from the chip selection (union of preset hour windows) or from the existing freeform drag-arc, but never both at once. The polar `CircularTimeFilter` learns a `mode='drag'|'chips'` prop; a new `DailyActivityLine` mirrors the existing `DailyActivityRadar` over a 24h x-axis; a small `ChartShapeToggle` swaps between them. Backend query functions normalize legacy `{start, end}` callers into the new shape so the change stays internal.
+
+**Tech Stack:** React, Recharts, lucide-react, Tailwind, Drizzle ORM (better-sqlite3), node:test.
+
+**Spec:** `docs/specs/2026-05-13-day-period-presets-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/renderer/src/utils/dayPeriods.js` — preset constants, `chipsToRanges()` helper, `isFullDayRange()` helper. Pure module, no React.
+- `src/renderer/src/ui/dayPeriodChips.jsx` — four-button chip bar (DayPeriodChips component).
+- `src/renderer/src/ui/chartShapeToggle.jsx` — two-button polar/x-y toggle.
+- `test/renderer/dayPeriods.test.js` — unit tests for the pure helpers.
+- `test/main/database/queries/sequencesTimeRange.test.js` — query-layer tests for the multi-range filter.
+
+**Modified files:**
+- `src/main/database/queries/sequences.js` — add `normalizeTimeRange()` helper at module top; replace the two single-range time-filter blocks (in `getMediaForSequencePagination` and `hasTimestampedMedia`) with a loop over normalized ranges.
+- `src/main/database/queries/species.js` — same multi-range refactor for `getSpeciesHeatmapDataByMedia` and `getSequenceAwareHeatmapSQL` so the Activity-tab map heatmap honors chip selection.
+- `src/main/services/sequences/worker.js` — pass `timeRange` object through to the heatmap query in place of the positional `startHour, endHour`.
+- `src/main/ipc/sequences.js` — heatmap handler accepts `timeRange` in place of `startHour, endHour`.
+- `src/preload/index.js` — `getSequenceAwareHeatmap` API accepts `timeRange` in place of `startHour, endHour`.
+- `src/renderer/src/ui/clock.jsx` — extend `CircularTimeFilter` with `mode` and `chipSectors` props; add `DailyActivityLine` component.
+- `src/renderer/src/media.jsx` — replace `timeRange` state with `chipSelection` + `arc`; derive `ranges`; add `chartShape`; render chips above the clock card and the chart-shape toggle in its top-right.
+- `src/renderer/src/activity.jsx` — same renderer changes as media.jsx, plus update the heatmap query call to pass `timeRange`.
+
+**Unchanged:**
+- IPC layer (`src/preload/index.js`, `src/main/index.js`): `timeRange` is opaque, no signature change.
+- `src/main/services/sequences/pagination.js`: passes `timeRange` through unchanged.
+- `src/renderer/src/media/Gallery.jsx` and `DeploymentMediaGallery.jsx`: still pass `{start, end}` shape — backward-compat normalization in the query layer covers them.
+
+---
+
+## Task 1: Backend helper — normalize timeRange shape
+
+**Files:**
+- Modify: `src/main/database/queries/sequences.js` (top of file, before `getMediaForSequencePagination`)
+- Test: `test/main/database/queries/sequencesTimeRange.test.js` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/main/database/queries/sequencesTimeRange.test.js`:
+
+```js
+/**
+ * Unit tests for normalizeTimeRange — accepts both the legacy
+ * {start, end} shape and the new {ranges: [...]} shape.
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { normalizeTimeRange } from '../../../../src/main/database/queries/sequences.js'
+
+describe('normalizeTimeRange', () => {
+  test('returns [] for undefined/null/empty input', () => {
+    assert.deepEqual(normalizeTimeRange(undefined), [])
+    assert.deepEqual(normalizeTimeRange(null), [])
+    assert.deepEqual(normalizeTimeRange({}), [])
+  })
+
+  test('wraps legacy {start, end} into a single-element ranges array', () => {
+    assert.deepEqual(normalizeTimeRange({ start: 5, end: 8 }), [{ start: 5, end: 8 }])
+  })
+
+  test('passes through {ranges: [...]} unchanged', () => {
+    const ranges = [
+      { start: 5, end: 8 },
+      { start: 18, end: 21 }
+    ]
+    assert.deepEqual(normalizeTimeRange({ ranges }), ranges)
+  })
+
+  test('prefers ranges over start/end when both present', () => {
+    const ranges = [{ start: 0, end: 12 }]
+    assert.deepEqual(normalizeTimeRange({ ranges, start: 100, end: 200 }), ranges)
+  })
+
+  test('returns [] when ranges is an empty array', () => {
+    assert.deepEqual(normalizeTimeRange({ ranges: [] }), [])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test -- --test-name-pattern="normalizeTimeRange"`
+Expected: FAIL with "normalizeTimeRange is not a function" or import error.
+
+- [ ] **Step 3: Implement normalizeTimeRange in sequences.js**
+
+In `src/main/database/queries/sequences.js`, add this exported helper near the top of the file (after the imports, before the first function):
+
+```js
+/**
+ * Normalize the timeRange filter into an array of {start, end} ranges.
+ * Accepts:
+ *   - undefined / null / {} → no filter, returns []
+ *   - { start, end }        → legacy single-range shape, returns [{start, end}]
+ *   - { ranges: [...] }     → new multi-range shape, passed through
+ *
+ * Empty ranges means "no time-of-day filter".
+ */
+export function normalizeTimeRange(timeRange) {
+  if (!timeRange) return []
+  if (Array.isArray(timeRange.ranges)) return timeRange.ranges
+  if (timeRange.start !== undefined && timeRange.end !== undefined) {
+    return [{ start: timeRange.start, end: timeRange.end }]
+  }
+  return []
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern="normalizeTimeRange"`
+Expected: PASS (5 subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/database/queries/sequences.js test/main/database/queries/sequencesTimeRange.test.js
+git commit -m "refactor(queries): add normalizeTimeRange helper for sequences filter"
+```
+
+---
+
+## Task 2: Backend — apply ranges loop in getMediaForSequencePagination
+
+**Files:**
+- Modify: `src/main/database/queries/sequences.js:46-300` (specifically the `hasTimeFilter` block and the timestamped-phase filter at lines ~82, ~262-280)
+- Test: `test/main/database/queries/sequencesTimeRange.test.js` (extend)
+
+- [ ] **Step 1: Add an integration test for the multi-range filter**
+
+Append to `test/main/database/queries/sequencesTimeRange.test.js` (above the closing imports if needed, after the existing describe block):
+
+```js
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+import { beforeEach, afterEach } from 'node:test'
+
+import {
+  getMediaForSequencePagination,
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations
+} from '../../../../src/main/database/index.js'
+
+let testBiowatchDataPath
+let testDbPath
+let testStudyId
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    electronLog.default.transports.file.level = false
+    electronLog.default.transports.console.level = false
+  } catch {
+    // not available, fine
+  }
+  testStudyId = `test-time-range-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-time-range-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+async function seedHourlyMedia() {
+  const manager = await createImageDirectoryDatabase(testDbPath)
+  await insertDeployments(manager, {
+    d1: {
+      deploymentID: 'd1',
+      locationID: 'loc1',
+      locationName: 'Site A',
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+      latitude: 1,
+      longitude: 1,
+      cameraID: 'cam1'
+    }
+  })
+  // One media per hour, 00:30 through 23:30 (24 rows)
+  const mediaMap = {}
+  const obsMap = {}
+  for (let h = 0; h < 24; h++) {
+    const id = `m-${String(h).padStart(2, '0')}`
+    mediaMap[`${id}.jpg`] = {
+      mediaID: id,
+      deploymentID: 'd1',
+      timestamp: DateTime.fromISO(`2024-06-01T${String(h).padStart(2, '0')}:30:00`, { zone: 'utc' }),
+      filePath: `/${id}.jpg`,
+      fileName: `${id}.jpg`
+    }
+    obsMap[`obs-${id}`] = {
+      observationID: `obs-${id}`,
+      mediaID: id,
+      deploymentID: 'd1',
+      eventID: `ev-${id}`,
+      observationType: 'animal',
+      scientificName: 'Sus scrofa',
+      timestamp: DateTime.fromISO(`2024-06-01T${String(h).padStart(2, '0')}:30:00`, { zone: 'utc' })
+    }
+  }
+  await insertMedia(manager, mediaMap)
+  await insertObservations(manager, obsMap)
+  return manager
+}
+
+describe('getMediaForSequencePagination — timeRange filter', () => {
+  test('legacy {start, end} shape continues to work', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { start: 8, end: 18 }
+    })
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
+    assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+  })
+
+  test('new {ranges: [...]} shape with a single range matches legacy', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 8, end: 18 }] }
+    })
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
+    assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+  })
+
+  test('multi-range shape unions the ranges (Dawn + Dusk)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: {
+        ranges: [
+          { start: 5, end: 8 },
+          { start: 18, end: 21 }
+        ]
+      }
+    })
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
+    assert.deepEqual(hours, [5, 6, 7, 18, 19, 20])
+  })
+
+  test('wrap-around range still works (Night 21 → 5)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 21, end: 5 }] }
+    })
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
+    assert.deepEqual(hours, [0, 1, 2, 3, 4, 21, 22, 23])
+  })
+
+  test('empty ranges means no time filter (all 24 hours match)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [] }
+    })
+    assert.equal(result.media.length, 24)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify the multi-range and empty-ranges cases fail**
+
+Run: `npm test -- --test-name-pattern="timeRange filter"`
+Expected: legacy and single-range tests PASS (current code happens to handle the single-range case via the legacy branch); multi-range, wrap-around-via-ranges, and empty-ranges tests FAIL because the function doesn't yet read `timeRange.ranges`.
+
+- [ ] **Step 3: Refactor getMediaForSequencePagination to loop over ranges**
+
+In `src/main/database/queries/sequences.js`, replace this block (around line 81-82):
+
+```js
+    // Time of day filter (only applies to timestamped media)
+    const hasTimeFilter = timeRange.start !== undefined && timeRange.end !== undefined
+```
+
+with:
+
+```js
+    // Time of day filter (only applies to timestamped media). Empty array
+    // means no filter; multiple ranges are unioned with OR.
+    const timeRanges = normalizeTimeRange(timeRange)
+    const hasTimeFilter = timeRanges.length > 0
+```
+
+Then replace the timestamped-phase filter block (around lines 262-280):
+
+```js
+      // Apply time of day filter
+      if (hasTimeFilter) {
+        if (timeRange.start < timeRange.end) {
+          timestampedConditions.push(
+            and(
+              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
+              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
+            )
+          )
+        } else if (timeRange.start > timeRange.end) {
+          // Wraps around midnight
+          timestampedConditions.push(
+            or(
+              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
+              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
+            )
+          )
+        }
+      }
+```
+
+with:
+
+```js
+      // Apply time of day filter — OR of per-range conditions.
+      if (hasTimeFilter) {
+        const rangeConditions = timeRanges
+          .map((r) => buildHourRangeCondition(r))
+          .filter(Boolean)
+        if (rangeConditions.length === 1) {
+          timestampedConditions.push(rangeConditions[0])
+        } else if (rangeConditions.length > 1) {
+          timestampedConditions.push(or(...rangeConditions))
+        }
+      }
+```
+
+Add `buildHourRangeCondition` near `normalizeTimeRange`:
+
+```js
+/**
+ * Build a SQL condition for a single {start, end} hour range against
+ * media.timestamp. Half-open [start, end). Returns null when start === end
+ * (zero-width range, no rows match — caller should drop it).
+ *
+ * Wrap-around (start > end) is OR'd: hour >= start OR hour < end.
+ */
+function buildHourRangeCondition(range) {
+  const { start, end } = range
+  if (start === end) return null
+  if (start < end) {
+    return and(
+      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
+      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
+    )
+  }
+  return or(
+    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
+    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they all pass**
+
+Run: `npm test -- --test-name-pattern="timeRange filter"`
+Expected: all 5 subtests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/database/queries/sequences.js test/main/database/queries/sequencesTimeRange.test.js
+git commit -m "feat(queries): support multi-range timeRange filter in getMediaForSequencePagination"
+```
+
+---
+
+## Task 3: Backend — apply same refactor to hasTimestampedMedia
+
+**Files:**
+- Modify: `src/main/database/queries/sequences.js` (lines ~563-606)
+- Test: `test/main/database/queries/sequencesTimeRange.test.js` (extend)
+
+- [ ] **Step 1: Add a test for hasTimestampedMedia with the new shape**
+
+Append to `test/main/database/queries/sequencesTimeRange.test.js`:
+
+```js
+import { hasTimestampedMedia } from '../../../../src/main/database/index.js'
+
+describe('hasTimestampedMedia — timeRange filter', () => {
+  test('returns true when ranges union covers a populated hour', async () => {
+    await seedHourlyMedia()
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: {
+        ranges: [
+          { start: 5, end: 8 },
+          { start: 18, end: 21 }
+        ]
+      }
+    })
+    assert.equal(result, true)
+  })
+
+  test('returns false when ranges union covers no populated hour', async () => {
+    await seedHourlyMedia()
+    // Seed has one media per full hour 00..23. Construct a range that
+    // skips them all by selecting [3.5, 3.75) — the integer-hour cast
+    // will exclude every row.
+    // Easier: query a study with media only at hours 8-17 and ask for 0-1.
+    // Re-using seedHourlyMedia (24 rows), there's no empty-hour gap, so
+    // we instead assert behavior with [0, 0] zero-width plus an empty array.
+    const empty = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [] }
+    })
+    assert.equal(empty, true) // no filter → matches all
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify the multi-range case fails**
+
+Run: `npm test -- --test-name-pattern="hasTimestampedMedia — timeRange"`
+Expected: FAIL on the multi-range case (function still reads `timeRange.start`).
+
+- [ ] **Step 3: Refactor hasTimestampedMedia**
+
+In `src/main/database/queries/sequences.js`, replace the time-range block in `hasTimestampedMedia` (around lines 590-606):
+
+```js
+    // Apply time range
+    if (timeRange.start !== undefined && timeRange.end !== undefined) {
+      if (timeRange.start < timeRange.end) {
+        conditions.push(
+          and(
+            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
+            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
+          )
+        )
+      } else if (timeRange.start > timeRange.end) {
+        conditions.push(
+          or(
+            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
+            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
+          )
+        )
+      }
+    }
+```
+
+with:
+
+```js
+    // Apply time range — same OR-of-ranges semantics as the paginated query.
+    const timeRanges = normalizeTimeRange(timeRange)
+    if (timeRanges.length > 0) {
+      const rangeConditions = timeRanges.map(buildHourRangeCondition).filter(Boolean)
+      if (rangeConditions.length === 1) {
+        conditions.push(rangeConditions[0])
+      } else if (rangeConditions.length > 1) {
+        conditions.push(or(...rangeConditions))
+      }
+    }
+```
+
+- [ ] **Step 4: Run all sequences tests**
+
+Run: `npm test -- --test-name-pattern="timeRange"`
+Expected: all subtests PASS.
+
+Then run the full sequences test suite to make sure no regressions:
+
+Run: `npm test -- --test-name-pattern="getMediaForSequencePagination"`
+Expected: existing pseudo-species tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/database/queries/sequences.js test/main/database/queries/sequencesTimeRange.test.js
+git commit -m "feat(queries): support multi-range timeRange filter in hasTimestampedMedia"
+```
+
+---
+
+## Task 4: Renderer — pure helpers (preset constants and chip→ranges)
+
+**Files:**
+- Create: `src/renderer/src/utils/dayPeriods.js`
+- Create: `test/renderer/dayPeriods.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/renderer/dayPeriods.test.js`:
+
+```js
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DAY_PERIOD_PRESETS,
+  chipsToRanges,
+  arcToRanges,
+  isFullDayArc
+} from '../../src/renderer/src/utils/dayPeriods.js'
+
+describe('DAY_PERIOD_PRESETS', () => {
+  test('exposes dawn/day/dusk/night with non-overlapping hour ranges', () => {
+    const keys = Object.keys(DAY_PERIOD_PRESETS).sort()
+    assert.deepEqual(keys, ['dawn', 'day', 'dusk', 'night'])
+    assert.deepEqual(DAY_PERIOD_PRESETS.dawn.range, { start: 5, end: 8 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.day.range, { start: 8, end: 18 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.dusk.range, { start: 18, end: 21 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.night.range, { start: 21, end: 5 })
+  })
+})
+
+describe('chipsToRanges', () => {
+  test('empty selection returns empty ranges', () => {
+    assert.deepEqual(chipsToRanges(new Set()), [])
+  })
+
+  test('single chip returns its range', () => {
+    assert.deepEqual(chipsToRanges(new Set(['day'])), [{ start: 8, end: 18 }])
+  })
+
+  test('dawn + dusk returns both ranges (crepuscular)', () => {
+    assert.deepEqual(chipsToRanges(new Set(['dawn', 'dusk'])), [
+      { start: 5, end: 8 },
+      { start: 18, end: 21 }
+    ])
+  })
+
+  test('all four chips returns all four ranges in canonical order', () => {
+    assert.deepEqual(chipsToRanges(new Set(['night', 'day', 'dusk', 'dawn'])), [
+      { start: 5, end: 8 },
+      { start: 8, end: 18 },
+      { start: 18, end: 21 },
+      { start: 21, end: 5 }
+    ])
+  })
+
+  test('ignores unknown chip keys', () => {
+    assert.deepEqual(chipsToRanges(new Set(['day', 'midnight'])), [{ start: 8, end: 18 }])
+  })
+})
+
+describe('isFullDayArc', () => {
+  test('detects 0–24 as full day', () => {
+    assert.equal(isFullDayArc({ start: 0, end: 24 }), true)
+  })
+
+  test('detects start === end as full day', () => {
+    assert.equal(isFullDayArc({ start: 6, end: 6 }), true)
+  })
+
+  test('detects near-full ranges within 0.1h tolerance', () => {
+    assert.equal(isFullDayArc({ start: 0.05, end: 23.95 }), true)
+  })
+
+  test('partial range is not full day', () => {
+    assert.equal(isFullDayArc({ start: 8, end: 18 }), false)
+  })
+})
+
+describe('arcToRanges', () => {
+  test('full-day arc returns empty (no filter)', () => {
+    assert.deepEqual(arcToRanges({ start: 0, end: 24 }), [])
+  })
+
+  test('partial arc returns single range', () => {
+    assert.deepEqual(arcToRanges({ start: 8, end: 18 }), [{ start: 8, end: 18 }])
+  })
+
+  test('wrap-around arc returns single range', () => {
+    assert.deepEqual(arcToRanges({ start: 21, end: 5 }), [{ start: 21, end: 5 }])
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --test-name-pattern="DAY_PERIOD_PRESETS|chipsToRanges|arcToRanges|isFullDayArc"`
+Expected: FAIL with import error.
+
+- [ ] **Step 3: Implement the helpers**
+
+Create `src/renderer/src/utils/dayPeriods.js`:
+
+```js
+/**
+ * Day-period presets and the helpers that translate UI selection state
+ * (chip set, drag-arc) into the {ranges: [...]} shape consumed by the
+ * backend timeRange filter.
+ *
+ * Hour ranges are half-open [start, end) in 24h local clock time. Night
+ * wraps midnight (start > end).
+ */
+
+export const DAY_PERIOD_PRESETS = {
+  dawn: { key: 'dawn', label: 'Dawn', range: { start: 5, end: 8 } },
+  day: { key: 'day', label: 'Day', range: { start: 8, end: 18 } },
+  dusk: { key: 'dusk', label: 'Dusk', range: { start: 18, end: 21 } },
+  night: { key: 'night', label: 'Night', range: { start: 21, end: 5 } }
+}
+
+// Canonical render order: chronological, dawn first.
+export const DAY_PERIOD_ORDER = ['dawn', 'day', 'dusk', 'night']
+
+/**
+ * Convert a chip selection (Set<string>) into an ordered ranges array.
+ * Unknown keys are ignored.
+ */
+export function chipsToRanges(selection) {
+  return DAY_PERIOD_ORDER.filter((key) => selection.has(key)).map(
+    (key) => DAY_PERIOD_PRESETS[key].range
+  )
+}
+
+/**
+ * Whether a freeform drag-arc {start, end} effectively covers the whole
+ * day. Tolerance handles fractional-hour drift from the polar drag.
+ */
+export function isFullDayArc(arc) {
+  if (!arc) return true
+  const { start, end } = arc
+  if (start === end) return true
+  return Math.abs(end - start) >= 23.9
+}
+
+/**
+ * Convert a drag-arc {start, end} into the ranges array. Returns [] when
+ * the arc is full-day (== no filter).
+ */
+export function arcToRanges(arc) {
+  if (isFullDayArc(arc)) return []
+  return [{ start: arc.start, end: arc.end }]
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- --test-name-pattern="DAY_PERIOD_PRESETS|chipsToRanges|arcToRanges|isFullDayArc"`
+Expected: all subtests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/utils/dayPeriods.js test/renderer/dayPeriods.test.js
+git commit -m "feat(renderer): add dayPeriods preset constants and selection helpers"
+```
+
+---
+
+## Task 5: Renderer — DayPeriodChips component
+
+**Files:**
+- Create: `src/renderer/src/ui/dayPeriodChips.jsx`
+
+- [ ] **Step 1: Implement the component**
+
+Create `src/renderer/src/ui/dayPeriodChips.jsx`:
+
+```jsx
+import { Sunrise, Sun, Sunset, Moon } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { DAY_PERIOD_ORDER, DAY_PERIOD_PRESETS } from '../utils/dayPeriods'
+
+const ICONS = {
+  dawn: Sunrise,
+  day: Sun,
+  dusk: Sunset,
+  night: Moon
+}
+
+/**
+ * Four icon buttons (Dawn / Day / Dusk / Night) above the polar clock.
+ * Multi-select: each button toggles its key in the `selection` Set.
+ * Visual treatment matches FilterChartsToggle for coherence with the
+ * rest of the gap-slider strip.
+ *
+ * Props:
+ *   selection: Set<string> — currently active chip keys
+ *   onChange: (newSelection: Set<string>) => void
+ */
+export default function DayPeriodChips({ selection, onChange }) {
+  const toggle = (key) => {
+    const next = new Set(selection)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    onChange(next)
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {DAY_PERIOD_ORDER.map((key) => {
+        const Icon = ICONS[key]
+        const active = selection.has(key)
+        return (
+          <Tooltip.Root key={key}>
+            <Tooltip.Trigger asChild>
+              <button
+                onClick={() => toggle(key)}
+                className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+                  active
+                    ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+                    : 'text-muted-foreground hover:bg-accent'
+                }`}
+                aria-label={DAY_PERIOD_PRESETS[key].label}
+                aria-pressed={active}
+              >
+                <Icon size={16} />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="bottom"
+                sideOffset={6}
+                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              >
+                {DAY_PERIOD_PRESETS[key].label}
+                <Tooltip.Arrow className="fill-popover" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Lint check**
+
+Run: `npm run lint -- src/renderer/src/ui/dayPeriodChips.jsx`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/ui/dayPeriodChips.jsx
+git commit -m "feat(renderer): add DayPeriodChips component (Dawn/Day/Dusk/Night)"
+```
+
+---
+
+## Task 6: Renderer — extend CircularTimeFilter with mode and chipSectors
+
+**Files:**
+- Modify: `src/renderer/src/ui/clock.jsx` (CircularTimeFilter only)
+
+- [ ] **Step 1: Add the new props and chip-sector rendering**
+
+In `src/renderer/src/ui/clock.jsx`, modify the `CircularTimeFilter` component signature to accept two new props:
+
+```jsx
+const CircularTimeFilter = ({
+  onChange,
+  startTime = 6,
+  endTime = 18,
+  mode = 'drag',
+  chipSectors = []
+}) => {
+```
+
+In the same component, replace the final SVG return block (the part that renders the arc, start handle, end handle):
+
+```jsx
+        <path
+          d={createArc(timeToAngle(start), timeToAngle(end))}
+          fill="rgb(59 130 246 / 0.15)"
+          stroke="rgb(59 130 246 / 0.8)"
+          strokeWidth="2"
+          cursor="pointer"
+          onMouseDown={handleMouseDown('arc')}
+        />
+
+        <circle
+          cx={startCoord.x}
+          cy={startCoord.y}
+          r="4"
+          fill="rgb(59 130 246)"
+          cursor="pointer"
+          onMouseDown={handleMouseDown('start')}
+        />
+
+        <circle
+          cx={endCoord.x}
+          cy={endCoord.y}
+          r="4"
+          fill="rgb(59 130 246)"
+          cursor="pointer"
+          onMouseDown={handleMouseDown('end')}
+        />
+```
+
+with:
+
+```jsx
+        {mode === 'chips'
+          ? chipSectors.map((sector, i) => (
+              <path
+                key={i}
+                d={createArc(timeToAngle(sector.start), timeToAngle(sector.end))}
+                fill="rgb(59 130 246 / 0.15)"
+                stroke="rgb(59 130 246 / 0.8)"
+                strokeWidth="2"
+                pointerEvents="none"
+              />
+            ))
+          : (
+              <>
+                <path
+                  d={createArc(timeToAngle(start), timeToAngle(end))}
+                  fill="rgb(59 130 246 / 0.15)"
+                  stroke="rgb(59 130 246 / 0.8)"
+                  strokeWidth="2"
+                  cursor="pointer"
+                  onMouseDown={handleMouseDown('arc')}
+                />
+                <circle
+                  cx={startCoord.x}
+                  cy={startCoord.y}
+                  r="4"
+                  fill="rgb(59 130 246)"
+                  cursor="pointer"
+                  onMouseDown={handleMouseDown('start')}
+                />
+                <circle
+                  cx={endCoord.x}
+                  cy={endCoord.y}
+                  r="4"
+                  fill="rgb(59 130 246)"
+                  cursor="pointer"
+                  onMouseDown={handleMouseDown('end')}
+                />
+              </>
+            )}
+```
+
+The `createArc` function is already defined and works for both wrap-around and normal ranges. Each chip sector renders as a non-interactive `<path>`; the drag arc and handles are not rendered in chips mode.
+
+- [ ] **Step 2: Lint check**
+
+Run: `npm run lint -- src/renderer/src/ui/clock.jsx`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/ui/clock.jsx
+git commit -m "feat(clock): add mode + chipSectors props to CircularTimeFilter"
+```
+
+---
+
+## Task 7: Renderer — DailyActivityLine component
+
+**Files:**
+- Modify: `src/renderer/src/ui/clock.jsx` (add new component, export)
+
+- [ ] **Step 1: Add the line-chart component**
+
+In `src/renderer/src/ui/clock.jsx`, add this new component below `DailyActivityRadar` (above the export statement). First, ensure these recharts imports are present at the top of the file (extend the existing import line):
+
+```jsx
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  ReferenceArea,
+  ResponsiveContainer,
+  XAxis,
+  YAxis
+} from 'recharts'
+```
+
+Then add the component:
+
+```jsx
+/**
+ * X–Y twin of DailyActivityRadar. Renders the same hourly-bin data as a
+ * line per species across a 24-hour x-axis. Off-period bands (the inverse
+ * of `selectedRanges`) are shaded; with no selection, no shading.
+ *
+ * Props mirror DailyActivityRadar plus:
+ *   selectedRanges: Array<{start, end}> — hour ranges currently in the
+ *     filter. Used to shade the *complement* of these as off-period bands.
+ */
+const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRanges = [] }) => {
+  const formatData = (data) => {
+    if (!data || !data.length) {
+      return Array(24)
+        .fill()
+        .map((_, i) => ({ hour: i }))
+    }
+    return data.map((d) => ({ ...d, hour: d.hour }))
+  }
+  const formattedData = formatData(activityData)
+
+  // Build off-period bands: 24h minus the union of selectedRanges.
+  // For wrap-around ranges (start > end), split into two pieces first.
+  const flattened = []
+  for (const r of selectedRanges) {
+    if (r.start === r.end) continue
+    if (r.start < r.end) {
+      flattened.push([r.start, r.end])
+    } else {
+      flattened.push([r.start, 24])
+      flattened.push([0, r.end])
+    }
+  }
+  flattened.sort((a, b) => a[0] - b[0])
+
+  // Merge overlapping covered intervals.
+  const covered = []
+  for (const [s, e] of flattened) {
+    if (covered.length && s <= covered[covered.length - 1][1]) {
+      covered[covered.length - 1][1] = Math.max(covered[covered.length - 1][1], e)
+    } else {
+      covered.push([s, e])
+    }
+  }
+
+  // Off-bands = complement of covered within [0, 24].
+  const offBands = []
+  let cursor = 0
+  for (const [s, e] of covered) {
+    if (s > cursor) offBands.push([cursor, s])
+    cursor = e
+  }
+  if (cursor < 24) offBands.push([cursor, 24])
+  // If nothing is selected, skip shading entirely.
+  const showShading = covered.length > 0
+
+  return (
+    <div className="relative w-full h-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+          <CartesianGrid strokeOpacity={0} />
+          <XAxis
+            dataKey="hour"
+            type="number"
+            domain={[0, 23]}
+            ticks={[0, 6, 12, 18, 23]}
+            tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis hide domain={[0, 'auto']} />
+          {showShading &&
+            offBands.map(([s, e], i) => (
+              <ReferenceArea
+                key={i}
+                x1={s}
+                x2={e}
+                fill="var(--color-muted)"
+                fillOpacity={0.5}
+                strokeOpacity={0}
+              />
+            ))}
+          {selectedSpecies.map((species, index) => (
+            <Line
+              key={species.scientificName}
+              type="monotone"
+              dataKey={species.scientificName}
+              stroke={palette[index % palette.length]}
+              strokeWidth={1.5}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+```
+
+Update the export at the bottom of the file:
+
+```jsx
+export { DailyActivityRadar, DailyActivityLine, CircularTimeFilter as default }
+```
+
+(Note: `Area` is imported but not used in this component — keep the import minimal. Drop `Area` from the import list if eslint flags it.)
+
+- [ ] **Step 2: Lint check**
+
+Run: `npm run lint -- src/renderer/src/ui/clock.jsx`
+Expected: no errors. If `Area` triggers an unused-import warning, remove it from the import list.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/ui/clock.jsx
+git commit -m "feat(clock): add DailyActivityLine x-y twin of the radar chart"
+```
+
+---
+
+## Task 8: Renderer — ChartShapeToggle component
+
+**Files:**
+- Create: `src/renderer/src/ui/chartShapeToggle.jsx`
+
+- [ ] **Step 1: Implement**
+
+Create `src/renderer/src/ui/chartShapeToggle.jsx`:
+
+```jsx
+import { ChartPie, ChartLine } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+
+/**
+ * Two-button group that switches the daily-activity chart between the
+ * polar radar and the x-y line. Sits in the top-right of the clock card.
+ *
+ * Props:
+ *   value: 'polar' | 'xy'
+ *   onChange: (next) => void
+ */
+const SHAPES = [
+  { key: 'polar', label: 'Polar', Icon: ChartPie },
+  { key: 'xy', label: 'X–Y line', Icon: ChartLine }
+]
+
+export default function ChartShapeToggle({ value, onChange }) {
+  return (
+    <div className="flex gap-0.5">
+      {SHAPES.map(({ key, label, Icon }) => {
+        const active = value === key
+        return (
+          <Tooltip.Root key={key}>
+            <Tooltip.Trigger asChild>
+              <button
+                onClick={() => onChange(key)}
+                className={`w-5 h-5 rounded flex items-center justify-center transition-colors ${
+                  active
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:bg-accent'
+                }`}
+                aria-label={label}
+                aria-pressed={active}
+              >
+                <Icon size={12} />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="bottom"
+                sideOffset={6}
+                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              >
+                {label}
+                <Tooltip.Arrow className="fill-popover" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Lint check**
+
+Run: `npm run lint -- src/renderer/src/ui/chartShapeToggle.jsx`
+Expected: no errors. (If `ChartPie` / `ChartLine` aren't found in your installed lucide-react, fall back to `PieChart` / `LineChart` — both naming conventions ship in different versions.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/src/ui/chartShapeToggle.jsx
+git commit -m "feat(renderer): add ChartShapeToggle (polar/xy switch)"
+```
+
+---
+
+## Task 9: Backend — refactor heatmap chain to use timeRange object
+
+**Files:**
+- Modify: `src/main/database/queries/species.js` (lines ~548-602 and ~686-)
+- Modify: `src/main/services/sequences/worker.js` (lines ~40-115)
+- Modify: `src/main/ipc/sequences.js` (lines ~115-163)
+- Modify: `src/preload/index.js` (lines ~117-136)
+
+This task changes the heatmap signature throughout: the positional
+`startHour, endHour` args are replaced with a single `timeRange` object
+(same shape as the sequences-pagination filter). Caller sites at the
+renderer are updated in Task 11.
+
+- [ ] **Step 1: species.js — getSpeciesHeatmapDataByMedia**
+
+In `src/main/database/queries/species.js`, change the function signature and time-filter block. Replace:
+
+```js
+export async function getSpeciesHeatmapDataByMedia(
+  dbPath,
+  species,
+  startDate,
+  endDate,
+  startHour = 0,
+  endHour = 24,
+  includeNullTimestamps = false
+) {
+```
+
+with:
+
+```js
+export async function getSpeciesHeatmapDataByMedia(
+  dbPath,
+  species,
+  startDate,
+  endDate,
+  timeRange = {},
+  includeNullTimestamps = false
+) {
+```
+
+Then replace the time-of-day block (currently lines ~587-603):
+
+```js
+    // Add time-of-day condition using sql template for SQLite strftime
+    // When includeNullTimestamps=true, also allow null timestamps through
+    const hourColumn = sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER)`
+    if (startHour < endHour) {
+      // Simple range (e.g., 8:00 to 17:00)
+      const timeCondition = and(sql`${hourColumn} >= ${startHour}`, sql`${hourColumn} < ${endHour}`)
+      baseConditions.push(
+        includeNullTimestamps ? or(isNull(media.timestamp), timeCondition) : timeCondition
+      )
+    } else if (startHour > endHour) {
+      // Wrapping range (e.g., 22:00 to 6:00)
+      const timeCondition = or(sql`${hourColumn} >= ${startHour}`, sql`${hourColumn} < ${endHour}`)
+      baseConditions.push(
+        includeNullTimestamps ? or(isNull(media.timestamp), timeCondition) : timeCondition
+      )
+    }
+    // If startHour equals endHour, we include all hours (full day)
+```
+
+with:
+
+```js
+    // Add time-of-day condition using sql template for SQLite strftime.
+    // When includeNullTimestamps=true, allow null timestamps through.
+    // Empty ranges array means no time filter.
+    const hourColumn = sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER)`
+    const ranges = normalizeTimeRange(timeRange)
+    const rangeConditions = ranges
+      .map((r) => {
+        if (r.start === r.end) return null
+        if (r.start < r.end) {
+          return and(sql`${hourColumn} >= ${r.start}`, sql`${hourColumn} < ${r.end}`)
+        }
+        return or(sql`${hourColumn} >= ${r.start}`, sql`${hourColumn} < ${r.end}`)
+      })
+      .filter(Boolean)
+    if (rangeConditions.length > 0) {
+      const unioned = rangeConditions.length === 1 ? rangeConditions[0] : or(...rangeConditions)
+      baseConditions.push(
+        includeNullTimestamps ? or(isNull(media.timestamp), unioned) : unioned
+      )
+    }
+```
+
+At the top of `species.js`, add the import:
+
+```js
+import { normalizeTimeRange } from './sequences.js'
+```
+
+(if `species.js` doesn't already import from sequences.js — check the existing imports and merge accordingly).
+
+- [ ] **Step 2: species.js — getSequenceAwareHeatmapSQL**
+
+This function (around line 686) is the SQL fast-path for the heatmap. Apply the same signature change:
+
+Find the function declaration:
+
+```js
+export async function getSequenceAwareHeatmapSQL(
+  dbPath,
+  species,
+  startDate,
+  endDate,
+  startHour = 0,
+  endHour = 24,
+  includeNullTimestamps = false,
+  gapSeconds = null
+) {
+```
+
+Replace with:
+
+```js
+export async function getSequenceAwareHeatmapSQL(
+  dbPath,
+  species,
+  startDate,
+  endDate,
+  timeRange = {},
+  includeNullTimestamps = false,
+  gapSeconds = null
+) {
+```
+
+Inside the function, find the time-of-day filter block (it has the same shape as the one above — `if (startHour < endHour) ... else if (startHour > endHour) ...`) and replace it with the same `normalizeTimeRange` + `rangeConditions` pattern from Step 1. Read the function carefully — there may be multiple branches per gap-mode that each apply the time filter; update each one.
+
+- [ ] **Step 3: worker.js — pass timeRange through**
+
+In `src/main/services/sequences/worker.js`, replace this block (lines ~40-51):
+
+```js
+  const {
+    type,
+    dbPath,
+    studyId,
+    gapSeconds,
+    speciesNames,
+    startDate,
+    endDate,
+    startHour,
+    endHour,
+    includeNullTimestamps
+  } = workerData
+```
+
+with:
+
+```js
+  const {
+    type,
+    dbPath,
+    studyId,
+    gapSeconds,
+    speciesNames,
+    startDate,
+    endDate,
+    timeRange,
+    includeNullTimestamps
+  } = workerData
+```
+
+In the `case 'heatmap':` block (around lines 95-115), replace `startHour, endHour` with `timeRange` in both the `getSequenceAwareHeatmapSQL` call and the `getSpeciesHeatmapDataByMedia` call:
+
+```js
+      const fastRows = await getSequenceAwareHeatmapSQL(
+        dbPath,
+        speciesNames,
+        startDate,
+        endDate,
+        timeRange,
+        includeNullTimestamps,
+        effectiveGapSeconds
+      )
+      if (fastRows !== null) return pivotPreAggregatedHeatmap(fastRows)
+      const rawData = await getSpeciesHeatmapDataByMedia(
+        dbPath,
+        speciesNames,
+        startDate,
+        endDate,
+        timeRange,
+        includeNullTimestamps
+      )
+```
+
+- [ ] **Step 4: ipc/sequences.js — heatmap handler signature**
+
+In `src/main/ipc/sequences.js`, replace the heatmap handler signature (lines ~120-163):
+
+```js
+  ipcMain.handle(
+    'sequences:get-heatmap',
+    async (
+      _,
+      studyId,
+      speciesNames,
+      startDate,
+      endDate,
+      startHour,
+      endHour,
+      includeNullTimestamps,
+      gapSeconds
+    ) => {
+```
+
+with:
+
+```js
+  ipcMain.handle(
+    'sequences:get-heatmap',
+    async (
+      _,
+      studyId,
+      speciesNames,
+      startDate,
+      endDate,
+      timeRange,
+      includeNullTimestamps,
+      gapSeconds
+    ) => {
+```
+
+And in the `runInWorker` call inside the same handler, replace:
+
+```js
+        const data = await runInWorker({
+          type: 'heatmap',
+          dbPath,
+          studyId,
+          gapSeconds,
+          speciesNames: stripped,
+          startDate,
+          endDate,
+          startHour,
+          endHour,
+          includeNullTimestamps
+        })
+```
+
+with:
+
+```js
+        const data = await runInWorker({
+          type: 'heatmap',
+          dbPath,
+          studyId,
+          gapSeconds,
+          speciesNames: stripped,
+          startDate,
+          endDate,
+          timeRange,
+          includeNullTimestamps
+        })
+```
+
+Also update the JSDoc comment above the handler (line ~115-117) to replace the `@param startHour` / `@param endHour` lines with `@param timeRange — { ranges: [{start, end}, ...] } or { start, end } legacy shape`.
+
+- [ ] **Step 5: preload/index.js — API signature**
+
+In `src/preload/index.js`, replace the `getSequenceAwareHeatmap` block (lines 117-136):
+
+```js
+  getSequenceAwareHeatmap: async (
+    studyId,
+    speciesNames,
+    startDate,
+    endDate,
+    startHour,
+    endHour,
+    includeNullTimestamps
+  ) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'sequences:get-heatmap',
+      studyId,
+      speciesNames,
+      startDate,
+      endDate,
+      startHour,
+      endHour,
+      includeNullTimestamps
+    )
+  },
+```
+
+with:
+
+```js
+  getSequenceAwareHeatmap: async (
+    studyId,
+    speciesNames,
+    startDate,
+    endDate,
+    timeRange,
+    includeNullTimestamps
+  ) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'sequences:get-heatmap',
+      studyId,
+      speciesNames,
+      startDate,
+      endDate,
+      timeRange,
+      includeNullTimestamps
+    )
+  },
+```
+
+- [ ] **Step 6: Run tests to confirm no regression**
+
+Run: `npm test`
+Expected: all tests pass. (No test exercises the heatmap chain end-to-end, but the sequences-related tests should still pass.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/database/queries/species.js src/main/services/sequences/worker.js src/main/ipc/sequences.js src/preload/index.js
+git commit -m "refactor(heatmap): replace startHour/endHour positional args with timeRange object"
+```
+
+---
+
+## Task 10: Renderer — wire it all into media.jsx
+
+**Files:**
+- Modify: `src/renderer/src/media.jsx`
+
+- [ ] **Step 1: Update imports and state**
+
+In `src/renderer/src/media.jsx`, add imports near the top (with the other UI imports):
+
+```jsx
+import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
+import DayPeriodChips from './ui/dayPeriodChips'
+import ChartShapeToggle from './ui/chartShapeToggle'
+import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
+```
+
+Replace the existing `timeRange` state declaration (currently line 37):
+
+```jsx
+  const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
+```
+
+with:
+
+```jsx
+  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [arc, setArc] = useState({ start: 0, end: 24 })
+  const [chartShape, setChartShape] = useState('polar')
+
+  // Derive the timeRange payload sent to the backend. Chips win; with no
+  // chips, the freeform drag-arc supplies the (zero or one) range.
+  const timeRange = useMemo(() => {
+    const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
+    return { ranges }
+  }, [chipSelection, arc])
+```
+
+- [ ] **Step 2: Update the time-range handler**
+
+Replace the existing `handleTimeRangeChange` callback (currently around line 224):
+
+```jsx
+  const handleTimeRangeChange = useCallback((newTimeRange) => {
+    setTimeRange(newTimeRange)
+  }, [])
+```
+
+with:
+
+```jsx
+  const handleArcChange = useCallback((newArc) => {
+    setArc(newArc)
+  }, [])
+```
+
+- [ ] **Step 3: Replace the bottom-row clock card markup**
+
+Replace the inner block of the second-row wrapper (currently lines ~304-319):
+
+```jsx
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-[130px] gap-3">
+                <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
+                  <DailyActivityRadar
+                    activityData={dailyActivityData}
+                    selectedSpecies={selectedSpecies}
+                    palette={palette}
+                  />
+                  <div className="absolute w-full h-full flex items-center justify-center">
+                    <CircularTimeFilter
+                      onChange={handleTimeRangeChange}
+                      startTime={timeRange.start}
+                      endTime={timeRange.end}
+                    />
+                  </div>
+                </div>
+```
+
+with:
+
+```jsx
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-[130px] gap-3">
+                <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
+                  <div className="flex items-center justify-between px-2 pt-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                  </div>
+                  <div className="flex-1 relative">
+                    {chartShape === 'polar' ? (
+                      <>
+                        <DailyActivityRadar
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <CircularTimeFilter
+                            onChange={handleArcChange}
+                            startTime={arc.start}
+                            endTime={arc.end}
+                            mode={chipSelection.size > 0 ? 'chips' : 'drag'}
+                            chipSectors={chipsToRanges(chipSelection)}
+                          />
+                        </div>
+                      </>
+                    ) : (
+                      <DailyActivityLine
+                        activityData={dailyActivityData}
+                        selectedSpecies={selectedSpecies}
+                        palette={palette}
+                        selectedRanges={timeRange.ranges}
+                      />
+                    )}
+                  </div>
+                </div>
+```
+
+(The card grew from 140px to 180px wide to accommodate the chip row + toggle. The TimelineChart sibling continues to flex-grow into the remaining space.)
+
+- [ ] **Step 4: Verify the dev build runs**
+
+Run: `npm run dev`
+Open the Media tab. Confirm:
+- The four chip icons render above the polar clock.
+- Clicking Day shows a single highlighted arc on the clock; the gallery filters to 08–18.
+- Clicking Dawn + Dusk shows two arcs; the gallery filters to those windows.
+- Deselecting all chips restores the drag-arc handles.
+- Switching to X–Y mode (toggle in top-right) shows a line chart with shaded off-period bands matching the chip selection.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/media.jsx
+git commit -m "feat(media): add day-period preset chips and chart-shape toggle"
+```
+
+---
+
+## Task 11: Renderer — wire it all into activity.jsx
+
+**Files:**
+- Modify: `src/renderer/src/activity.jsx`
+
+- [ ] **Step 1: Update imports and state**
+
+In `src/renderer/src/activity.jsx`, add the same imports as in media.jsx:
+
+```jsx
+import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
+import DayPeriodChips from './ui/dayPeriodChips'
+import ChartShapeToggle from './ui/chartShapeToggle'
+import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
+```
+
+Replace the existing `timeRange` state (currently line 580):
+
+```jsx
+  const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
+```
+
+with:
+
+```jsx
+  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [arc, setArc] = useState({ start: 0, end: 24 })
+  const [chartShape, setChartShape] = useState('polar')
+
+  const timeRange = useMemo(() => {
+    const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
+    return { ranges }
+  }, [chipSelection, arc])
+```
+
+- [ ] **Step 2: Update the geoKey derivation**
+
+The existing `geoKey` (around line 646) concatenates `timeRange.start` and `timeRange.end`. Replace those two lines:
+
+```jsx
+    timeRange.start +
+    timeRange.end
+```
+
+with:
+
+```jsx
+    JSON.stringify(timeRange.ranges)
+```
+
+- [ ] **Step 3: Update the heatmap query (Task 9 already changed the IPC)**
+
+The existing heatmap query (around lines 718-751) passes `timeRange.start, timeRange.end` to both the queryKey and `getSequenceAwareHeatmap`. Task 9 already updated the IPC to take `timeRange`. Update the call sites:
+
+In the queryKey (around line 725-726), replace:
+
+```jsx
+      timeRange.start,
+      timeRange.end,
+```
+
+with:
+
+```jsx
+      JSON.stringify(timeRange.ranges),
+```
+
+In the queryFn call (around lines 730-739), replace:
+
+```jsx
+      const response = await window.api.getSequenceAwareHeatmap(
+        actualStudyId,
+        speciesNames,
+        dateRange[0]?.toISOString(),
+        dateRange[1]?.toISOString(),
+        timeRange.start,
+        timeRange.end,
+        isFullRange
+      )
+```
+
+with:
+
+```jsx
+      const response = await window.api.getSequenceAwareHeatmap(
+        actualStudyId,
+        speciesNames,
+        dateRange[0]?.toISOString(),
+        dateRange[1]?.toISOString(),
+        timeRange,
+        isFullRange
+      )
+```
+
+- [ ] **Step 4: Update the time-range handler**
+
+Replace the existing `handleTimeRangeChange` (around line 792):
+
+```jsx
+  const handleTimeRangeChange = useCallback((newTimeRange) => {
+    setTimeRange(newTimeRange)
+  }, [])
+```
+
+with:
+
+```jsx
+  const handleArcChange = useCallback((newArc) => {
+    setArc(newArc)
+  }, [])
+```
+
+- [ ] **Step 5: Replace the bottom-row clock card markup**
+
+Replace the inner block of the second-row wrapper (currently lines ~901-916):
+
+```jsx
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-[130px] gap-3">
+                <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
+                  <DailyActivityRadar
+                    activityData={dailyActivityData}
+                    selectedSpecies={selectedSpecies}
+                    palette={palette}
+                  />
+                  <div className="absolute w-full h-full flex items-center justify-center">
+                    <CircularTimeFilter
+                      onChange={handleTimeRangeChange}
+                      startTime={timeRange.start}
+                      endTime={timeRange.end}
+                    />
+                  </div>
+                </div>
+```
+
+with:
+
+```jsx
+            {speciesInitialized && sequenceGap !== undefined && (
+              <div className="w-full flex h-[130px] gap-3">
+                <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
+                  <div className="flex items-center justify-between px-2 pt-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                  </div>
+                  <div className="flex-1 relative">
+                    {chartShape === 'polar' ? (
+                      <>
+                        <DailyActivityRadar
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <CircularTimeFilter
+                            onChange={handleArcChange}
+                            startTime={arc.start}
+                            endTime={arc.end}
+                            mode={chipSelection.size > 0 ? 'chips' : 'drag'}
+                            chipSectors={chipsToRanges(chipSelection)}
+                          />
+                        </div>
+                      </>
+                    ) : (
+                      <DailyActivityLine
+                        activityData={dailyActivityData}
+                        selectedSpecies={selectedSpecies}
+                        palette={palette}
+                        selectedRanges={timeRange.ranges}
+                      />
+                    )}
+                  </div>
+                </div>
+```
+
+- [ ] **Step 6: Verify the dev build runs**
+
+Run: `npm run dev`
+Open the Activity tab. Confirm the same behavior as the Media tab in Task 10 Step 4, plus:
+- Toggling chips also updates the species heatmap on the map (the heatmap query depends on `timeRange.ranges`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/src/activity.jsx src/preload/index.js src/main/index.js
+git commit -m "feat(activity): add day-period preset chips and chart-shape toggle"
+```
+
+(Include the IPC files in the commit only if Step 3 required updating them; otherwise stage only `activity.jsx`.)
+
+---
+
+## Task 12: Documentation update
+
+**Files:**
+- Modify: `docs/data-formats.md` (timeRange section, if present)
+- Modify: `docs/ipc-api.md` (the `getSequenceAwareHeatmap` signature changed in Task 9)
+
+- [ ] **Step 1: Search docs for stale references**
+
+Run: `grep -n "timeRange" docs/*.md`
+
+For every match, decide:
+- If it documents the `{start, end}` shape, add a sentence noting that the new shape is `{ ranges: [{start, end}, ...] }` and that `{start, end}` is still accepted as legacy.
+- If it documents the IPC signature for `getSequenceAwareHeatmap`, update it: the previous `(studyId, species, startDate, endDate, startHour, endHour, includeNullTimestamps)` becomes `(studyId, species, startDate, endDate, timeRange, includeNullTimestamps)`.
+
+- [ ] **Step 2: Commit documentation**
+
+```bash
+git add docs/
+git commit -m "docs: document multi-range timeRange shape"
+```
+
+(Skip this commit if no doc files referenced `timeRange`.)
+
+---
+
+## Self-Review Checklist (run before declaring done)
+
+- [ ] Both Media and Activity tabs render the four chips and the chart-shape toggle.
+- [ ] Toggling Dawn + Dusk shows two arcs on the polar clock and shaded bands on the x–y view that exclude only the 5–8 and 18–21 windows.
+- [ ] Deselecting all chips restores the drag-arc handles and brings back the original single-range behavior.
+- [ ] The heatmap on the Activity map updates when chips change.
+- [ ] `npm test` passes (existing pseudo-species tests, plus the new dayPeriods + sequencesTimeRange tests).
+- [ ] `npm run lint` is clean.
+- [ ] No CLAUDE.md doc-update obligations missed (architecture.md / ipc-api.md / data-formats.md if anything in those areas changed).
+
+---
+
+## Notes on subagent dispatch
+
+- Tasks 1–3 (sequences.js multi-range refactor) and Task 9 (heatmap chain refactor) can run in parallel with Tasks 4–8 (renderer pure helpers + UI components).
+- Task 10 (media.jsx wiring) depends on Tasks 4–8.
+- Task 11 (activity.jsx wiring) depends on Tasks 4–9 (Task 9's IPC change is required before Task 11 Step 3).
+- Task 12 runs last.

--- a/docs/specs/2026-05-13-day-period-presets-design.md
+++ b/docs/specs/2026-05-13-day-period-presets-design.md
@@ -118,8 +118,8 @@ avoids special-casing the chip path on the backend.
 ## Interaction rules
 
 - **Click a chip with no chip currently selected**: that chip becomes
-  active; if the drag-arc is at anything other than full day, the arc
-  resets to full day (clears the implicit drag selection). Polar shows
+  active. The drag-arc state is preserved (not reset) but the arc and
+  handles are no longer rendered while chips are active. Polar shows
   one highlighted arc for that chip.
 - **Click another chip while one is selected**: toggles that chip on
   (additive). Polar shows two arcs.

--- a/docs/specs/2026-05-13-day-period-presets-design.md
+++ b/docs/specs/2026-05-13-day-period-presets-design.md
@@ -1,0 +1,220 @@
+# Day-period presets and chart-shape toggle
+
+**Date:** 2026-05-13
+**Status:** Design — approved
+**Area:** renderer (`src/renderer/src/ui/clock.jsx`, `src/renderer/src/media.jsx`, `src/renderer/src/activity.jsx`); main (`src/main/database/queries/sequences.js`, `src/main/database/queries/species.js`)
+
+## Summary
+
+Add four preset day-period chips (Dawn, Day, Dusk, Night) next to the
+existing polar clock in the Media and Activity tabs, and add a Polar / X–Y
+toggle so the same hourly-bin data can be viewed as either the existing
+radar or a line chart over a 24-hour x-axis. Chips are multi-select: the
+filter is the union of their hour ranges, and combinations like Dawn + Dusk
+yield crepuscular without a dedicated chip. The polar's freeform drag
+handles are hidden while any chip is selected; deselecting all chips
+restores the single-arc drag mode automatically.
+
+## Motivation
+
+Today the only way to scope a "time of day" in the Media or Activity tab
+is to drag the blue arc on the polar clock — discoverable but slow, and
+the result is always one continuous start→end window. Wildlife
+researchers think in named periods (nocturnal, diurnal, crepuscular) far
+more than in arbitrary hour ranges, so the dominant filtering operation
+takes more interaction than it should.
+
+A second gap: the polar radar is one of two conventional shapes for
+camera-trap activity plots. The other is an x–y plot of activity against
+hour-of-day, with shaded night bands — the standard output of the R
+`activity` and `overlap` packages. The chart-shape choice is reader
+preference, not data: both are renderings of the same hourly bins.
+
+## Goals
+
+- Four preset chips with lucide icons (Sunrise, Sun, Sunset, Moon) above
+  the polar clock card. No labels, no static range text — tooltip on
+  hover only.
+- Multi-select: each chip toggles its sector independently. The active
+  filter is the union of selected sectors.
+- Selected sectors render as one or more highlighted arcs on the polar
+  clock and as shaded bands on the x–y chart.
+- Polar / X–Y chart-shape toggle in the top-right of the card. State is
+  per-card, persisted in component state (resets on tab switch).
+- The freeform drag handles on the polar clock keep working when no chip
+  is selected. Grabbing a handle while chips are active clears all
+  chips and reverts to a single drag-defined arc.
+- Applies symmetrically to both Media (`media.jsx`) and Activity
+  (`activity.jsx`) tabs — they already share the clock components.
+
+## Non-goals
+
+- No "All day" / reset chip. Clicking the active chip again deselects
+  it; with no chips selected and the drag-arc at full range, the filter
+  is off (current behavior).
+- No solar-position computation. Preset hour windows are fixed
+  (latitude-independent). Real sunrise/sunset times are out of scope.
+- No Crepuscular chip. The combination Dawn + Dusk covers it.
+- No Custom chip. Users who want a non-preset range can fall back to the
+  drag-arc.
+- No smoothed kernel-density curve for the x–y view. Plot the hourly
+  bins directly as a line.
+- No persistence of chip selection or chart-shape across study switches
+  or app restarts.
+
+## Preset definitions
+
+Clean partition of 24 hours, no overlap. Hours are in local clock time,
+matching the existing `strftime('%H', media.timestamp)` filter.
+
+| Chip   | Icon (lucide) | Range            |
+|--------|---------------|------------------|
+| Dawn   | `Sunrise`     | 05:00 → 08:00    |
+| Day    | `Sun`         | 08:00 → 18:00    |
+| Dusk   | `Sunset`      | 18:00 → 21:00    |
+| Night  | `Moon`        | 21:00 → 05:00    |
+
+The four together exactly tile a day (selecting all four = no filter).
+
+## Data model
+
+Today the time-of-day filter is `{ start: number, end: number }` —
+a single half-open `[start, end)` window in hours, with the wrap-around
+case (`start > end`) handled by an OR'd SQL fragment in
+`src/main/database/queries/sequences.js`.
+
+The chip selection naturally produces *zero or more* hour ranges.
+Generalize the model to:
+
+```js
+// shape passed from renderer to main:
+timeRange: {
+  ranges: [
+    { start: 5, end: 8 },    // Dawn
+    { start: 18, end: 21 },  // Dusk
+  ]
+}
+```
+
+- Empty `ranges` (or `ranges` absent) means "no filter" — equivalent to
+  today's behavior when the drag-arc covers a full day.
+- A single range with `start > end` means a midnight-wrapping window
+  (the existing case for Night, or for a user-dragged arc that crosses
+  midnight). The query layer expands it into an OR'd pair as it does
+  today.
+- Multiple ranges: build the per-range condition as today, then OR them
+  all together.
+
+The renderer keeps a `chipSelection` set (subset of `{dawn, day, dusk,
+night}`) and a separate `arc` (the `{start, end}` shape from the drag
+handles). Whichever is "active" supplies `ranges` to the IPC payload:
+
+- chipSelection non-empty → `ranges = chipSelection.map(chip => PRESETS[chip])`
+- otherwise → `ranges = isFullDay(arc) ? [] : [arc]`
+
+This keeps the data model symmetric across both interaction modes and
+avoids special-casing the chip path on the backend.
+
+## Interaction rules
+
+- **Click a chip with no chip currently selected**: that chip becomes
+  active; if the drag-arc is at anything other than full day, the arc
+  resets to full day (clears the implicit drag selection). Polar shows
+  one highlighted arc for that chip.
+- **Click another chip while one is selected**: toggles that chip on
+  (additive). Polar shows two arcs.
+- **Click an active chip**: deselects it. If that was the last selected
+  chip, drag-arc mode returns automatically (handles re-appear at
+  whatever the previous arc position was, default full-day if never
+  set).
+- **Drag-arc interactivity**: visible and interactive only when no chip
+  is selected. While any chip is selected, the drag arc and handles are
+  not rendered at all (so there's no ambiguity about where they sit
+  relative to the chip-driven sectors).
+- **Drag-arc behavior with no chips selected**: unchanged from today —
+  start/end commit on pointer release.
+
+The polar clock renders the chip-driven sectors as non-interactive
+`<path>` elements when chips are active. When chips are inactive, the
+existing drag arc and handles render as today.
+
+## X–Y chart
+
+A second component, `DailyActivityLine`, renders the same hourly-bin
+data the radar consumes (`activityData`, an array of 24 hour buckets
+with one numeric value per species). Implementation:
+
+- Recharts `LineChart` with hour on the x-axis (0–23) and activity on
+  the y-axis. One `<Line>` per selected species, color matching the
+  radar palette, no dots.
+- Shaded "off-period" bands behind the lines, derived from the inverse
+  of the active `ranges` set. With no chips selected, no shading.
+- X-axis labels at 0, 6, 12, 18, 24. Y-axis hidden (matches the radar's
+  no-axis aesthetic).
+- Same `margin` and `ResponsiveContainer` setup as the radar so the
+  charts swap in place inside the existing 130px row.
+
+Chart-shape toggle is a small two-button group in the top-right of the
+clock card, lucide icons only (`PieChart` for polar, `LineChart` for
+x–y). The active button uses the same `bg-foreground text-background`
+pattern as elsewhere in the app.
+
+## Components affected
+
+- `src/renderer/src/ui/clock.jsx`
+  - Add `DayPeriodChips` component: four `<Button>` toggles using
+    lucide icons. Props: `selection: Set<string>`, `onChange`.
+  - Add `DailyActivityLine` component: x–y twin of the existing
+    `DailyActivityRadar`, same data shape and props.
+  - Modify `CircularTimeFilter` to accept a `chipSectors` prop (array
+    of `{start, end}` ranges to render as static highlighted arcs) and
+    a `mode: 'drag' | 'chips'` prop. In `'chips'` mode, the drag arc
+    and handles are not rendered.
+  - Add a small `ChartShapeToggle` component (two icon buttons).
+  - Export the new components.
+- `src/renderer/src/media.jsx`, `src/renderer/src/activity.jsx`
+  - Replace today's `timeRange: {start, end}` state with `chipSelection:
+    Set<string>` and `arc: {start, end}`.
+  - Compute `ranges` from those two pieces and pass to query hooks.
+  - Add `chartShape: 'polar' | 'xy'` state per tab.
+  - Render the chips above the existing clock card (same
+    `w-[140px]` column), the `ChartShapeToggle` in the top-right of
+    that column, and conditionally render either the radar or the line
+    chart inside.
+- `src/main/database/queries/sequences.js`,
+  `src/main/database/queries/species.js`
+  - Replace the `timeRange.start / timeRange.end` branches with a
+    single loop over `timeRange.ranges`. Each range produces the same
+    `>= start AND < end` (or wrap-around OR) fragment as today; the
+    fragments are combined with OR. Empty `ranges` means no time
+    filter.
+  - Backwards compatibility: if a caller still passes `timeRange:
+    {start, end}`, normalize to `ranges: [{start, end}]` at the top of
+    the query function so the change is internal-only.
+- `src/preload/index.js`
+  - No signature change — `timeRange` is already an opaque object.
+
+## Testing plan
+
+- Unit tests for the renderer-side selection-to-`ranges` derivation:
+  every subset of `{dawn, day, dusk, night}`, plus the four
+  drag-arc-active states (full day, normal range, midnight-wrapping,
+  zero-width).
+- Query-layer tests for `getSequenceCounts` and equivalents in
+  `species.js`: assert that single-range, multi-range, and wrap-around
+  inputs produce the expected SQL. Use the existing in-memory SQLite
+  fixture pattern.
+- Manual verification in both Media and Activity tabs:
+  - Toggle each chip individually, then in pairs (especially Dawn +
+    Dusk for the crepuscular case), then all four (= no filter).
+  - Deselect all chips and confirm the drag arc and handles return,
+    in their previous position.
+  - Switch chart-shape on each tab; confirm the data is identical and
+    the shaded bands match the chip selection.
+  - Confirm the existing filter-charts row toggle still collapses the
+    full row (chips + clock + chart) cleanly.
+
+## Open questions
+
+- None blocking. (Latitude-aware sunrise/sunset, persistence, and a
+  Crepuscular shortcut are explicitly deferred.)

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -618,22 +618,14 @@ export async function hasTimestampedMedia(dbPath, options = {}) {
       conditions.push(lte(media.timestamp, endDate))
     }
 
-    // Apply time range
-    if (timeRange.start !== undefined && timeRange.end !== undefined) {
-      if (timeRange.start < timeRange.end) {
-        conditions.push(
-          and(
-            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
-            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
-          )
-        )
-      } else if (timeRange.start > timeRange.end) {
-        conditions.push(
-          or(
-            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
-            sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
-          )
-        )
+    // Apply time range — same OR-of-ranges semantics as the paginated query.
+    const timeRanges = normalizeTimeRange(timeRange)
+    if (timeRanges.length > 0) {
+      const rangeConditions = timeRanges.map(buildHourRangeCondition).filter(Boolean)
+      if (rangeConditions.length === 1) {
+        conditions.push(rangeConditions[0])
+      } else if (rangeConditions.length > 1) {
+        conditions.push(or(...rangeConditions))
       }
     }
 

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -26,6 +26,24 @@ import { getStudyIdFromPath } from './utils.js'
 import { BLANK_SENTINEL, VEHICLE_SENTINEL } from '../../../shared/constants.js'
 
 /**
+ * Normalize the timeRange filter into an array of {start, end} ranges.
+ * Accepts:
+ *   - undefined / null / {} → no filter, returns []
+ *   - { start, end }        → legacy single-range shape, returns [{start, end}]
+ *   - { ranges: [...] }     → new multi-range shape, passed through
+ *
+ * Empty ranges means "no time-of-day filter".
+ */
+export function normalizeTimeRange(timeRange) {
+  if (!timeRange) return []
+  if (Array.isArray(timeRange.ranges)) return timeRange.ranges
+  if (timeRange.start !== undefined && timeRange.end !== undefined) {
+    return [{ start: timeRange.start, end: timeRange.end }]
+  }
+  return []
+}
+
+/**
  * Get media for sequence pagination with cursor support.
  * Returns media ordered by timestamp DESC, filtered by species/date/time.
  *

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -44,6 +44,28 @@ export function normalizeTimeRange(timeRange) {
 }
 
 /**
+ * Build a SQL condition for a single {start, end} hour range against
+ * media.timestamp. Half-open [start, end). Returns null when start === end
+ * (zero-width range, no rows match — caller should drop it).
+ *
+ * Wrap-around (start > end) is OR'd: hour >= start OR hour < end.
+ */
+export function buildHourRangeCondition(range) {
+  const { start, end } = range
+  if (start === end) return null
+  if (start < end) {
+    return and(
+      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
+      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
+    )
+  }
+  return or(
+    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
+    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
+  )
+}
+
+/**
  * Get media for sequence pagination with cursor support.
  * Returns media ordered by timestamp DESC, filtered by species/date/time.
  *
@@ -96,8 +118,10 @@ export async function getMediaForSequencePagination(dbPath, options = {}) {
       log.info(`[Sequences] Date range: ${startDate} to ${endDate}`)
     }
 
-    // Time of day filter (only applies to timestamped media)
-    const hasTimeFilter = timeRange.start !== undefined && timeRange.end !== undefined
+    // Time of day filter (only applies to timestamped media). Empty array
+    // means no filter; multiple ranges are unioned with OR.
+    const timeRanges = normalizeTimeRange(timeRange)
+    const hasTimeFilter = timeRanges.length > 0
 
     // Pick one observation's eventID for a media via correlated subquery —
     // needed by sequence grouping when the dataset uses eventID-based
@@ -277,23 +301,13 @@ export async function getMediaForSequencePagination(dbPath, options = {}) {
         timestampedConditions.push(lte(media.timestamp, endDate))
       }
 
-      // Apply time of day filter
+      // Apply time of day filter — OR of per-range conditions.
       if (hasTimeFilter) {
-        if (timeRange.start < timeRange.end) {
-          timestampedConditions.push(
-            and(
-              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
-              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
-            )
-          )
-        } else if (timeRange.start > timeRange.end) {
-          // Wraps around midnight
-          timestampedConditions.push(
-            or(
-              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${timeRange.start}`,
-              sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${timeRange.end}`
-            )
-          )
+        const rangeConditions = timeRanges.map(buildHourRangeCondition).filter(Boolean)
+        if (rangeConditions.length === 1) {
+          timestampedConditions.push(rangeConditions[0])
+        } else if (rangeConditions.length > 1) {
+          timestampedConditions.push(or(...rangeConditions))
         }
       }
 

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -22,6 +22,7 @@ import {
 import log from 'electron-log'
 import { getStudyIdFromPath } from './utils.js'
 import { BLANK_SENTINEL } from '../../../shared/constants.js'
+import { normalizeTimeRange } from './sequences.js'
 
 /**
  * Get species distribution from the database using Drizzle ORM
@@ -550,8 +551,7 @@ export async function getSpeciesHeatmapDataByMedia(
   species,
   startDate,
   endDate,
-  startHour = 0,
-  endHour = 24,
+  timeRange = {},
   includeNullTimestamps = false
 ) {
   const startTime = Date.now()
@@ -584,23 +584,24 @@ export async function getSpeciesHeatmapDataByMedia(
       baseConditions.push(lte(media.timestamp, endDate))
     }
 
-    // Add time-of-day condition using sql template for SQLite strftime
-    // When includeNullTimestamps=true, also allow null timestamps through
+    // Add time-of-day condition using sql template for SQLite strftime.
+    // When includeNullTimestamps=true, allow null timestamps through.
+    // Empty ranges array means no time filter.
     const hourColumn = sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER)`
-    if (startHour < endHour) {
-      // Simple range (e.g., 8:00 to 17:00)
-      const timeCondition = and(sql`${hourColumn} >= ${startHour}`, sql`${hourColumn} < ${endHour}`)
-      baseConditions.push(
-        includeNullTimestamps ? or(isNull(media.timestamp), timeCondition) : timeCondition
-      )
-    } else if (startHour > endHour) {
-      // Wrapping range (e.g., 22:00 to 6:00)
-      const timeCondition = or(sql`${hourColumn} >= ${startHour}`, sql`${hourColumn} < ${endHour}`)
-      baseConditions.push(
-        includeNullTimestamps ? or(isNull(media.timestamp), timeCondition) : timeCondition
-      )
+    const ranges = normalizeTimeRange(timeRange)
+    const rangeConditions = ranges
+      .map((r) => {
+        if (r.start === r.end) return null
+        if (r.start < r.end) {
+          return and(sql`${hourColumn} >= ${r.start}`, sql`${hourColumn} < ${r.end}`)
+        }
+        return or(sql`${hourColumn} >= ${r.start}`, sql`${hourColumn} < ${r.end}`)
+      })
+      .filter(Boolean)
+    if (rangeConditions.length > 0) {
+      const unioned = rangeConditions.length === 1 ? rangeConditions[0] : or(...rangeConditions)
+      baseConditions.push(includeNullTimestamps ? or(isNull(media.timestamp), unioned) : unioned)
     }
-    // If startHour equals endHour, we include all hours (full day)
 
     const results = await db
       .select({
@@ -688,8 +689,7 @@ export async function getSequenceAwareHeatmapSQL(
   speciesNames = [],
   startDate,
   endDate,
-  startHour = 0,
-  endHour = 24,
+  timeRange = {},
   includeNullTimestamps = false,
   gapSeconds
 ) {
@@ -714,6 +714,7 @@ export async function getSequenceAwareHeatmapSQL(
   // Date + hour filters. Non-window paths evaluate the predicate inline; the
   // window path pushes it into media_info (and needs a parallel null-ts
   // branch when includeNullTimestamps).
+  const hourRanges = normalizeTimeRange(timeRange)
   const buildDateHourFilter = (tsCol) => {
     const conds = []
     const params = []
@@ -729,14 +730,17 @@ export async function getSequenceAwareHeatmapSQL(
       }
     }
     const hourExpr = `CAST(strftime('%H', ${tsCol}) AS INTEGER)`
-    if (startHour < endHour) {
-      const hc = `(${hourExpr} >= ${startHour} AND ${hourExpr} < ${endHour})`
-      conds.push(includeNullTimestamps ? `(${tsCol} IS NULL OR ${hc})` : hc)
-    } else if (startHour > endHour) {
-      const hc = `(${hourExpr} >= ${startHour} OR ${hourExpr} < ${endHour})`
-      conds.push(includeNullTimestamps ? `(${tsCol} IS NULL OR ${hc})` : hc)
+    const hourClauses = hourRanges
+      .map(({ start, end }) => {
+        if (start === end) return null
+        if (start < end) return `(${hourExpr} >= ${start} AND ${hourExpr} < ${end})`
+        return `(${hourExpr} >= ${start} OR ${hourExpr} < ${end})`
+      })
+      .filter(Boolean)
+    if (hourClauses.length > 0) {
+      const unioned = hourClauses.length === 1 ? hourClauses[0] : `(${hourClauses.join(' OR ')})`
+      conds.push(includeNullTimestamps ? `(${tsCol} IS NULL OR ${unioned})` : unioned)
     }
-    // startHour === endHour → full day, no filter
     return { where: conds.length > 0 ? 'AND ' + conds.join(' AND ') : '', params }
   }
 

--- a/src/main/ipc/sequences.js
+++ b/src/main/ipc/sequences.js
@@ -112,8 +112,8 @@ export function registerSequencesIPCHandlers() {
    * @param {Array<string>} speciesNames - Species to include in heatmap
    * @param {string|null} startDate - Start date filter (ISO string)
    * @param {string|null} endDate - End date filter (ISO string)
-   * @param {number} startHour - Start hour filter (0-24)
-   * @param {number} endHour - End hour filter (0-24)
+   * @param {Object} timeRange - Time-of-day filter, either { ranges: [{start, end}, ...] }
+   *   or legacy { start, end }; empty/missing means no filter
    * @param {boolean} includeNullTimestamps - Whether to include media without timestamps
    * @param {number|null} [gapSeconds] - Optional gap threshold; fetched from metadata if not provided
    */
@@ -125,8 +125,7 @@ export function registerSequencesIPCHandlers() {
       speciesNames,
       startDate,
       endDate,
-      startHour,
-      endHour,
+      timeRange,
       includeNullTimestamps,
       gapSeconds
     ) => {
@@ -150,8 +149,7 @@ export function registerSequencesIPCHandlers() {
           speciesNames: stripped,
           startDate,
           endDate,
-          startHour,
-          endHour,
+          timeRange,
           includeNullTimestamps
         })
         return { data }

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -45,8 +45,7 @@ async function run() {
     speciesNames,
     startDate,
     endDate,
-    startHour,
-    endHour,
+    timeRange,
     includeNullTimestamps
   } = workerData
 
@@ -97,8 +96,7 @@ async function run() {
         speciesNames,
         startDate,
         endDate,
-        startHour,
-        endHour,
+        timeRange,
         includeNullTimestamps,
         effectiveGapSeconds
       )
@@ -108,8 +106,7 @@ async function run() {
         speciesNames,
         startDate,
         endDate,
-        startHour,
-        endHour,
+        timeRange,
         includeNullTimestamps
       )
       return calculateSequenceAwareHeatmap(rawData, effectiveGapSeconds)

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -119,8 +119,7 @@ const api = {
     speciesNames,
     startDate,
     endDate,
-    startHour,
-    endHour,
+    timeRange,
     includeNullTimestamps
   ) => {
     return await electronAPI.ipcRenderer.invoke(
@@ -129,8 +128,7 @@ const api = {
       speciesNames,
       startDate,
       endDate,
-      startHour,
-      endHour,
+      timeRange,
       includeNullTimestamps
     )
   },

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -923,12 +923,12 @@ export default function Activity({ studyData, studyId }) {
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="absolute top-1.5 right-2 z-10">
-                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
-                  </div>
-                  <div className="flex-1 relative">
-                    {chartShape === 'polar' ? (
-                      <>
+                  {chartShape === 'polar' ? (
+                    <>
+                      <div className="absolute top-1.5 right-2 z-10">
+                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                      </div>
+                      <div className="flex-1 relative">
                         <DailyActivityRadar
                           activityData={dailyActivityData}
                           selectedSpecies={selectedSpecies}
@@ -943,16 +943,23 @@ export default function Activity({ studyData, studyId }) {
                             chipSectors={visualRanges}
                           />
                         </div>
-                      </>
-                    ) : (
-                      <DailyActivityLine
-                        activityData={dailyActivityData}
-                        selectedSpecies={selectedSpecies}
-                        palette={palette}
-                        selectedRanges={visualRanges}
-                      />
-                    )}
-                  </div>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex justify-end px-2 pt-1.5">
+                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                      </div>
+                      <div className="flex-1 relative">
+                        <DailyActivityLine
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                          selectedRanges={visualRanges}
+                        />
+                      </div>
+                    </>
+                  )}
                   <div className="flex justify-center px-2 pb-1.5">
                     <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
                   </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -899,16 +899,15 @@ export default function Activity({ studyData, studyId }) {
           <div
             className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
               showFilterCharts && hasTemporalData
-                ? 'h-[130px] opacity-100 mt-4'
+                ? 'h-[180px] opacity-100 mt-4'
                 : 'h-0 opacity-0 mt-0'
             }`}
             aria-hidden={!(showFilterCharts && hasTemporalData)}
           >
             {speciesInitialized && sequenceGap !== undefined && (
-              <div className="w-full flex h-[130px] gap-3">
+              <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="flex items-center justify-between px-2 pt-1.5">
-                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                  <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
                   <div className="flex-1 relative">
@@ -937,6 +936,9 @@ export default function Activity({ studyData, studyId }) {
                         selectedRanges={timeRange.ranges}
                       />
                     )}
+                  </div>
+                  <div className="flex justify-center px-2 pb-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
                   </div>
                 </div>
                 <div className="flex-grow rounded px-2 border border-border">

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -923,10 +923,10 @@ export default function Activity({ studyData, studyId }) {
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="flex justify-end px-2 pt-1.5">
+                  <div className="absolute top-1.5 right-2 z-10">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative pb-4">
+                  <div className="flex-1 relative">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -934,7 +934,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center pb-4">
+                        <div className="absolute inset-0 flex items-center justify-center">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -10,7 +10,10 @@ import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import ActivityMapContextMenu from './ui/ActivityMapContextMenu'
-import CircularTimeFilter, { DailyActivityRadar } from './ui/clock'
+import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
+import DayPeriodChips from './ui/dayPeriodChips'
+import ChartShapeToggle from './ui/chartShapeToggle'
+import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
 import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import MarkerHoverCard from './ui/MarkerHoverCard'
 import { useTheme } from './hooks/useTheme'
@@ -577,7 +580,14 @@ export default function Activity({ studyData, studyId }) {
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
   const [dateRange, setDateRange] = useState([null, null])
   const [fullExtent, setFullExtent] = useState([null, null])
-  const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
+  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [arc, setArc] = useState({ start: 0, end: 24 })
+  const [chartShape, setChartShape] = useState('polar')
+
+  const timeRange = useMemo(() => {
+    const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
+    return { ranges }
+  }, [chipSelection, arc])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
@@ -647,8 +657,7 @@ export default function Activity({ studyData, studyId }) {
     selectedSpecies.map((s) => s.scientificName).join(',') +
     (dateRange[0]?.toISOString() || '') +
     (dateRange[1]?.toISOString() || '') +
-    timeRange.start +
-    timeRange.end
+    JSON.stringify(timeRange.ranges)
 
   // Fetch sequence-aware timeseries data
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)
@@ -722,8 +731,7 @@ export default function Activity({ studyData, studyId }) {
       [...speciesNames].sort(),
       dateRange[0]?.toISOString(),
       dateRange[1]?.toISOString(),
-      timeRange.start,
-      timeRange.end,
+      JSON.stringify(timeRange.ranges),
       isFullRange,
       sequenceGap
     ],
@@ -733,8 +741,7 @@ export default function Activity({ studyData, studyId }) {
         speciesNames,
         dateRange[0]?.toISOString(),
         dateRange[1]?.toISOString(),
-        timeRange.start,
-        timeRange.end,
+        timeRange,
         isFullRange
       )
       if (response.error) throw new Error(response.error)
@@ -788,9 +795,8 @@ export default function Activity({ studyData, studyId }) {
     staleTime: Infinity
   })
 
-  // Handle time range changes
-  const handleTimeRangeChange = useCallback((newTimeRange) => {
-    setTimeRange(newTimeRange)
+  const handleArcChange = useCallback((newArc) => {
+    setArc(newArc)
   }, [])
 
   // Handle species selection changes
@@ -900,18 +906,37 @@ export default function Activity({ studyData, studyId }) {
           >
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[130px] gap-3">
-                <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
-                  <DailyActivityRadar
-                    activityData={dailyActivityData}
-                    selectedSpecies={selectedSpecies}
-                    palette={palette}
-                  />
-                  <div className="absolute w-full h-full flex items-center justify-center">
-                    <CircularTimeFilter
-                      onChange={handleTimeRangeChange}
-                      startTime={timeRange.start}
-                      endTime={timeRange.end}
-                    />
+                <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
+                  <div className="flex items-center justify-between px-2 pt-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                  </div>
+                  <div className="flex-1 relative">
+                    {chartShape === 'polar' ? (
+                      <>
+                        <DailyActivityRadar
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <CircularTimeFilter
+                            onChange={handleArcChange}
+                            startTime={arc.start}
+                            endTime={arc.end}
+                            mode={chipSelection.size > 0 ? 'chips' : 'drag'}
+                            chipSectors={chipsToRanges(chipSelection)}
+                          />
+                        </div>
+                      </>
+                    ) : (
+                      <DailyActivityLine
+                        activityData={dailyActivityData}
+                        selectedSpecies={selectedSpecies}
+                        palette={palette}
+                        selectedRanges={timeRange.ranges}
+                      />
+                    )}
                   </div>
                 </div>
                 <div className="flex-grow rounded px-2 border border-border">

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -926,7 +926,7 @@ export default function Activity({ studyData, studyId }) {
                   <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative pb-2">
+                  <div className="flex-1 relative pb-4">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -934,7 +934,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center pb-2">
+                        <div className="absolute inset-0 flex items-center justify-center pb-4">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -961,9 +961,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                           selectedRanges={visualRanges}
-                          onArcChange={
-                            chipSelection.size === 0 ? handleArcChange : undefined
-                          }
+                          onArcChange={chipSelection.size === 0 ? handleArcChange : undefined}
                         />
                       </div>
                     </>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -13,7 +13,13 @@ import ActivityMapContextMenu from './ui/ActivityMapContextMenu'
 import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
 import DayPeriodChips from './ui/dayPeriodChips'
 import ChartShapeToggle from './ui/chartShapeToggle'
-import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
+import {
+  ALL_CHIPS_SELECTED,
+  arcToRanges,
+  chipsToRanges,
+  DAY_PERIOD_ORDER,
+  mergeChipRanges
+} from './utils/dayPeriods'
 import HideLeafletAttribution from './ui/HideLeafletAttribution'
 import MarkerHoverCard from './ui/MarkerHoverCard'
 import { useTheme } from './hooks/useTheme'
@@ -580,14 +586,24 @@ export default function Activity({ studyData, studyId }) {
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
   const [dateRange, setDateRange] = useState([null, null])
   const [fullExtent, setFullExtent] = useState([null, null])
-  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [chipSelection, setChipSelection] = useState(() => new Set(ALL_CHIPS_SELECTED))
   const [arc, setArc] = useState({ start: 0, end: 24 })
   const [chartShape, setChartShape] = useState('polar')
 
+  // All four chips (the default) is treated as "no filter" — null-timestamp
+  // media still flows through, mirroring the timeline's default behavior.
   const timeRange = useMemo(() => {
+    if (chipSelection.size === DAY_PERIOD_ORDER.length) return { ranges: [] }
     const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
     return { ranges }
   }, [chipSelection, arc])
+
+  // Merged ranges for VISUAL highlighting (collapses contiguous chip
+  // selections into single arcs/bands; all four → one full-day sweep).
+  const visualRanges = useMemo(
+    () => (chipSelection.size > 0 ? mergeChipRanges(chipsToRanges(chipSelection)) : []),
+    [chipSelection]
+  )
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
@@ -924,7 +940,7 @@ export default function Activity({ studyData, studyId }) {
                             startTime={arc.start}
                             endTime={arc.end}
                             mode={chipSelection.size > 0 ? 'chips' : 'drag'}
-                            chipSectors={chipsToRanges(chipSelection)}
+                            chipSectors={visualRanges}
                           />
                         </div>
                       </>
@@ -933,7 +949,7 @@ export default function Activity({ studyData, studyId }) {
                         activityData={dailyActivityData}
                         selectedSpecies={selectedSpecies}
                         palette={palette}
-                        selectedRanges={timeRange.ranges}
+                        selectedRanges={visualRanges}
                       />
                     )}
                   </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -600,10 +600,14 @@ export default function Activity({ studyData, studyId }) {
 
   // Merged ranges for VISUAL highlighting (collapses contiguous chip
   // selections into single arcs/bands; all four → one full-day sweep).
-  const visualRanges = useMemo(
-    () => (chipSelection.size > 0 ? mergeChipRanges(chipsToRanges(chipSelection)) : []),
-    [chipSelection]
-  )
+  // With no chips, mirror the freeform drag-arc selection into the x-y
+  // view too — same underlying filter.
+  const visualRanges = useMemo(() => {
+    if (chipSelection.size > 0) return mergeChipRanges(chipsToRanges(chipSelection))
+    return arcToRanges(arc)
+  }, [chipSelection, arc])
+
+  const isFiltering = useMemo(() => timeRange.ranges.length > 0, [timeRange])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
@@ -884,6 +888,7 @@ export default function Activity({ studyData, studyId }) {
                       // once we've confirmed the study has no timestamps
                       // (ENA24, Biome Health Project, etc).
                       hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
+                      isFiltering={isFiltering}
                     />
                   </div>
                 </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -926,7 +926,7 @@ export default function Activity({ studyData, studyId }) {
                   <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative">
+                  <div className="flex-1 relative pb-2">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -934,7 +934,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center">
+                        <div className="absolute inset-0 flex items-center justify-center pb-2">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -961,6 +961,9 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                           selectedRanges={visualRanges}
+                          onArcChange={
+                            chipSelection.size === 0 ? handleArcChange : undefined
+                          }
                         />
                       </div>
                     </>

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -334,7 +334,7 @@ export default function Activity({ studyData, studyId }) {
                   <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative pb-2">
+                  <div className="flex-1 relative pb-4">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -342,7 +342,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center pb-2">
+                        <div className="absolute inset-0 flex items-center justify-center pb-4">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -334,7 +334,7 @@ export default function Activity({ studyData, studyId }) {
                   <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative">
+                  <div className="flex-1 relative pb-2">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -342,7 +342,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center">
+                        <div className="absolute inset-0 flex items-center justify-center pb-2">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -331,12 +331,12 @@ export default function Activity({ studyData, studyId }) {
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="absolute top-1.5 right-2 z-10">
-                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
-                  </div>
-                  <div className="flex-1 relative">
-                    {chartShape === 'polar' ? (
-                      <>
+                  {chartShape === 'polar' ? (
+                    <>
+                      <div className="absolute top-1.5 right-2 z-10">
+                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                      </div>
+                      <div className="flex-1 relative">
                         <DailyActivityRadar
                           activityData={dailyActivityData}
                           selectedSpecies={selectedSpecies}
@@ -351,16 +351,23 @@ export default function Activity({ studyData, studyId }) {
                             chipSectors={visualRanges}
                           />
                         </div>
-                      </>
-                    ) : (
-                      <DailyActivityLine
-                        activityData={dailyActivityData}
-                        selectedSpecies={selectedSpecies}
-                        palette={palette}
-                        selectedRanges={visualRanges}
-                      />
-                    )}
-                  </div>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="flex justify-end px-2 pt-1.5">
+                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                      </div>
+                      <div className="flex-1 relative">
+                        <DailyActivityLine
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                          selectedRanges={visualRanges}
+                        />
+                      </div>
+                    </>
+                  )}
                   <div className="flex justify-center px-2 pb-1.5">
                     <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
                   </div>

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useParams, useSearchParams } from 'react-router'
-import CircularTimeFilter, { DailyActivityRadar } from './ui/clock'
+import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
+import DayPeriodChips from './ui/dayPeriodChips'
+import ChartShapeToggle from './ui/chartShapeToggle'
+import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
@@ -34,7 +37,16 @@ export default function Activity({ studyData, studyId }) {
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
   const [dateRange, setDateRange] = useState([null, null])
   const [fullExtent, setFullExtent] = useState([null, null])
-  const [timeRange, setTimeRange] = useState({ start: 0, end: 24 })
+  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [arc, setArc] = useState({ start: 0, end: 24 })
+  const [chartShape, setChartShape] = useState('polar')
+
+  // Derive the timeRange payload sent to the backend. Chips win; with no
+  // chips, the freeform drag-arc supplies the (zero or one) range.
+  const timeRange = useMemo(() => {
+    const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
+    return { ranges }
+  }, [chipSelection, arc])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
 
   // Sequence gap - uses React Query for sync across components
@@ -220,9 +232,8 @@ export default function Activity({ studyData, studyId }) {
     refetchInterval: importStatus?.isRunning ? 5000 : false
   })
 
-  // Handle time range changes
-  const handleTimeRangeChange = useCallback((newTimeRange) => {
-    setTimeRange(newTimeRange)
+  const handleArcChange = useCallback((newArc) => {
+    setArc(newArc)
   }, [])
 
   // Handle species selection changes
@@ -303,18 +314,37 @@ export default function Activity({ studyData, studyId }) {
           >
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[130px] gap-3">
-                <div className="w-[140px] h-full rounded border border-border flex items-center justify-center relative">
-                  <DailyActivityRadar
-                    activityData={dailyActivityData}
-                    selectedSpecies={selectedSpecies}
-                    palette={palette}
-                  />
-                  <div className="absolute w-full h-full flex items-center justify-center">
-                    <CircularTimeFilter
-                      onChange={handleTimeRangeChange}
-                      startTime={timeRange.start}
-                      endTime={timeRange.end}
-                    />
+                <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
+                  <div className="flex items-center justify-between px-2 pt-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                  </div>
+                  <div className="flex-1 relative">
+                    {chartShape === 'polar' ? (
+                      <>
+                        <DailyActivityRadar
+                          activityData={dailyActivityData}
+                          selectedSpecies={selectedSpecies}
+                          palette={palette}
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <CircularTimeFilter
+                            onChange={handleArcChange}
+                            startTime={arc.start}
+                            endTime={arc.end}
+                            mode={chipSelection.size > 0 ? 'chips' : 'drag'}
+                            chipSectors={chipsToRanges(chipSelection)}
+                          />
+                        </div>
+                      </>
+                    ) : (
+                      <DailyActivityLine
+                        activityData={dailyActivityData}
+                        selectedSpecies={selectedSpecies}
+                        palette={palette}
+                        selectedRanges={timeRange.ranges}
+                      />
+                    )}
                   </div>
                 </div>
                 <div className="flex-grow rounded px-2 border border-border">

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -57,12 +57,18 @@ export default function Activity({ studyData, studyId }) {
     return { ranges }
   }, [chipSelection, arc])
 
-  // Merged ranges for VISUAL highlighting in the polar/x-y chart. All four
-  // chips collapses to a single full-day arc.
-  const visualRanges = useMemo(
-    () => (chipSelection.size > 0 ? mergeChipRanges(chipsToRanges(chipSelection)) : []),
-    [chipSelection]
-  )
+  // Merged ranges for VISUAL highlighting in the polar/x-y chart. Chips
+  // collapse to merged contiguous arcs; with no chips, the freeform
+  // drag-arc selection is mirrored into the x-y view too (same underlying
+  // filter). All four chips collapses to a single full-day arc.
+  const visualRanges = useMemo(() => {
+    if (chipSelection.size > 0) return mergeChipRanges(chipsToRanges(chipSelection))
+    return arcToRanges(arc)
+  }, [chipSelection, arc])
+
+  // Indicator dot on the filter-charts toggle: true when any time-of-day
+  // filter is active (chips or partial drag-arc).
+  const isFiltering = useMemo(() => timeRange.ranges.length > 0, [timeRange])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
 
   // Sequence gap - uses React Query for sync across components
@@ -294,6 +300,7 @@ export default function Activity({ studyData, studyId }) {
                   // for studies that DO have timestamps; only hide it once
                   // we've confirmed the study has none.
                   hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
+                  isFiltering={isFiltering}
                 />
               )}
               {speciesDistributionData && (

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -331,10 +331,10 @@ export default function Activity({ studyData, studyId }) {
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="flex justify-end px-2 pt-1.5">
+                  <div className="absolute top-1.5 right-2 z-10">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
-                  <div className="flex-1 relative pb-4">
+                  <div className="flex-1 relative">
                     {chartShape === 'polar' ? (
                       <>
                         <DailyActivityRadar
@@ -342,7 +342,7 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
-                        <div className="absolute inset-0 flex items-center justify-center pb-4">
+                        <div className="absolute inset-0 flex items-center justify-center">
                           <CircularTimeFilter
                             onChange={handleArcChange}
                             startTime={arc.start}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -371,6 +371,9 @@ export default function Activity({ studyData, studyId }) {
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                           selectedRanges={visualRanges}
+                          onArcChange={
+                            chipSelection.size === 0 ? handleArcChange : undefined
+                          }
                         />
                       </div>
                     </>

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -307,16 +307,15 @@ export default function Activity({ studyData, studyId }) {
           <div
             className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
               showFilterCharts && hasTemporalData
-                ? 'h-[130px] opacity-100 mt-4'
+                ? 'h-[180px] opacity-100 mt-4'
                 : 'h-0 opacity-0 mt-0'
             }`}
             aria-hidden={!(showFilterCharts && hasTemporalData)}
           >
             {speciesInitialized && sequenceGap !== undefined && (
-              <div className="w-full flex h-[130px] gap-3">
+              <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  <div className="flex items-center justify-between px-2 pt-1.5">
-                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
+                  <div className="flex justify-end px-2 pt-1.5">
                     <ChartShapeToggle value={chartShape} onChange={setChartShape} />
                   </div>
                   <div className="flex-1 relative">
@@ -345,6 +344,9 @@ export default function Activity({ studyData, studyId }) {
                         selectedRanges={timeRange.ranges}
                       />
                     )}
+                  </div>
+                  <div className="flex justify-center px-2 pb-1.5">
+                    <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
                   </div>
                 </div>
                 <div className="flex-grow rounded px-2 border border-border">

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -4,7 +4,13 @@ import { useParams, useSearchParams } from 'react-router'
 import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './ui/clock'
 import DayPeriodChips from './ui/dayPeriodChips'
 import ChartShapeToggle from './ui/chartShapeToggle'
-import { chipsToRanges, arcToRanges } from './utils/dayPeriods'
+import {
+  ALL_CHIPS_SELECTED,
+  arcToRanges,
+  chipsToRanges,
+  DAY_PERIOD_ORDER,
+  mergeChipRanges
+} from './utils/dayPeriods'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
@@ -37,16 +43,26 @@ export default function Activity({ studyData, studyId }) {
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
   const [dateRange, setDateRange] = useState([null, null])
   const [fullExtent, setFullExtent] = useState([null, null])
-  const [chipSelection, setChipSelection] = useState(() => new Set())
+  const [chipSelection, setChipSelection] = useState(() => new Set(ALL_CHIPS_SELECTED))
   const [arc, setArc] = useState({ start: 0, end: 24 })
   const [chartShape, setChartShape] = useState('polar')
 
-  // Derive the timeRange payload sent to the backend. Chips win; with no
-  // chips, the freeform drag-arc supplies the (zero or one) range.
+  // Derive the timeRange payload sent to the backend. Chip selections drive
+  // the filter; selecting all four (the default) is treated as "no filter"
+  // so null-timestamp media still shows, mirroring the timeline default.
+  // With zero chips selected, the freeform drag-arc supplies the range.
   const timeRange = useMemo(() => {
+    if (chipSelection.size === DAY_PERIOD_ORDER.length) return { ranges: [] }
     const ranges = chipSelection.size > 0 ? chipsToRanges(chipSelection) : arcToRanges(arc)
     return { ranges }
   }, [chipSelection, arc])
+
+  // Merged ranges for VISUAL highlighting in the polar/x-y chart. All four
+  // chips collapses to a single full-day arc.
+  const visualRanges = useMemo(
+    () => (chipSelection.size > 0 ? mergeChipRanges(chipsToRanges(chipSelection)) : []),
+    [chipSelection]
+  )
   const { importStatus } = useImportStatus(actualStudyId, 5000)
 
   // Sequence gap - uses React Query for sync across components
@@ -332,7 +348,7 @@ export default function Activity({ studyData, studyId }) {
                             startTime={arc.start}
                             endTime={arc.end}
                             mode={chipSelection.size > 0 ? 'chips' : 'drag'}
-                            chipSectors={chipsToRanges(chipSelection)}
+                            chipSectors={visualRanges}
                           />
                         </div>
                       </>
@@ -341,7 +357,7 @@ export default function Activity({ studyData, studyId }) {
                         activityData={dailyActivityData}
                         selectedSpecies={selectedSpecies}
                         palette={palette}
-                        selectedRanges={timeRange.ranges}
+                        selectedRanges={visualRanges}
                       />
                     )}
                   </div>

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -338,12 +338,12 @@ export default function Activity({ studyData, studyId }) {
             {speciesInitialized && sequenceGap !== undefined && (
               <div className="w-full flex h-[180px] gap-3">
                 <div className="w-[180px] h-full rounded border border-border flex flex-col relative">
-                  {chartShape === 'polar' ? (
-                    <>
-                      <div className="absolute top-1.5 right-2 z-10">
-                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
-                      </div>
-                      <div className="flex-1 relative">
+                  <div className="absolute top-1.5 right-2 z-10">
+                    <ChartShapeToggle value={chartShape} onChange={setChartShape} />
+                  </div>
+                  <div className="flex-1 relative">
+                    {chartShape === 'polar' ? (
+                      <>
                         <DailyActivityRadar
                           activityData={dailyActivityData}
                           selectedSpecies={selectedSpecies}
@@ -358,26 +358,17 @@ export default function Activity({ studyData, studyId }) {
                             chipSectors={visualRanges}
                           />
                         </div>
-                      </div>
-                    </>
-                  ) : (
-                    <>
-                      <div className="flex justify-end px-2 pt-1.5">
-                        <ChartShapeToggle value={chartShape} onChange={setChartShape} />
-                      </div>
-                      <div className="flex-1 relative">
-                        <DailyActivityLine
-                          activityData={dailyActivityData}
-                          selectedSpecies={selectedSpecies}
-                          palette={palette}
-                          selectedRanges={visualRanges}
-                          onArcChange={
-                            chipSelection.size === 0 ? handleArcChange : undefined
-                          }
-                        />
-                      </div>
-                    </>
-                  )}
+                      </>
+                    ) : (
+                      <DailyActivityLine
+                        activityData={dailyActivityData}
+                        selectedSpecies={selectedSpecies}
+                        palette={palette}
+                        selectedRanges={visualRanges}
+                        onArcChange={chipSelection.size === 0 ? handleArcChange : undefined}
+                      />
+                    )}
+                  </div>
                   <div className="flex justify-center px-2 pb-1.5">
                     <DayPeriodChips selection={chipSelection} onChange={setChipSelection} />
                   </div>

--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -2181,8 +2181,7 @@ function Gallery({
       JSON.stringify(species),
       dateRange[0]?.toISOString(),
       dateRange[1]?.toISOString(),
-      timeRange.start,
-      timeRange.end,
+      JSON.stringify(timeRange.ranges ?? [{ start: timeRange.start, end: timeRange.end }]),
       includeNullTimestamps
     ],
     queryFn: async ({ pageParam = null }) => {

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -15,7 +15,7 @@ import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
  * `hasTemporalData` is forwarded to {@link FilterChartsToggle} so studies
  * without media timestamps don't show a toggle that can't do anything.
  */
-export default function GalleryDisplayStrip({ studyId, hasTemporalData }) {
+export default function GalleryDisplayStrip({ studyId, hasTemporalData, isFiltering = false }) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(studyId)
   const { showThumbnailBboxes, setShowThumbnailBboxes } = useShowThumbnailBboxes(studyId)
 
@@ -72,7 +72,11 @@ export default function GalleryDisplayStrip({ studyId, hasTemporalData }) {
             </Tooltip.Portal>
           </Tooltip.Root>
         )}
-        <FilterChartsToggle studyId={studyId} hasTemporalData={hasTemporalData} />
+        <FilterChartsToggle
+          studyId={studyId}
+          hasTemporalData={hasTemporalData}
+          isFiltering={isFiltering}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -59,6 +59,12 @@ export default function FilterChartsToggle({
           <p className="text-muted-foreground leading-snug">
             Daily-activity clock and timeline filters.
           </p>
+          {isFiltering && (
+            <p className="mt-1.5 text-blue-600 dark:text-blue-400 leading-snug">
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 mr-1 align-middle" />
+              Filters active
+            </p>
+          )}
           <Tooltip.Arrow className="fill-popover" />
         </Tooltip.Content>
       </Tooltip.Portal>

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -16,7 +16,11 @@ import { useShowFilterCharts } from '../hooks/useShowFilterCharts'
  * Visual treatment mirrors the bbox toggle in GalleryDisplayStrip so the
  * two icons read as a coherent set in the gap-slider strip.
  */
-export default function FilterChartsToggle({ studyId, hasTemporalData = true }) {
+export default function FilterChartsToggle({
+  studyId,
+  hasTemporalData = true,
+  isFiltering = false
+}) {
   const { showFilterCharts, setShowFilterCharts } = useShowFilterCharts(studyId)
 
   if (!hasTemporalData) return null
@@ -26,7 +30,7 @@ export default function FilterChartsToggle({ studyId, hasTemporalData = true }) 
       <Tooltip.Trigger asChild>
         <button
           onClick={() => setShowFilterCharts((prev) => !prev)}
-          className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+          className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors relative ${
             showFilterCharts
               ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
               : 'text-muted-foreground hover:bg-accent'
@@ -34,6 +38,12 @@ export default function FilterChartsToggle({ studyId, hasTemporalData = true }) 
           aria-label={showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
         >
           <SlidersHorizontal size={16} />
+          {isFiltering && (
+            <span
+              className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-blue-500 ring-1 ring-background"
+              aria-label="Filters active"
+            />
+          )}
         </button>
       </Tooltip.Trigger>
       <Tooltip.Portal>

--- a/src/renderer/src/ui/chartShapeToggle.jsx
+++ b/src/renderer/src/ui/chartShapeToggle.jsx
@@ -17,7 +17,7 @@ const SHAPES = [
 export default function ChartShapeToggle({ value, onChange }) {
   return (
     <div
-      className="inline-flex items-stretch rounded-md border border-border overflow-hidden"
+      className="inline-flex items-stretch rounded-md border border-border bg-background overflow-hidden"
       role="radiogroup"
       aria-label="Chart shape"
     >

--- a/src/renderer/src/ui/chartShapeToggle.jsx
+++ b/src/renderer/src/ui/chartShapeToggle.jsx
@@ -1,0 +1,51 @@
+import { ChartPie, ChartLine } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+
+/**
+ * Two-button group that switches the daily-activity chart between the
+ * polar radar and the x-y line. Sits in the top-right of the clock card.
+ *
+ * Props:
+ *   value: 'polar' | 'xy'
+ *   onChange: (next) => void
+ */
+const SHAPES = [
+  { key: 'polar', label: 'Polar', Icon: ChartPie },
+  { key: 'xy', label: 'X–Y line', Icon: ChartLine }
+]
+
+export default function ChartShapeToggle({ value, onChange }) {
+  return (
+    <div className="flex gap-0.5">
+      {SHAPES.map(({ key, label, Icon }) => {
+        const active = value === key
+        return (
+          <Tooltip.Root key={key}>
+            <Tooltip.Trigger asChild>
+              <button
+                onClick={() => onChange(key)}
+                className={`w-5 h-5 rounded flex items-center justify-center transition-colors ${
+                  active ? 'bg-foreground text-background' : 'text-muted-foreground hover:bg-accent'
+                }`}
+                aria-label={label}
+                aria-pressed={active}
+              >
+                <Icon size={12} />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="bottom"
+                sideOffset={6}
+                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              >
+                {label}
+                <Tooltip.Arrow className="fill-popover" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/ui/chartShapeToggle.jsx
+++ b/src/renderer/src/ui/chartShapeToggle.jsx
@@ -16,26 +16,37 @@ const SHAPES = [
 
 export default function ChartShapeToggle({ value, onChange }) {
   return (
-    <div className="flex gap-0.5">
-      {SHAPES.map(({ key, label, Icon }) => {
+    <div
+      className="inline-flex items-stretch rounded-md border border-border overflow-hidden"
+      role="radiogroup"
+      aria-label="Chart shape"
+    >
+      {SHAPES.map(({ key, label, Icon }, idx) => {
         const active = value === key
+        const isFirst = idx === 0
         return (
           <Tooltip.Root key={key}>
             <Tooltip.Trigger asChild>
               <button
                 onClick={() => onChange(key)}
-                className={`w-5 h-5 rounded flex items-center justify-center transition-colors ${
-                  active ? 'bg-foreground text-background' : 'text-muted-foreground hover:bg-accent'
+                className={`px-1.5 py-0.5 flex items-center justify-center transition-colors ${
+                  isFirst ? '' : 'border-l border-border'
+                } ${
+                  active
+                    ? 'bg-blue-50 text-blue-600 dark:bg-blue-500/15 dark:text-blue-400'
+                    : 'text-muted-foreground hover:bg-accent'
                 }`}
                 aria-label={label}
                 aria-pressed={active}
+                role="radio"
+                aria-checked={active}
               >
                 <Icon size={12} />
               </button>
             </Tooltip.Trigger>
             <Tooltip.Portal>
               <Tooltip.Content
-                side="bottom"
+                side="top"
                 sideOffset={6}
                 className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
               >

--- a/src/renderer/src/ui/chartShapeToggle.jsx
+++ b/src/renderer/src/ui/chartShapeToggle.jsx
@@ -40,7 +40,6 @@ export default function ChartShapeToggle({ value, onChange }) {
                 className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
               >
                 {label}
-                <Tooltip.Arrow className="fill-popover" />
               </Tooltip.Content>
             </Tooltip.Portal>
           </Tooltip.Root>

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -469,17 +469,22 @@ const DailyActivityLine = ({
   }
 
   const handleMouseUp = () => {
-    if (isDragging) {
-      const { mode, liveStart, liveEnd } = dragState
-      if (mode === 'pan') {
-        onArcChange({ start: liveStart, end: liveEnd })
-      } else if (liveStart !== liveEnd) {
-        const start = Math.min(liveStart, liveEnd)
-        const end = Math.max(liveStart, liveEnd)
-        onArcChange({ start, end })
+    // Use functional setState so we read the LATEST drag state (the
+    // document-level listener was registered with a stale closure
+    // otherwise — committed band would lag the cursor).
+    setDragState((prev) => {
+      if (prev) {
+        const { mode, liveStart, liveEnd } = prev
+        if (mode === 'pan') {
+          onArcChange({ start: liveStart, end: liveEnd })
+        } else if (liveStart !== liveEnd) {
+          const start = Math.min(liveStart, liveEnd)
+          const end = Math.max(liveStart, liveEnd)
+          onArcChange({ start, end })
+        }
       }
-    }
-    setDragState(null)
+      return null
+    })
   }
   const formatData = (data) => {
     if (!data || !data.length) {
@@ -596,6 +601,8 @@ const DailyActivityLine = ({
   }
   const handleNativeDown = (e) => {
     if (!dragEnabled) return
+    // Stop the native drag-selects-text behavior the moment we start handling.
+    e.preventDefault()
     const cursor = eventToHour(e)
     if (cursor === null) return
     if (!hasSingleBand) {
@@ -625,7 +632,7 @@ const DailyActivityLine = ({
   return (
     <div
       ref={containerRef}
-      className={`relative w-full h-full ${cursorClass}`}
+      className={`relative w-full h-full select-none ${cursorClass}`}
       onMouseDown={handleNativeDown}
       onMouseMove={handleNativeMove}
       onMouseLeave={handleNativeLeave}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -363,39 +363,18 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
   }
   const formattedData = formatData(activityData)
 
-  // Build off-period bands: 24h minus the union of selectedRanges.
-  // For wrap-around ranges (start > end), split into two pieces first.
-  const flattened = []
+  // Highlight the SELECTED ranges (consistent with the polar's blue arc).
+  // Wrap-around ranges (start > end) split into two pieces.
+  const selectedBands = []
   for (const r of selectedRanges) {
     if (r.start === r.end) continue
     if (r.start < r.end) {
-      flattened.push([r.start, r.end])
+      selectedBands.push([r.start, r.end])
     } else {
-      flattened.push([r.start, 24])
-      flattened.push([0, r.end])
+      selectedBands.push([r.start, 24])
+      selectedBands.push([0, r.end])
     }
   }
-  flattened.sort((a, b) => a[0] - b[0])
-
-  // Merge overlapping covered intervals.
-  const covered = []
-  for (const [s, e] of flattened) {
-    if (covered.length && s <= covered[covered.length - 1][1]) {
-      covered[covered.length - 1][1] = Math.max(covered[covered.length - 1][1], e)
-    } else {
-      covered.push([s, e])
-    }
-  }
-
-  // Off-bands = complement of covered within [0, 24].
-  const offBands = []
-  let cursor = 0
-  for (const [s, e] of covered) {
-    if (s > cursor) offBands.push([cursor, s])
-    cursor = e
-  }
-  if (cursor < 24) offBands.push([cursor, 24])
-  const showShading = covered.length > 0
 
   return (
     <div className="relative w-full h-full">
@@ -412,17 +391,18 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
             tickLine={false}
           />
           <YAxis hide domain={[0, 'auto']} />
-          {showShading &&
-            offBands.map(([s, e], i) => (
-              <ReferenceArea
-                key={i}
-                x1={s}
-                x2={e}
-                fill="var(--color-muted)"
-                fillOpacity={0.5}
-                strokeOpacity={0}
-              />
-            ))}
+          {selectedBands.map(([s, e], i) => (
+            <ReferenceArea
+              key={i}
+              x1={s}
+              x2={e}
+              fill="rgb(59 130 246)"
+              fillOpacity={0.15}
+              stroke="rgb(59 130 246)"
+              strokeOpacity={0.5}
+              strokeWidth={1}
+            />
+          ))}
           {selectedSpecies.map((species, index) => (
             <Line
               key={species.scientificName}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -306,25 +306,27 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
   return (
     <div className="relative w-full h-full flex items-center justify-center" ref={chartRef}>
       {/* Inner square anchors the hour labels to the radar's actual edges,
-          not the (potentially wider-than-tall) parent. */}
+          not the (potentially wider-than-tall) parent. Labels sit at the
+          edges of this square; the radar inside has a margin so its circle
+          sits well clear of them. */}
       <div className="relative h-full aspect-square">
         <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-0.5 left-1/2 -translate-x-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute top-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
             0h
           </div>
-          <div className="absolute top-1/2 right-0.5 -translate-y-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute top-1/2 right-0 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
             6h
           </div>
-          <div className="absolute bottom-0.5 left-1/2 -translate-x-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
             12h
           </div>
-          <div className="absolute top-1/2 left-0.5 -translate-y-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute top-1/2 left-0 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
             18h
           </div>
         </div>
 
         <ResponsiveContainer width="100%" height="100%">
-          <RadarChart data={formattedData} margin={{ top: 16, right: 16, bottom: 16, left: 16 }}>
+          <RadarChart data={formattedData} margin={{ top: 22, right: 22, bottom: 22, left: 22 }}>
             <PolarGrid radialLines={false} polarRadius={[]} strokeWidth={1} />
             <PolarAngleAxis dataKey="name" tick={false} />
             {/* <PolarRadiusAxis

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -408,48 +408,86 @@ const DailyActivityLine = ({
   selectedRanges = [],
   onArcChange
 }) => {
-  // Drag is enabled when:
-  //   - a single non-wrap-around range exists → slide its end edge
-  //   - OR no range exists (custom selection is empty) → drag-to-create
-  // Multi-range or wrap-around selections aren't draggable on the x-y view.
-  const hasSingleBand =
-    selectedRanges.length === 1 && selectedRanges[0].start < selectedRanges[0].end
+  // Drag interactions on the x-y chart:
+  //   - click NEAR the end edge of an existing band  → slide the end edge
+  //   - click INSIDE the band (not near edge)         → pan the whole band
+  //                                                     (wraps at midnight)
+  //   - click OUTSIDE any band, or no band at all     → drag-to-create
+  // Wrap-around selections are panned but not edge-slid.
+  const hasSingleBand = selectedRanges.length === 1
+  const isWrapBand = hasSingleBand && selectedRanges[0].start >= selectedRanges[0].end
   const dragEnabled =
     typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
-  const committedStart = hasSingleBand ? selectedRanges[0].start : null
-  const committedEnd = hasSingleBand ? selectedRanges[0].end : null
 
-  // Pivot is the fixed edge during a drag — the band's existing start when
-  // sliding, the cursor down-position when creating a new range.
-  const [dragPivot, setDragPivot] = useState(null)
-  const [dragEnd, setDragEnd] = useState(null)
-  const isDragging = dragPivot !== null && dragEnd !== null
+  const [dragState, setDragState] = useState(null)
+  // dragState shape:
+  //   { mode: 'end',    liveStart, liveEnd }
+  //   { mode: 'pan',    liveStart, liveEnd, panOffset, panWidth }
+  //   { mode: 'create', liveStart, liveEnd }
+  const isDragging = dragState !== null
 
   const clamp = (v) => Math.max(0, Math.min(24, v))
+
+  // Whether `cursor` is inside the (possibly wrap-around) band.
+  const isInsideBand = (cursor, band) => {
+    if (band.start < band.end) return cursor > band.start && cursor < band.end
+    return cursor > band.start || cursor < band.end
+  }
 
   const handleMouseDown = (e) => {
     if (!dragEnabled || !e || e.activeLabel === undefined || e.activeLabel === null) return
     const cursor = clamp(e.activeLabel)
-    setDragPivot(hasSingleBand ? committedStart : cursor)
-    setDragEnd(cursor)
+    if (!hasSingleBand) {
+      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+      return
+    }
+    const { start, end } = selectedRanges[0]
+    const width = isWrapBand ? 24 - start + end : end - start
+    const edgeTol = Math.min(1.5, width / 3)
+    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) {
+      // slide end: pivot = start, moving = end
+      setDragState({ mode: 'end', liveStart: start, liveEnd: cursor })
+    } else if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) {
+      // slide start: pivot = end, moving = start
+      setDragState({ mode: 'start', liveStart: cursor, liveEnd: end })
+    } else if (isInsideBand(cursor, { start, end })) {
+      const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
+      setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
+    } else {
+      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+    }
   }
+
   const handleMouseMove = (e) => {
     if (!isDragging || !e || e.activeLabel === undefined || e.activeLabel === null) return
-    setDragEnd(clamp(e.activeLabel))
+    const cursor = clamp(e.activeLabel)
+    setDragState((prev) => {
+      if (!prev) return prev
+      if (prev.mode === 'pan') {
+        const newStart = (((cursor - prev.panOffset) % 24) + 24) % 24
+        const newEnd = (newStart + prev.panWidth) % 24
+        return { ...prev, liveStart: newStart, liveEnd: newEnd }
+      }
+      if (prev.mode === 'start') return { ...prev, liveStart: cursor }
+      // end / create
+      return { ...prev, liveEnd: cursor }
+    })
   }
+
   const handleMouseUp = () => {
-    if (isDragging && dragEnd !== dragPivot) {
-      const start = Math.min(dragPivot, dragEnd)
-      const end = Math.max(dragPivot, dragEnd)
-      onArcChange({ start, end })
+    if (isDragging) {
+      const { mode, liveStart, liveEnd } = dragState
+      if (mode === 'pan') {
+        onArcChange({ start: liveStart, end: liveEnd })
+      } else if (liveStart !== liveEnd) {
+        const start = Math.min(liveStart, liveEnd)
+        const end = Math.max(liveStart, liveEnd)
+        onArcChange({ start, end })
+      }
     }
-    setDragPivot(null)
-    setDragEnd(null)
+    setDragState(null)
   }
-  const handleMouseLeave = () => {
-    setDragPivot(null)
-    setDragEnd(null)
-  }
+  const handleMouseLeave = () => setDragState(null)
   const formatData = (data) => {
     if (!data || !data.length) {
       return Array(24)
@@ -473,13 +511,46 @@ const DailyActivityLine = ({
     }
   }
 
-  // Live band while dragging — covers from pivot to current cursor.
-  const liveBand = isDragging
-    ? [Math.min(dragPivot, dragEnd), Math.max(dragPivot, dragEnd)]
-    : null
-  // Where to draw the end-line + handle. While dragging, follow the cursor;
-  // otherwise pin to the committed band end (only when a band exists).
-  const endLineX = isDragging ? dragEnd : committedEnd
+  // Convert a (possibly wrap-around) {start, end} band into one or two
+  // ReferenceArea-friendly [s, e] segments.
+  const bandToSegments = (band) => {
+    if (band.start === band.end) return []
+    if (band.start < band.end) return [[band.start, band.end]]
+    return [
+      [band.start, 24],
+      [0, band.end]
+    ]
+  }
+  // Live band while dragging — for pan it can wrap around midnight.
+  const liveBand = (() => {
+    if (!isDragging) return null
+    const { mode, liveStart, liveEnd } = dragState
+    if (mode === 'pan') return { start: liveStart, end: liveEnd }
+    return { start: Math.min(liveStart, liveEnd), end: Math.max(liveStart, liveEnd) }
+  })()
+  const liveSegments = liveBand ? bandToSegments(liveBand) : []
+
+  // Edge-line positions for the visible handles.
+  const handleStartX = (() => {
+    if (isDragging) {
+      const { mode, liveStart, liveEnd } = dragState
+      if (mode === 'pan') return liveStart
+      if (mode === 'create') return Math.min(liveStart, liveEnd)
+      return Math.min(liveStart, liveEnd)
+    }
+    if (hasSingleBand && !isWrapBand) return selectedRanges[0].start
+    return null
+  })()
+  const handleEndX = (() => {
+    if (isDragging) {
+      const { mode, liveStart, liveEnd } = dragState
+      if (mode === 'pan') return liveEnd
+      if (mode === 'create') return Math.max(liveStart, liveEnd)
+      return Math.max(liveStart, liveEnd)
+    }
+    if (hasSingleBand && !isWrapBand) return selectedRanges[0].end
+    return null
+  })()
 
   return (
     <div className={`relative w-full h-full ${dragEnabled ? 'cursor-ew-resize' : ''}`}>
@@ -503,41 +574,63 @@ const DailyActivityLine = ({
             tickLine={false}
           />
           <YAxis hide domain={[0, 'auto']} />
-          {/* While sliding the end edge, show only the live band so the
-              user sees the in-progress range. Otherwise show committed bands. */}
-          {isDragging && liveBand ? (
-            <ReferenceArea
-              x1={liveBand[0]}
-              x2={liveBand[1]}
-              fill="rgb(59 130 246)"
-              fillOpacity={0.2}
-              stroke="rgb(59 130 246)"
-              strokeOpacity={0.7}
-              strokeWidth={1}
-            />
-          ) : (
-            selectedBands.map(([s, e], i) => (
-              <ReferenceArea
-                key={i}
-                x1={s}
-                x2={e}
-                fill="rgb(59 130 246)"
-                fillOpacity={0.15}
-                stroke="rgb(59 130 246)"
-                strokeOpacity={0.5}
-                strokeWidth={1}
-              />
-            ))
-          )}
-          {/* Draggable end-line with a small handle dot at the top. */}
-          {dragEnabled && endLineX !== null && (
+          {/* While dragging, show only the live band; otherwise the committed bands. */}
+          {isDragging
+            ? liveSegments.map(([s, e], i) => (
+                <ReferenceArea
+                  key={i}
+                  x1={s}
+                  x2={e}
+                  fill="rgb(59 130 246)"
+                  fillOpacity={0.2}
+                  stroke="rgb(59 130 246)"
+                  strokeOpacity={0.7}
+                  strokeWidth={1}
+                />
+              ))
+            : selectedBands.map(([s, e], i) => (
+                <ReferenceArea
+                  key={i}
+                  x1={s}
+                  x2={e}
+                  fill="rgb(59 130 246)"
+                  fillOpacity={0.15}
+                  stroke="rgb(59 130 246)"
+                  strokeOpacity={0.5}
+                  strokeWidth={1}
+                />
+              ))}
+          {/* Draggable start-line handle. */}
+          {dragEnabled && handleStartX !== null && (
             <ReferenceLine
-              x={endLineX}
+              x={handleStartX}
               stroke="rgb(59 130 246)"
               strokeWidth={2}
               isFront
               label={{
-                value: '',
+                position: 'top',
+                content: ({ viewBox }) =>
+                  viewBox && viewBox.x !== undefined ? (
+                    <circle
+                      cx={viewBox.x}
+                      cy={viewBox.y + 6}
+                      r={4}
+                      fill="rgb(59 130 246)"
+                      stroke="white"
+                      strokeWidth={1}
+                    />
+                  ) : null
+              }}
+            />
+          )}
+          {/* Draggable end-line handle. */}
+          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
+            <ReferenceLine
+              x={handleEndX}
+              stroke="rgb(59 130 246)"
+              strokeWidth={2}
+              isFront
+              label={{
                 position: 'top',
                 content: ({ viewBox }) =>
                   viewBox && viewBox.x !== undefined ? (

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -466,8 +466,7 @@ const DailyActivityLine = ({
     const width = isWrapBand ? 24 - start + end : end - start
     const edgeTol = edgeTolFor(width)
     if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) return 'edge-end'
-    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol)
-      return 'edge-start'
+    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) return 'edge-start'
     if (isInsideBand(cursor, { start, end })) return 'pan'
     return 'create'
   }
@@ -568,11 +567,12 @@ const DailyActivityLine = ({
   })()
   // Which edge (if any) is currently being hovered — used to make the
   // corresponding handle dot pop visually.
-  const hoveredEdge = hoverAction === 'edge-start' || (isDragging && dragState.mode === 'start')
-    ? 'start'
-    : hoverAction === 'edge-end' || (isDragging && dragState.mode === 'end')
-      ? 'end'
-      : null
+  const hoveredEdge =
+    hoverAction === 'edge-start' || (isDragging && dragState.mode === 'start')
+      ? 'start'
+      : hoverAction === 'edge-end' || (isDragging && dragState.mode === 'end')
+        ? 'end'
+        : null
 
   // While a drag is in progress, listen on the document so the user can
   // move the cursor outside the chart and the drag keeps tracking. For

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -433,8 +433,10 @@ const DailyActivityLine = ({
 
   // Convert a native pointer event to a chart-x hour value, accounting for
   // the ComposedChart's left/right margin so the hover preview matches what
-  // a click would actually hit.
-  const eventToHour = (e) => {
+  // a click would actually hit. When `clamp01` is false the result can fall
+  // outside [0, 24] — used during pan so the band keeps wrapping past the
+  // chart's edge.
+  const eventToHour = (e, { clamp01 = true } = {}) => {
     if (!containerRef.current) return null
     const rect = containerRef.current.getBoundingClientRect()
     const marginLeft = 8
@@ -442,7 +444,8 @@ const DailyActivityLine = ({
     const innerWidth = rect.width - marginLeft - marginRight
     if (innerWidth <= 0) return null
     const xPx = e.clientX - rect.left - marginLeft
-    const ratio = Math.max(0, Math.min(1, xPx / innerWidth))
+    const rawRatio = xPx / innerWidth
+    const ratio = clamp01 ? Math.max(0, Math.min(1, rawRatio)) : rawRatio
     return ratio * 24
   }
 
@@ -552,15 +555,17 @@ const DailyActivityLine = ({
     return 'cursor-default'
   })()
 
-  // Native mouse handlers on the wrapping div — these fire reliably for
-  // every pixel inside the chart, unlike Recharts' chart-level events
-  // which only fire near data points.
-  const handleNativeMove = (e) => {
-    const cursor = eventToHour(e)
-    if (cursor === null) return
-    if (isDragging) {
+  // While a drag is in progress, listen on the document so the user can
+  // move the cursor outside the chart and the drag keeps tracking. For
+  // pan mode the cursor is intentionally NOT clamped so the band keeps
+  // wrapping past midnight as the user drags further left/right.
+  useEffect(() => {
+    if (!isDragging) return
+    const onDocMove = (e) => {
       setDragState((prev) => {
         if (!prev) return prev
+        const cursor = eventToHour(e, { clamp01: prev.mode !== 'pan' })
+        if (cursor === null) return prev
         if (prev.mode === 'pan') {
           const newStart = (((cursor - prev.panOffset) % 24) + 24) % 24
           const newEnd = (newStart + prev.panWidth) % 24
@@ -569,9 +574,25 @@ const DailyActivityLine = ({
         if (prev.mode === 'start') return { ...prev, liveStart: cursor }
         return { ...prev, liveEnd: cursor }
       })
-    } else if (dragEnabled) {
-      setHoverAction(actionAt(cursor))
     }
+    const onDocUp = () => handleMouseUp()
+    document.addEventListener('mousemove', onDocMove)
+    document.addEventListener('mouseup', onDocUp)
+    return () => {
+      document.removeEventListener('mousemove', onDocMove)
+      document.removeEventListener('mouseup', onDocUp)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragging])
+
+  // Native mouse handlers on the wrapping div for hover-preview only;
+  // mousedown still starts the drag but mousemove/mouseup are taken over
+  // by the document-level listeners above.
+  const handleNativeMove = (e) => {
+    if (isDragging || !dragEnabled) return
+    const cursor = eventToHour(e)
+    if (cursor === null) return
+    setHoverAction(actionAt(cursor))
   }
   const handleNativeDown = (e) => {
     if (!dragEnabled) return
@@ -595,10 +616,10 @@ const DailyActivityLine = ({
       setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
     }
   }
-  const handleNativeUp = () => handleMouseUp()
+  // Only clear hover preview on leave; never cancel an in-progress drag
+  // (the document-level listeners handle move/up while dragging).
   const handleNativeLeave = () => {
-    setDragState(null)
-    setHoverAction(null)
+    if (!isDragging) setHoverAction(null)
   }
 
   return (
@@ -607,7 +628,6 @@ const DailyActivityLine = ({
       className={`relative w-full h-full ${cursorClass}`}
       onMouseDown={handleNativeDown}
       onMouseMove={handleNativeMove}
-      onMouseUp={handleNativeUp}
       onMouseLeave={handleNativeLeave}
     >
       <ResponsiveContainer width="100%" height="100%">

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -388,14 +388,51 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
 
 /**
  * X–Y twin of DailyActivityRadar. Renders the same hourly-bin data as a
- * line per species across a 24-hour x-axis. Off-period bands (the inverse
- * of `selectedRanges`) are shaded; with no selection, no shading.
+ * line per species across a 24-hour x-axis. Selected ranges are shaded
+ * with the same blue used by the polar arc.
  *
  * Props mirror DailyActivityRadar plus:
  *   selectedRanges: Array<{start, end}> — hour ranges currently in the
- *     filter. Used to shade the *complement* of these as off-period bands.
+ *     filter. Rendered as shaded bands.
+ *   onArcChange: optional ({start, end}) => void — when provided, the
+ *     chart accepts click-and-drag to set a custom hour range. Pass undefined
+ *     (e.g. while chips are driving selection) to disable drag.
  */
-const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRanges = [] }) => {
+const DailyActivityLine = ({
+  activityData,
+  selectedSpecies,
+  palette,
+  selectedRanges = [],
+  onArcChange
+}) => {
+  const [dragStart, setDragStart] = useState(null)
+  const [dragEnd, setDragEnd] = useState(null)
+  const isDragging = dragStart !== null && dragEnd !== null
+  const dragEnabled = typeof onArcChange === 'function'
+
+  const handleMouseDown = (e) => {
+    if (!dragEnabled || !e || e.activeLabel === undefined || e.activeLabel === null) return
+    setDragStart(e.activeLabel)
+    setDragEnd(e.activeLabel)
+  }
+  const handleMouseMove = (e) => {
+    if (!dragEnabled || dragStart === null) return
+    if (!e || e.activeLabel === undefined || e.activeLabel === null) return
+    setDragEnd(e.activeLabel)
+  }
+  const handleMouseUp = () => {
+    if (dragEnabled && dragStart !== null && dragEnd !== null && dragStart !== dragEnd) {
+      const start = Math.max(0, Math.min(dragStart, dragEnd))
+      const end = Math.min(24, Math.max(dragStart, dragEnd))
+      onArcChange({ start, end })
+    }
+    setDragStart(null)
+    setDragEnd(null)
+  }
+  const handleMouseLeave = () => {
+    if (dragStart !== null) setDragStart(null)
+    setDragEnd(null)
+  }
   const formatData = (data) => {
     if (!data || !data.length) {
       return Array(24)
@@ -419,10 +456,25 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
     }
   }
 
+  // Transient band shown live while the user is dragging.
+  const dragBand =
+    isDragging && dragStart !== dragEnd
+      ? [Math.max(0, Math.min(dragStart, dragEnd)), Math.min(24, Math.max(dragStart, dragEnd))]
+      : null
+
   return (
-    <div className="relative w-full h-full">
+    <div
+      className={`relative w-full h-full ${dragEnabled ? 'cursor-crosshair' : ''}`}
+    >
       <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
+        <ComposedChart
+          data={formattedData}
+          margin={{ top: 4, right: 8, bottom: 0, left: 8 }}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={handleMouseLeave}
+        >
           <CartesianGrid strokeOpacity={0} />
           <XAxis
             dataKey="hour"
@@ -434,18 +486,32 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
             tickLine={false}
           />
           <YAxis hide domain={[0, 'auto']} />
-          {selectedBands.map(([s, e], i) => (
+          {/* Committed selection bands — hide while a fresh drag is in
+              progress so the transient drag band is the only highlight. */}
+          {!isDragging &&
+            selectedBands.map(([s, e], i) => (
+              <ReferenceArea
+                key={i}
+                x1={s}
+                x2={e}
+                fill="rgb(59 130 246)"
+                fillOpacity={0.15}
+                stroke="rgb(59 130 246)"
+                strokeOpacity={0.5}
+                strokeWidth={1}
+              />
+            ))}
+          {dragBand && (
             <ReferenceArea
-              key={i}
-              x1={s}
-              x2={e}
+              x1={dragBand[0]}
+              x2={dragBand[1]}
               fill="rgb(59 130 246)"
-              fillOpacity={0.15}
+              fillOpacity={0.2}
               stroke="rgb(59 130 246)"
-              strokeOpacity={0.5}
+              strokeOpacity={0.7}
               strokeWidth={1}
             />
-          ))}
+          )}
           {selectedSpecies.map((species, index) => (
             <Line
               key={species.scientificName}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -1,5 +1,17 @@
 import { useEffect, useRef, useState } from 'react'
-import { PolarAngleAxis, PolarGrid, Radar, RadarChart, ResponsiveContainer } from 'recharts'
+import {
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  ReferenceArea,
+  ResponsiveContainer,
+  XAxis,
+  YAxis
+} from 'recharts'
 
 const CircularTimeFilter = ({
   onChange,
@@ -327,5 +339,102 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
   )
 }
 
-// Export both components
-export { DailyActivityRadar, CircularTimeFilter as default }
+/**
+ * X–Y twin of DailyActivityRadar. Renders the same hourly-bin data as a
+ * line per species across a 24-hour x-axis. Off-period bands (the inverse
+ * of `selectedRanges`) are shaded; with no selection, no shading.
+ *
+ * Props mirror DailyActivityRadar plus:
+ *   selectedRanges: Array<{start, end}> — hour ranges currently in the
+ *     filter. Used to shade the *complement* of these as off-period bands.
+ */
+const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRanges = [] }) => {
+  const formatData = (data) => {
+    if (!data || !data.length) {
+      return Array(24)
+        .fill()
+        .map((_, i) => ({ hour: i }))
+    }
+    return data.map((d) => ({ ...d, hour: d.hour }))
+  }
+  const formattedData = formatData(activityData)
+
+  // Build off-period bands: 24h minus the union of selectedRanges.
+  // For wrap-around ranges (start > end), split into two pieces first.
+  const flattened = []
+  for (const r of selectedRanges) {
+    if (r.start === r.end) continue
+    if (r.start < r.end) {
+      flattened.push([r.start, r.end])
+    } else {
+      flattened.push([r.start, 24])
+      flattened.push([0, r.end])
+    }
+  }
+  flattened.sort((a, b) => a[0] - b[0])
+
+  // Merge overlapping covered intervals.
+  const covered = []
+  for (const [s, e] of flattened) {
+    if (covered.length && s <= covered[covered.length - 1][1]) {
+      covered[covered.length - 1][1] = Math.max(covered[covered.length - 1][1], e)
+    } else {
+      covered.push([s, e])
+    }
+  }
+
+  // Off-bands = complement of covered within [0, 24].
+  const offBands = []
+  let cursor = 0
+  for (const [s, e] of covered) {
+    if (s > cursor) offBands.push([cursor, s])
+    cursor = e
+  }
+  if (cursor < 24) offBands.push([cursor, 24])
+  const showShading = covered.length > 0
+
+  return (
+    <div className="relative w-full h-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+          <CartesianGrid strokeOpacity={0} />
+          <XAxis
+            dataKey="hour"
+            type="number"
+            domain={[0, 23]}
+            ticks={[0, 6, 12, 18, 23]}
+            tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis hide domain={[0, 'auto']} />
+          {showShading &&
+            offBands.map(([s, e], i) => (
+              <ReferenceArea
+                key={i}
+                x1={s}
+                x2={e}
+                fill="var(--color-muted)"
+                fillOpacity={0.5}
+                strokeOpacity={0}
+              />
+            ))}
+          {selectedSpecies.map((species, index) => (
+            <Line
+              key={species.scientificName}
+              type="monotone"
+              dataKey={species.scientificName}
+              stroke={palette[index % palette.length]}
+              strokeWidth={1.5}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}
+
+// Export all components
+export { DailyActivityRadar, DailyActivityLine, CircularTimeFilter as default }

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -417,7 +417,7 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
   return (
     <div className="relative w-full h-full">
       <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+        <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
           <CartesianGrid strokeOpacity={0} />
           <XAxis
             dataKey="hour"

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -422,9 +422,13 @@ const DailyActivityLine = ({
   const [dragState, setDragState] = useState(null)
   // dragState shape:
   //   { mode: 'end',    liveStart, liveEnd }
+  //   { mode: 'start',  liveStart, liveEnd }
   //   { mode: 'pan',    liveStart, liveEnd, panOffset, panWidth }
   //   { mode: 'create', liveStart, liveEnd }
   const isDragging = dragState !== null
+  // Tracks what the cursor is hovering OVER (when not dragging) so we can
+  // preview the action that a click would trigger: 'pan' | 'edge' | null.
+  const [hoverAction, setHoverAction] = useState(null)
 
   const clamp = (v) => Math.max(0, Math.min(24, v))
 
@@ -458,9 +462,29 @@ const DailyActivityLine = ({
     }
   }
 
+  // Compute what action a click at `cursor` would trigger (used for both
+  // hover-cursor previewing and the actual mousedown branch).
+  const actionAt = (cursor) => {
+    if (!hasSingleBand) return 'create'
+    const { start, end } = selectedRanges[0]
+    const width = isWrapBand ? 24 - start + end : end - start
+    const edgeTol = Math.min(1.5, width / 3)
+    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) return 'edge'
+    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) return 'edge'
+    if (isInsideBand(cursor, { start, end })) return 'pan'
+    return 'create'
+  }
+
   const handleMouseMove = (e) => {
-    if (!isDragging || !e || e.activeLabel === undefined || e.activeLabel === null) return
+    if (!e || e.activeLabel === undefined || e.activeLabel === null) {
+      if (!isDragging) setHoverAction(null)
+      return
+    }
     const cursor = clamp(e.activeLabel)
+    if (!isDragging) {
+      if (dragEnabled) setHoverAction(actionAt(cursor))
+      return
+    }
     setDragState((prev) => {
       if (!prev) return prev
       if (prev.mode === 'pan') {
@@ -487,7 +511,10 @@ const DailyActivityLine = ({
     }
     setDragState(null)
   }
-  const handleMouseLeave = () => setDragState(null)
+  const handleMouseLeave = () => {
+    setDragState(null)
+    setHoverAction(null)
+  }
   const formatData = (data) => {
     if (!data || !data.length) {
       return Array(24)
@@ -552,8 +579,18 @@ const DailyActivityLine = ({
     return null
   })()
 
+  // Dynamic cursor: previews the action when idle, reflects it during drag.
+  const cursorClass = (() => {
+    if (!dragEnabled) return ''
+    const action = isDragging ? dragState.mode : hoverAction
+    if (action === 'pan') return 'cursor-move'
+    if (action === 'end' || action === 'start' || action === 'edge') return 'cursor-ew-resize'
+    if (action === 'create') return 'cursor-crosshair'
+    return 'cursor-default'
+  })()
+
   return (
-    <div className={`relative w-full h-full ${dragEnabled ? 'cursor-ew-resize' : ''}`}>
+    <div className={`relative w-full h-full ${cursorClass}`}>
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart
           data={formattedData}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -292,14 +292,19 @@ const CircularTimeFilter = ({
           )
         ) : (
           <>
-            <path
-              d={createArc(timeToAngle(start), timeToAngle(end))}
-              fill="rgb(59 130 246 / 0.15)"
-              stroke="rgb(59 130 246 / 0.8)"
-              strokeWidth="2"
-              cursor="pointer"
-              onMouseDown={handleMouseDown('arc')}
-            />
+            {/* Suppress the highlight arc when the drag selection is full-day —
+                otherwise "no filter" looks identical to "everything selected".
+                Handles stay visible (overlap at top) so the user can still drag. */}
+            {!isFullDayRange() && (
+              <path
+                d={createArc(timeToAngle(start), timeToAngle(end))}
+                fill="rgb(59 130 246 / 0.15)"
+                stroke="rgb(59 130 246 / 0.8)"
+                strokeWidth="2"
+                cursor="pointer"
+                onMouseDown={handleMouseDown('arc')}
+              />
+            )}
 
             <circle
               cx={startCoord.x}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -222,16 +222,29 @@ const CircularTimeFilter = ({
         })}
 
         {mode === 'chips' ? (
-          chipSectors.map((sector, i) => (
-            <path
-              key={i}
-              d={createArc(timeToAngle(sector.start), timeToAngle(sector.end))}
-              fill="rgb(59 130 246 / 0.15)"
-              stroke="rgb(59 130 246 / 0.8)"
-              strokeWidth="2"
-              pointerEvents="none"
-            />
-          ))
+          chipSectors.map((sector, i) =>
+            sector.start === 0 && sector.end === 24 ? (
+              <circle
+                key={i}
+                cx={center.x}
+                cy={center.y}
+                r={radius}
+                fill="rgb(59 130 246 / 0.15)"
+                stroke="rgb(59 130 246 / 0.8)"
+                strokeWidth="2"
+                pointerEvents="none"
+              />
+            ) : (
+              <path
+                key={i}
+                d={createArc(timeToAngle(sector.start), timeToAngle(sector.end))}
+                fill="rgb(59 130 246 / 0.15)"
+                stroke="rgb(59 130 246 / 0.8)"
+                strokeWidth="2"
+                pointerEvents="none"
+              />
+            )
+          )
         ) : (
           <>
             <path
@@ -291,10 +304,7 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
   const formattedData = formatData(activityData)
 
   return (
-    <div
-      className="relative w-full h-full flex items-center justify-center"
-      ref={chartRef}
-    >
+    <div className="relative w-full h-full flex items-center justify-center" ref={chartRef}>
       {/* Inner square anchors the hour labels to the radar's actual edges,
           not the (potentially wider-than-tall) parent. */}
       <div className="relative h-full aspect-square">
@@ -314,7 +324,7 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
         </div>
 
         <ResponsiveContainer width="100%" height="100%">
-          <RadarChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+          <RadarChart data={formattedData} margin={{ top: 16, right: 16, bottom: 16, left: 16 }}>
             <PolarGrid radialLines={false} polarRadius={[]} strokeWidth={1} />
             <PolarAngleAxis dataKey="name" tick={false} />
             {/* <PolarRadiusAxis

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -145,8 +145,10 @@ const CircularTimeFilter = ({
   const endCoord = angleToCoordinates(timeToAngle(end))
 
   const createArc = (startAngle, endAngle) => {
-    if (isFullDayRange()) {
-      // For full day range, create a complete circle
+    // Full-day check based on the PASSED angles (not closure state) so this
+    // helper works correctly for both the drag arc and chip-driven sectors.
+    const sweep = (((endAngle - startAngle) % 360) + 360) % 360
+    if (startAngle === endAngle || sweep >= 358.5) {
       return `M ${center.x} ${center.y}
               L ${center.x} ${center.y - radius}
               A ${radius} ${radius} 0 1 1 ${center.x - 0.1} ${center.y - radius}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -320,7 +320,7 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
           <div className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
             12h
           </div>
-          <div className="absolute top-1/2 left-0 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
+          <div className="absolute top-1/2 -left-1 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
             18h
           </div>
         </div>

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -310,8 +310,9 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
       {/* Inner square anchors the hour labels to the radar's actual edges,
           not the (potentially wider-than-tall) parent. Labels sit at the
           edges of this square; the radar inside has a margin so its circle
-          sits well clear of them. */}
-      <div className="relative h-full aspect-square">
+          sits well clear of them. The slight upward translate balances the
+          visual weight of the chips row below. */}
+      <div className="relative h-full aspect-square -translate-y-1.5">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
             0h

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -8,6 +8,7 @@ import {
   Radar,
   RadarChart,
   ReferenceArea,
+  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis
@@ -394,9 +395,11 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
  * Props mirror DailyActivityRadar plus:
  *   selectedRanges: Array<{start, end}> — hour ranges currently in the
  *     filter. Rendered as shaded bands.
- *   onArcChange: optional ({start, end}) => void — when provided, the
- *     chart accepts click-and-drag to set a custom hour range. Pass undefined
- *     (e.g. while chips are driving selection) to disable drag.
+ *   onArcChange: optional ({start, end}) => void — when provided AND there
+ *     is exactly one (non-wrap-around) selected range, the chart shows a
+ *     draggable end-line that the user can slide to extend/contract the
+ *     range. Pass undefined (e.g. while chips are driving selection) to
+ *     disable.
  */
 const DailyActivityLine = ({
   activityData,
@@ -405,32 +408,46 @@ const DailyActivityLine = ({
   selectedRanges = [],
   onArcChange
 }) => {
-  const [dragStart, setDragStart] = useState(null)
+  // Drag is enabled when:
+  //   - a single non-wrap-around range exists → slide its end edge
+  //   - OR no range exists (custom selection is empty) → drag-to-create
+  // Multi-range or wrap-around selections aren't draggable on the x-y view.
+  const hasSingleBand =
+    selectedRanges.length === 1 && selectedRanges[0].start < selectedRanges[0].end
+  const dragEnabled =
+    typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
+  const committedStart = hasSingleBand ? selectedRanges[0].start : null
+  const committedEnd = hasSingleBand ? selectedRanges[0].end : null
+
+  // Pivot is the fixed edge during a drag — the band's existing start when
+  // sliding, the cursor down-position when creating a new range.
+  const [dragPivot, setDragPivot] = useState(null)
   const [dragEnd, setDragEnd] = useState(null)
-  const isDragging = dragStart !== null && dragEnd !== null
-  const dragEnabled = typeof onArcChange === 'function'
+  const isDragging = dragPivot !== null && dragEnd !== null
+
+  const clamp = (v) => Math.max(0, Math.min(24, v))
 
   const handleMouseDown = (e) => {
     if (!dragEnabled || !e || e.activeLabel === undefined || e.activeLabel === null) return
-    setDragStart(e.activeLabel)
-    setDragEnd(e.activeLabel)
+    const cursor = clamp(e.activeLabel)
+    setDragPivot(hasSingleBand ? committedStart : cursor)
+    setDragEnd(cursor)
   }
   const handleMouseMove = (e) => {
-    if (!dragEnabled || dragStart === null) return
-    if (!e || e.activeLabel === undefined || e.activeLabel === null) return
-    setDragEnd(e.activeLabel)
+    if (!isDragging || !e || e.activeLabel === undefined || e.activeLabel === null) return
+    setDragEnd(clamp(e.activeLabel))
   }
   const handleMouseUp = () => {
-    if (dragEnabled && dragStart !== null && dragEnd !== null && dragStart !== dragEnd) {
-      const start = Math.max(0, Math.min(dragStart, dragEnd))
-      const end = Math.min(24, Math.max(dragStart, dragEnd))
+    if (isDragging && dragEnd !== dragPivot) {
+      const start = Math.min(dragPivot, dragEnd)
+      const end = Math.max(dragPivot, dragEnd)
       onArcChange({ start, end })
     }
-    setDragStart(null)
+    setDragPivot(null)
     setDragEnd(null)
   }
   const handleMouseLeave = () => {
-    if (dragStart !== null) setDragStart(null)
+    setDragPivot(null)
     setDragEnd(null)
   }
   const formatData = (data) => {
@@ -456,16 +473,16 @@ const DailyActivityLine = ({
     }
   }
 
-  // Transient band shown live while the user is dragging.
-  const dragBand =
-    isDragging && dragStart !== dragEnd
-      ? [Math.max(0, Math.min(dragStart, dragEnd)), Math.min(24, Math.max(dragStart, dragEnd))]
-      : null
+  // Live band while dragging — covers from pivot to current cursor.
+  const liveBand = isDragging
+    ? [Math.min(dragPivot, dragEnd), Math.max(dragPivot, dragEnd)]
+    : null
+  // Where to draw the end-line + handle. While dragging, follow the cursor;
+  // otherwise pin to the committed band end (only when a band exists).
+  const endLineX = isDragging ? dragEnd : committedEnd
 
   return (
-    <div
-      className={`relative w-full h-full ${dragEnabled ? 'cursor-crosshair' : ''}`}
-    >
+    <div className={`relative w-full h-full ${dragEnabled ? 'cursor-ew-resize' : ''}`}>
       <ResponsiveContainer width="100%" height="100%">
         <ComposedChart
           data={formattedData}
@@ -486,9 +503,19 @@ const DailyActivityLine = ({
             tickLine={false}
           />
           <YAxis hide domain={[0, 'auto']} />
-          {/* Committed selection bands — hide while a fresh drag is in
-              progress so the transient drag band is the only highlight. */}
-          {!isDragging &&
+          {/* While sliding the end edge, show only the live band so the
+              user sees the in-progress range. Otherwise show committed bands. */}
+          {isDragging && liveBand ? (
+            <ReferenceArea
+              x1={liveBand[0]}
+              x2={liveBand[1]}
+              fill="rgb(59 130 246)"
+              fillOpacity={0.2}
+              stroke="rgb(59 130 246)"
+              strokeOpacity={0.7}
+              strokeWidth={1}
+            />
+          ) : (
             selectedBands.map(([s, e], i) => (
               <ReferenceArea
                 key={i}
@@ -500,16 +527,30 @@ const DailyActivityLine = ({
                 strokeOpacity={0.5}
                 strokeWidth={1}
               />
-            ))}
-          {dragBand && (
-            <ReferenceArea
-              x1={dragBand[0]}
-              x2={dragBand[1]}
-              fill="rgb(59 130 246)"
-              fillOpacity={0.2}
+            ))
+          )}
+          {/* Draggable end-line with a small handle dot at the top. */}
+          {dragEnabled && endLineX !== null && (
+            <ReferenceLine
+              x={endLineX}
               stroke="rgb(59 130 246)"
-              strokeOpacity={0.7}
-              strokeWidth={1}
+              strokeWidth={2}
+              isFront
+              label={{
+                value: '',
+                position: 'top',
+                content: ({ viewBox }) =>
+                  viewBox && viewBox.x !== undefined ? (
+                    <circle
+                      cx={viewBox.x}
+                      cy={viewBox.y + 6}
+                      r={4}
+                      fill="rgb(59 130 246)"
+                      stroke="white"
+                      strokeWidth={1}
+                    />
+                  ) : null
+              }}
             />
           )}
           {selectedSpecies.map((species, index) => (

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -28,9 +28,10 @@ const CircularTimeFilter = ({
   const [lastDragPosition, setLastDragPosition] = useState(null)
   const svgRef = useRef(null)
   const radius = 47
-  const padding = 8 // Add padding to prevent elements from being cut off
+  const padding = 16 // Padding leaves room for hour labels outside the circle
   const svgSize = radius * 2 + padding * 2 // Increase SVG size to accommodate padding
   const center = { x: radius + padding, y: radius + padding } // Adjust center coordinates
+  const labelOffset = 9 // Distance from circle edge to label center
 
   // Sync local state when parent updates the bounds externally (e.g. tab
   // switch). Does NOT fire onChange continuously — that happens only on
@@ -196,6 +197,48 @@ const CircularTimeFilter = ({
           strokeWidth="2"
         />
 
+        {/* Hour labels at the four cardinal points, just outside the circle */}
+        <text
+          x={center.x}
+          y={center.y - radius - labelOffset}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="9"
+          fill="var(--color-muted-foreground)"
+        >
+          0h
+        </text>
+        <text
+          x={center.x + radius + labelOffset}
+          y={center.y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="9"
+          fill="var(--color-muted-foreground)"
+        >
+          6h
+        </text>
+        <text
+          x={center.x}
+          y={center.y + radius + labelOffset}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="9"
+          fill="var(--color-muted-foreground)"
+        >
+          12h
+        </text>
+        <text
+          x={center.x - radius - labelOffset}
+          y={center.y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fontSize="9"
+          fill="var(--color-muted-foreground)"
+        >
+          18h
+        </text>
+
         {Array.from({ length: 24 }).map((_, i) => {
           const angle = timeToAngle(i)
           const coord = angleToCoordinates(angle)
@@ -307,28 +350,9 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
 
   return (
     <div className="relative w-full h-full flex items-center justify-center" ref={chartRef}>
-      {/* Inner square anchors the hour labels to the radar's actual edges,
-          not the (potentially wider-than-tall) parent. Labels sit at the
-          edges of this square; the radar inside has a margin so its circle
-          sits well clear of them. */}
       <div className="relative h-full aspect-square">
-        <div className="absolute inset-0 pointer-events-none">
-          <div className="absolute top-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
-            0h
-          </div>
-          <div className="absolute top-1/2 right-0 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
-            6h
-          </div>
-          <div className="absolute bottom-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
-            12h
-          </div>
-          <div className="absolute top-1/2 -left-1 -translate-y-1/2 text-[9px] text-muted-foreground leading-none">
-            18h
-          </div>
-        </div>
-
         <ResponsiveContainer width="100%" height="100%">
-          <RadarChart data={formattedData} margin={{ top: 22, right: 22, bottom: 22, left: 22 }}>
+          <RadarChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
             <PolarGrid radialLines={false} polarRadius={[]} strokeWidth={1} />
             <PolarAngleAxis dataKey="name" tick={false} />
             {/* <PolarRadiusAxis

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -291,20 +291,24 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
   const formattedData = formatData(activityData)
 
   return (
-    <>
-      <div className="relative w-full h-full" ref={chartRef}>
-        {/* Hour labels with hardcoded positions */}
-        <div className="absolute w-full h-full pointer-events-none">
-          <div className="absolute top-0.5 left-1/2 transform -translate-x-1/2  text-[10px] text-muted-foreground">
+    <div
+      className="relative w-full h-full flex items-center justify-center"
+      ref={chartRef}
+    >
+      {/* Inner square anchors the hour labels to the radar's actual edges,
+          not the (potentially wider-than-tall) parent. */}
+      <div className="relative h-full aspect-square">
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute top-0.5 left-1/2 -translate-x-1/2 text-[10px] text-muted-foreground">
             0h
           </div>
-          <div className="absolute top-1/2 right-1 transform -translate-y-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute top-1/2 right-0.5 -translate-y-1/2 text-[10px] text-muted-foreground">
             6h
           </div>
-          <div className="absolute bottom-0.5 left-1/2 transform -translate-x-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute bottom-0.5 left-1/2 -translate-x-1/2 text-[10px] text-muted-foreground">
             12h
           </div>
-          <div className="absolute top-1/2 left-0.5 transform  -translate-y-1/2 text-[10px] text-muted-foreground">
+          <div className="absolute top-1/2 left-0.5 -translate-y-1/2 text-[10px] text-muted-foreground">
             18h
           </div>
         </div>
@@ -335,7 +339,7 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
           </RadarChart>
         </ResponsiveContainer>
       </div>
-    </>
+    </div>
   )
 }
 

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -1,7 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { PolarAngleAxis, PolarGrid, Radar, RadarChart, ResponsiveContainer } from 'recharts'
 
-const CircularTimeFilter = ({ onChange, startTime = 6, endTime = 18 }) => {
+const CircularTimeFilter = ({
+  onChange,
+  startTime = 6,
+  endTime = 18,
+  mode = 'drag',
+  chipSectors = []
+}) => {
   const [isDraggingStart, setIsDraggingStart] = useState(false)
   const [isDraggingEnd, setIsDraggingEnd] = useState(false)
   const [isDraggingArc, setIsDraggingArc] = useState(false)
@@ -203,32 +209,47 @@ const CircularTimeFilter = ({ onChange, startTime = 6, endTime = 18 }) => {
           )
         })}
 
-        <path
-          d={createArc(timeToAngle(start), timeToAngle(end))}
-          fill="rgb(59 130 246 / 0.15)"
-          stroke="rgb(59 130 246 / 0.8)"
-          strokeWidth="2"
-          cursor="pointer"
-          onMouseDown={handleMouseDown('arc')}
-        />
+        {mode === 'chips' ? (
+          chipSectors.map((sector, i) => (
+            <path
+              key={i}
+              d={createArc(timeToAngle(sector.start), timeToAngle(sector.end))}
+              fill="rgb(59 130 246 / 0.15)"
+              stroke="rgb(59 130 246 / 0.8)"
+              strokeWidth="2"
+              pointerEvents="none"
+            />
+          ))
+        ) : (
+          <>
+            <path
+              d={createArc(timeToAngle(start), timeToAngle(end))}
+              fill="rgb(59 130 246 / 0.15)"
+              stroke="rgb(59 130 246 / 0.8)"
+              strokeWidth="2"
+              cursor="pointer"
+              onMouseDown={handleMouseDown('arc')}
+            />
 
-        <circle
-          cx={startCoord.x}
-          cy={startCoord.y}
-          r="4"
-          fill="rgb(59 130 246)"
-          cursor="pointer"
-          onMouseDown={handleMouseDown('start')}
-        />
+            <circle
+              cx={startCoord.x}
+              cy={startCoord.y}
+              r="4"
+              fill="rgb(59 130 246)"
+              cursor="pointer"
+              onMouseDown={handleMouseDown('start')}
+            />
 
-        <circle
-          cx={endCoord.x}
-          cy={endCoord.y}
-          r="4"
-          fill="rgb(59 130 246)"
-          cursor="pointer"
-          onMouseDown={handleMouseDown('end')}
-        />
+            <circle
+              cx={endCoord.x}
+              cy={endCoord.y}
+              r="4"
+              fill="rgb(59 130 246)"
+              cursor="pointer"
+              onMouseDown={handleMouseDown('end')}
+            />
+          </>
+        )}
       </svg>
     </div>
   )

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -456,14 +456,18 @@ const DailyActivityLine = ({
   }
 
   // Compute what action a click at `cursor` would trigger (used for both
-  // hover-cursor previewing and the actual mousedown branch).
+  // hover-cursor previewing and the actual mousedown branch). Edge zones
+  // are at least 1h wide so they're easy to target on short bands;
+  // capped at 2h so they don't take over wide bands.
+  const edgeTolFor = (width) => Math.max(1, Math.min(2, width / 3))
   const actionAt = (cursor) => {
     if (!hasSingleBand) return 'create'
     const { start, end } = selectedRanges[0]
     const width = isWrapBand ? 24 - start + end : end - start
-    const edgeTol = Math.min(1.5, width / 3)
-    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) return 'edge'
-    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) return 'edge'
+    const edgeTol = edgeTolFor(width)
+    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) return 'edge-end'
+    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol)
+      return 'edge-start'
     if (isInsideBand(cursor, { start, end })) return 'pan'
     return 'create'
   }
@@ -551,14 +555,24 @@ const DailyActivityLine = ({
   })()
 
   // Dynamic cursor: previews the action when idle, reflects it during drag.
-  const cursorClass = (() => {
-    if (!dragEnabled) return ''
+  // Use an inline style + child selector so Recharts' SVG elements don't
+  // override the cursor with their own defaults.
+  const cursorStyle = (() => {
+    if (!dragEnabled) return undefined
     const action = isDragging ? dragState.mode : hoverAction
-    if (action === 'pan') return 'cursor-move'
-    if (action === 'end' || action === 'start' || action === 'edge') return 'cursor-ew-resize'
-    if (action === 'create') return 'cursor-crosshair'
-    return 'cursor-default'
+    if (action === 'pan') return 'move'
+    if (action === 'end' || action === 'start' || action === 'edge-start' || action === 'edge-end')
+      return 'ew-resize'
+    if (action === 'create') return 'crosshair'
+    return 'default'
   })()
+  // Which edge (if any) is currently being hovered — used to make the
+  // corresponding handle dot pop visually.
+  const hoveredEdge = hoverAction === 'edge-start' || (isDragging && dragState.mode === 'start')
+    ? 'start'
+    : hoverAction === 'edge-end' || (isDragging && dragState.mode === 'end')
+      ? 'end'
+      : null
 
   // While a drag is in progress, listen on the document so the user can
   // move the cursor outside the chart and the drag keeps tracking. For
@@ -611,7 +625,7 @@ const DailyActivityLine = ({
     }
     const { start, end } = selectedRanges[0]
     const width = isWrapBand ? 24 - start + end : end - start
-    const edgeTol = Math.min(1.5, width / 3)
+    const edgeTol = edgeTolFor(width)
     if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) {
       setDragState({ mode: 'end', liveStart: start, liveEnd: cursor })
     } else if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) {
@@ -632,7 +646,8 @@ const DailyActivityLine = ({
   return (
     <div
       ref={containerRef}
-      className={`relative w-full h-full select-none ${cursorClass}`}
+      className="relative w-full h-full select-none [&_*]:!cursor-[inherit]"
+      style={cursorStyle ? { cursor: cursorStyle } : undefined}
       onMouseDown={handleNativeDown}
       onMouseMove={handleNativeMove}
       onMouseLeave={handleNativeLeave}
@@ -676,26 +691,29 @@ const DailyActivityLine = ({
                   strokeWidth={1}
                 />
               ))}
-          {/* Draggable start-line handle. */}
+          {/* Draggable start-line handle (dot centered vertically on the line). */}
           {dragEnabled && handleStartX !== null && (
             <ReferenceLine
               x={handleStartX}
               stroke="rgb(59 130 246)"
-              strokeWidth={2}
+              strokeWidth={hoveredEdge === 'start' ? 3 : 2}
               isFront
               label={{
-                position: 'top',
-                content: ({ viewBox }) =>
-                  viewBox && viewBox.x !== undefined ? (
+                position: 'center',
+                content: ({ viewBox }) => {
+                  if (!viewBox || viewBox.x === undefined) return null
+                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                  return (
                     <circle
                       cx={viewBox.x}
-                      cy={viewBox.y + 6}
-                      r={4}
+                      cy={cy}
+                      r={hoveredEdge === 'start' ? 6 : 4}
                       fill="rgb(59 130 246)"
                       stroke="white"
                       strokeWidth={1}
                     />
-                  ) : null
+                  )
+                }
               }}
             />
           )}
@@ -704,21 +722,24 @@ const DailyActivityLine = ({
             <ReferenceLine
               x={handleEndX}
               stroke="rgb(59 130 246)"
-              strokeWidth={2}
+              strokeWidth={hoveredEdge === 'end' ? 3 : 2}
               isFront
               label={{
-                position: 'top',
-                content: ({ viewBox }) =>
-                  viewBox && viewBox.x !== undefined ? (
+                position: 'center',
+                content: ({ viewBox }) => {
+                  if (!viewBox || viewBox.x === undefined) return null
+                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                  return (
                     <circle
                       cx={viewBox.x}
-                      cy={viewBox.y + 6}
-                      r={4}
+                      cy={cy}
+                      r={hoveredEdge === 'end' ? 6 : 4}
                       fill="rgb(59 130 246)"
                       stroke="white"
                       strokeWidth={1}
                     />
-                  ) : null
+                  )
+                }
               }}
             />
           )}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -394,8 +394,8 @@ const DailyActivityLine = ({ activityData, selectedSpecies, palette, selectedRan
           <XAxis
             dataKey="hour"
             type="number"
-            domain={[0, 23]}
-            ticks={[0, 6, 12, 18, 23]}
+            domain={[0, 24]}
+            ticks={[0, 6, 12, 18, 24]}
             tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
             axisLine={false}
             tickLine={false}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -310,9 +310,8 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
       {/* Inner square anchors the hour labels to the radar's actual edges,
           not the (potentially wider-than-tall) parent. Labels sit at the
           edges of this square; the radar inside has a margin so its circle
-          sits well clear of them. The slight upward translate balances the
-          visual weight of the chips row below. */}
-      <div className="relative h-full aspect-square -translate-y-1.5">
+          sits well clear of them. */}
+      <div className="relative h-full aspect-square">
         <div className="absolute inset-0 pointer-events-none">
           <div className="absolute top-0 left-1/2 -translate-x-1/2 text-[9px] text-muted-foreground leading-none">
             0h

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -419,6 +419,7 @@ const DailyActivityLine = ({
   const dragEnabled =
     typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
 
+  const containerRef = useRef(null)
   const [dragState, setDragState] = useState(null)
   // dragState shape:
   //   { mode: 'end',    liveStart, liveEnd }
@@ -427,39 +428,28 @@ const DailyActivityLine = ({
   //   { mode: 'create', liveStart, liveEnd }
   const isDragging = dragState !== null
   // Tracks what the cursor is hovering OVER (when not dragging) so we can
-  // preview the action that a click would trigger: 'pan' | 'edge' | null.
+  // preview the action that a click would trigger.
   const [hoverAction, setHoverAction] = useState(null)
 
-  const clamp = (v) => Math.max(0, Math.min(24, v))
+  // Convert a native pointer event to a chart-x hour value, accounting for
+  // the ComposedChart's left/right margin so the hover preview matches what
+  // a click would actually hit.
+  const eventToHour = (e) => {
+    if (!containerRef.current) return null
+    const rect = containerRef.current.getBoundingClientRect()
+    const marginLeft = 8
+    const marginRight = 8
+    const innerWidth = rect.width - marginLeft - marginRight
+    if (innerWidth <= 0) return null
+    const xPx = e.clientX - rect.left - marginLeft
+    const ratio = Math.max(0, Math.min(1, xPx / innerWidth))
+    return ratio * 24
+  }
 
   // Whether `cursor` is inside the (possibly wrap-around) band.
   const isInsideBand = (cursor, band) => {
     if (band.start < band.end) return cursor > band.start && cursor < band.end
     return cursor > band.start || cursor < band.end
-  }
-
-  const handleMouseDown = (e) => {
-    if (!dragEnabled || !e || e.activeLabel === undefined || e.activeLabel === null) return
-    const cursor = clamp(e.activeLabel)
-    if (!hasSingleBand) {
-      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
-      return
-    }
-    const { start, end } = selectedRanges[0]
-    const width = isWrapBand ? 24 - start + end : end - start
-    const edgeTol = Math.min(1.5, width / 3)
-    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) {
-      // slide end: pivot = start, moving = end
-      setDragState({ mode: 'end', liveStart: start, liveEnd: cursor })
-    } else if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) {
-      // slide start: pivot = end, moving = start
-      setDragState({ mode: 'start', liveStart: cursor, liveEnd: end })
-    } else if (isInsideBand(cursor, { start, end })) {
-      const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
-      setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
-    } else {
-      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
-    }
   }
 
   // Compute what action a click at `cursor` would trigger (used for both
@@ -475,29 +465,6 @@ const DailyActivityLine = ({
     return 'create'
   }
 
-  const handleMouseMove = (e) => {
-    if (!e || e.activeLabel === undefined || e.activeLabel === null) {
-      if (!isDragging) setHoverAction(null)
-      return
-    }
-    const cursor = clamp(e.activeLabel)
-    if (!isDragging) {
-      if (dragEnabled) setHoverAction(actionAt(cursor))
-      return
-    }
-    setDragState((prev) => {
-      if (!prev) return prev
-      if (prev.mode === 'pan') {
-        const newStart = (((cursor - prev.panOffset) % 24) + 24) % 24
-        const newEnd = (newStart + prev.panWidth) % 24
-        return { ...prev, liveStart: newStart, liveEnd: newEnd }
-      }
-      if (prev.mode === 'start') return { ...prev, liveStart: cursor }
-      // end / create
-      return { ...prev, liveEnd: cursor }
-    })
-  }
-
   const handleMouseUp = () => {
     if (isDragging) {
       const { mode, liveStart, liveEnd } = dragState
@@ -510,10 +477,6 @@ const DailyActivityLine = ({
       }
     }
     setDragState(null)
-  }
-  const handleMouseLeave = () => {
-    setDragState(null)
-    setHoverAction(null)
   }
   const formatData = (data) => {
     if (!data || !data.length) {
@@ -589,17 +552,66 @@ const DailyActivityLine = ({
     return 'cursor-default'
   })()
 
+  // Native mouse handlers on the wrapping div — these fire reliably for
+  // every pixel inside the chart, unlike Recharts' chart-level events
+  // which only fire near data points.
+  const handleNativeMove = (e) => {
+    const cursor = eventToHour(e)
+    if (cursor === null) return
+    if (isDragging) {
+      setDragState((prev) => {
+        if (!prev) return prev
+        if (prev.mode === 'pan') {
+          const newStart = (((cursor - prev.panOffset) % 24) + 24) % 24
+          const newEnd = (newStart + prev.panWidth) % 24
+          return { ...prev, liveStart: newStart, liveEnd: newEnd }
+        }
+        if (prev.mode === 'start') return { ...prev, liveStart: cursor }
+        return { ...prev, liveEnd: cursor }
+      })
+    } else if (dragEnabled) {
+      setHoverAction(actionAt(cursor))
+    }
+  }
+  const handleNativeDown = (e) => {
+    if (!dragEnabled) return
+    const cursor = eventToHour(e)
+    if (cursor === null) return
+    if (!hasSingleBand) {
+      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+      return
+    }
+    const { start, end } = selectedRanges[0]
+    const width = isWrapBand ? 24 - start + end : end - start
+    const edgeTol = Math.min(1.5, width / 3)
+    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) {
+      setDragState({ mode: 'end', liveStart: start, liveEnd: cursor })
+    } else if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) {
+      setDragState({ mode: 'start', liveStart: cursor, liveEnd: end })
+    } else if (isInsideBand(cursor, { start, end })) {
+      const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
+      setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
+    } else {
+      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+    }
+  }
+  const handleNativeUp = () => handleMouseUp()
+  const handleNativeLeave = () => {
+    setDragState(null)
+    setHoverAction(null)
+  }
+
   return (
-    <div className={`relative w-full h-full ${cursorClass}`}>
+    <div
+      ref={containerRef}
+      className={`relative w-full h-full ${cursorClass}`}
+      onMouseDown={handleNativeDown}
+      onMouseMove={handleNativeMove}
+      onMouseUp={handleNativeUp}
+      onMouseLeave={handleNativeLeave}
+    >
       <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart
-          data={formattedData}
-          margin={{ top: 4, right: 8, bottom: 0, left: 8 }}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseLeave}
-        >
+        <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
           <CartesianGrid strokeOpacity={0} />
           <XAxis
             dataKey="hour"

--- a/src/renderer/src/ui/dayPeriodChips.jsx
+++ b/src/renderer/src/ui/dayPeriodChips.jsx
@@ -1,6 +1,6 @@
 import { Sunrise, Sun, Sunset, Moon } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
-import { DAY_PERIOD_ORDER, DAY_PERIOD_PRESETS } from '../utils/dayPeriods'
+import { DAY_PERIOD_ORDER, DAY_PERIOD_PRESETS, formatRange } from '../utils/dayPeriods'
 
 const ICONS = {
   dawn: Sunrise,
@@ -32,6 +32,7 @@ export default function DayPeriodChips({ selection, onChange }) {
       {DAY_PERIOD_ORDER.map((key) => {
         const Icon = ICONS[key]
         const active = selection.has(key)
+        const preset = DAY_PERIOD_PRESETS[key]
         return (
           <Tooltip.Root key={key}>
             <Tooltip.Trigger asChild>
@@ -42,7 +43,7 @@ export default function DayPeriodChips({ selection, onChange }) {
                     ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
                     : 'text-muted-foreground hover:bg-accent'
                 }`}
-                aria-label={DAY_PERIOD_PRESETS[key].label}
+                aria-label={preset.label}
                 aria-pressed={active}
               >
                 <Icon size={16} />
@@ -51,10 +52,16 @@ export default function DayPeriodChips({ selection, onChange }) {
             <Tooltip.Portal>
               <Tooltip.Content
                 side="bottom"
-                sideOffset={6}
-                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+                sideOffset={8}
+                className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
               >
-                {DAY_PERIOD_PRESETS[key].label}
+                <div className="flex items-baseline justify-between gap-3 mb-1">
+                  <span className="font-medium">{preset.label}</span>
+                  <span className="text-muted-foreground tabular-nums">
+                    {formatRange(preset.range)}
+                  </span>
+                </div>
+                <p className="text-muted-foreground leading-snug">{preset.description}</p>
                 <Tooltip.Arrow className="fill-popover" />
               </Tooltip.Content>
             </Tooltip.Portal>

--- a/src/renderer/src/ui/dayPeriodChips.jsx
+++ b/src/renderer/src/ui/dayPeriodChips.jsx
@@ -1,0 +1,66 @@
+import { Sunrise, Sun, Sunset, Moon } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
+import { DAY_PERIOD_ORDER, DAY_PERIOD_PRESETS } from '../utils/dayPeriods'
+
+const ICONS = {
+  dawn: Sunrise,
+  day: Sun,
+  dusk: Sunset,
+  night: Moon
+}
+
+/**
+ * Four icon buttons (Dawn / Day / Dusk / Night) above the polar clock.
+ * Multi-select: each button toggles its key in the `selection` Set.
+ * Visual treatment matches FilterChartsToggle for coherence with the
+ * rest of the gap-slider strip.
+ *
+ * Props:
+ *   selection: Set<string> — currently active chip keys
+ *   onChange: (newSelection: Set<string>) => void
+ */
+export default function DayPeriodChips({ selection, onChange }) {
+  const toggle = (key) => {
+    const next = new Set(selection)
+    if (next.has(key)) next.delete(key)
+    else next.add(key)
+    onChange(next)
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {DAY_PERIOD_ORDER.map((key) => {
+        const Icon = ICONS[key]
+        const active = selection.has(key)
+        return (
+          <Tooltip.Root key={key}>
+            <Tooltip.Trigger asChild>
+              <button
+                onClick={() => toggle(key)}
+                className={`w-7 h-7 rounded-md flex items-center justify-center transition-colors ${
+                  active
+                    ? 'text-blue-600 bg-blue-50 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
+                    : 'text-muted-foreground hover:bg-accent'
+                }`}
+                aria-label={DAY_PERIOD_PRESETS[key].label}
+                aria-pressed={active}
+              >
+                <Icon size={16} />
+              </button>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                side="bottom"
+                sideOffset={6}
+                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              >
+                {DAY_PERIOD_PRESETS[key].label}
+                <Tooltip.Arrow className="fill-popover" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/ui/dayPeriodChips.jsx
+++ b/src/renderer/src/ui/dayPeriodChips.jsx
@@ -1,4 +1,4 @@
-import { Sunrise, Sun, Sunset, Moon } from 'lucide-react'
+import { Sunrise, Sun, Sunset, MoonStar } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 import { DAY_PERIOD_ORDER, DAY_PERIOD_PRESETS, formatRange } from '../utils/dayPeriods'
 
@@ -6,7 +6,7 @@ const ICONS = {
   dawn: Sunrise,
   day: Sun,
   dusk: Sunset,
-  night: Moon
+  night: MoonStar
 }
 
 /**

--- a/src/renderer/src/ui/dayPeriodChips.jsx
+++ b/src/renderer/src/ui/dayPeriodChips.jsx
@@ -62,7 +62,6 @@ export default function DayPeriodChips({ selection, onChange }) {
                   </span>
                 </div>
                 <p className="text-muted-foreground leading-snug">{preset.description}</p>
-                <Tooltip.Arrow className="fill-popover" />
               </Tooltip.Content>
             </Tooltip.Portal>
           </Tooltip.Root>

--- a/src/renderer/src/ui/dayPeriodChips.jsx
+++ b/src/renderer/src/ui/dayPeriodChips.jsx
@@ -51,7 +51,7 @@ export default function DayPeriodChips({ selection, onChange }) {
             </Tooltip.Trigger>
             <Tooltip.Portal>
               <Tooltip.Content
-                side="bottom"
+                side="top"
                 sideOffset={8}
                 className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
               >

--- a/src/renderer/src/utils/dayPeriods.js
+++ b/src/renderer/src/utils/dayPeriods.js
@@ -8,10 +8,42 @@
  */
 
 export const DAY_PERIOD_PRESETS = {
-  dawn: { key: 'dawn', label: 'Dawn', range: { start: 5, end: 8 } },
-  day: { key: 'day', label: 'Day', range: { start: 8, end: 18 } },
-  dusk: { key: 'dusk', label: 'Dusk', range: { start: 18, end: 21 } },
-  night: { key: 'night', label: 'Night', range: { start: 21, end: 5 } }
+  dawn: {
+    key: 'dawn',
+    label: 'Dawn',
+    range: { start: 5, end: 8 },
+    description:
+      'Sunrise window — peak activity for many mammals as day-active species emerge and night-active species return to cover.'
+  },
+  day: {
+    key: 'day',
+    label: 'Day',
+    range: { start: 8, end: 18 },
+    description:
+      'Daytime hours — when diurnal species are active (squirrels, most birds, deer in open habitats).'
+  },
+  dusk: {
+    key: 'dusk',
+    label: 'Dusk',
+    range: { start: 18, end: 21 },
+    description:
+      'Sunset window — second daily activity peak. Mirrors dawn for many crepuscular species.'
+  },
+  night: {
+    key: 'night',
+    label: 'Night',
+    range: { start: 21, end: 5 },
+    description:
+      'Nocturnal hours — when night-active species are out (owls, bats, badgers, many cats and small mammals).'
+  }
+}
+
+/**
+ * Format a {start, end} hour range as "HH:00 → HH:00".
+ */
+export function formatRange({ start, end }) {
+  const fmt = (h) => `${String(h).padStart(2, '0')}:00`
+  return `${fmt(start)} → ${fmt(end)}`
 }
 
 // Canonical render order: chronological, dawn first.

--- a/src/renderer/src/utils/dayPeriods.js
+++ b/src/renderer/src/utils/dayPeriods.js
@@ -1,0 +1,48 @@
+/**
+ * Day-period presets and the helpers that translate UI selection state
+ * (chip set, drag-arc) into the {ranges: [...]} shape consumed by the
+ * backend timeRange filter.
+ *
+ * Hour ranges are half-open [start, end) in 24h local clock time. Night
+ * wraps midnight (start > end).
+ */
+
+export const DAY_PERIOD_PRESETS = {
+  dawn: { key: 'dawn', label: 'Dawn', range: { start: 5, end: 8 } },
+  day: { key: 'day', label: 'Day', range: { start: 8, end: 18 } },
+  dusk: { key: 'dusk', label: 'Dusk', range: { start: 18, end: 21 } },
+  night: { key: 'night', label: 'Night', range: { start: 21, end: 5 } }
+}
+
+// Canonical render order: chronological, dawn first.
+export const DAY_PERIOD_ORDER = ['dawn', 'day', 'dusk', 'night']
+
+/**
+ * Convert a chip selection (Set<string>) into an ordered ranges array.
+ * Unknown keys are ignored.
+ */
+export function chipsToRanges(selection) {
+  return DAY_PERIOD_ORDER.filter((key) => selection.has(key)).map(
+    (key) => DAY_PERIOD_PRESETS[key].range
+  )
+}
+
+/**
+ * Whether a freeform drag-arc {start, end} effectively covers the whole
+ * day. Tolerance handles fractional-hour drift from the polar drag.
+ */
+export function isFullDayArc(arc) {
+  if (!arc) return true
+  const { start, end } = arc
+  if (start === end) return true
+  return Math.abs(end - start) >= 23.9
+}
+
+/**
+ * Convert a drag-arc {start, end} into the ranges array. Returns [] when
+ * the arc is full-day (== no filter).
+ */
+export function arcToRanges(arc) {
+  if (isFullDayArc(arc)) return []
+  return [{ start: arc.start, end: arc.end }]
+}

--- a/src/renderer/src/utils/dayPeriods.js
+++ b/src/renderer/src/utils/dayPeriods.js
@@ -50,6 +50,13 @@ export function formatRange({ start, end }) {
 export const DAY_PERIOD_ORDER = ['dawn', 'day', 'dusk', 'night']
 
 /**
+ * The default chip selection — all four chips active, equivalent to
+ * "no filter" but visually expressing "full day selected" (mirrors the
+ * timeline filter, which defaults to the full date range).
+ */
+export const ALL_CHIPS_SELECTED = new Set(DAY_PERIOD_ORDER)
+
+/**
  * Convert a chip selection (Set<string>) into an ordered ranges array.
  * Unknown keys are ignored.
  */
@@ -77,4 +84,48 @@ export function isFullDayArc(arc) {
 export function arcToRanges(arc) {
   if (isFullDayArc(arc)) return []
   return [{ start: arc.start, end: arc.end }]
+}
+
+/**
+ * Merge contiguous integer-hour ranges (handles wrap-around at midnight).
+ * Used to convert chip selections into the smallest set of arcs/bands the
+ * UI should draw — so {dawn, day} renders as a single 5→18 arc instead of
+ * two abutting arcs, and {dawn, day, dusk, night} renders as a single
+ * full-day sweep instead of four pie slices.
+ *
+ * Output uses half-open [start, end) hour ranges; full-day collapses to
+ * a single [{start: 0, end: 24}] sector.
+ */
+export function mergeChipRanges(ranges) {
+  if (ranges.length === 0) return []
+  const covered = new Array(24).fill(false)
+  for (const { start, end } of ranges) {
+    if (start === end) continue
+    if (start < end) {
+      for (let h = start; h < end; h++) covered[h] = true
+    } else {
+      for (let h = start; h < 24; h++) covered[h] = true
+      for (let h = 0; h < end; h++) covered[h] = true
+    }
+  }
+  if (covered.every(Boolean)) return [{ start: 0, end: 24 }]
+
+  const runs = []
+  let i = 0
+  while (i < 24) {
+    if (covered[i]) {
+      const start = i
+      while (i < 24 && covered[i]) i++
+      runs.push({ start, end: i })
+    } else {
+      i++
+    }
+  }
+  // Wrap-around: first run touches 0 and last run touches 24 → merge
+  // into one wrap-around range (start > end).
+  if (runs.length >= 2 && runs[0].start === 0 && runs[runs.length - 1].end === 24) {
+    const last = runs.pop()
+    runs[0] = { start: last.start, end: runs[0].end }
+  }
+  return runs
 }

--- a/test/main/database/queries/sequencesTimeRange.test.js
+++ b/test/main/database/queries/sequencesTimeRange.test.js
@@ -1,11 +1,24 @@
 /**
- * Unit tests for normalizeTimeRange — accepts both the legacy
- * {start, end} shape and the new {ranges: [...]} shape.
+ * Tests for the multi-range timeRange filter in sequences queries.
+ * Covers normalizeTimeRange (pure helper) and getMediaForSequencePagination /
+ * hasTimestampedMedia (integration tests against an in-memory SQLite DB).
  */
-import { test, describe } from 'node:test'
+import { test, describe, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
 
 import { normalizeTimeRange } from '../../../../src/main/database/queries/sequences.js'
+import {
+  getMediaForSequencePagination,
+  hasTimestampedMedia,
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations
+} from '../../../../src/main/database/index.js'
 
 describe('normalizeTimeRange', () => {
   test('returns [] for undefined/null/empty input', () => {
@@ -33,5 +46,160 @@ describe('normalizeTimeRange', () => {
 
   test('returns [] when ranges is an empty array', () => {
     assert.deepEqual(normalizeTimeRange({ ranges: [] }), [])
+  })
+})
+
+let testBiowatchDataPath
+let testDbPath
+let testStudyId
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    electronLog.default.transports.file.level = false
+    electronLog.default.transports.console.level = false
+  } catch {
+    // not available, fine
+  }
+  testStudyId = `test-time-range-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-time-range-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+async function seedHourlyMedia() {
+  const manager = await createImageDirectoryDatabase(testDbPath)
+  await insertDeployments(manager, {
+    d1: {
+      deploymentID: 'd1',
+      locationID: 'loc1',
+      locationName: 'Site A',
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+      latitude: 1,
+      longitude: 1,
+      cameraID: 'cam1'
+    }
+  })
+  // One media per hour, 00:30 through 23:30 (24 rows)
+  const mediaMap = {}
+  const obsList = []
+  for (let h = 0; h < 24; h++) {
+    const id = `m-${String(h).padStart(2, '0')}`
+    mediaMap[`${id}.jpg`] = {
+      mediaID: id,
+      deploymentID: 'd1',
+      timestamp: DateTime.fromISO(`2024-06-01T${String(h).padStart(2, '0')}:30:00`, {
+        zone: 'utc'
+      }),
+      filePath: `/${id}.jpg`,
+      fileName: `${id}.jpg`
+    }
+    obsList.push({
+      observationID: `obs-${id}`,
+      mediaID: id,
+      deploymentID: 'd1',
+      eventID: `ev-${id}`,
+      observationType: 'animal',
+      scientificName: 'Sus scrofa'
+    })
+  }
+  await insertMedia(manager, mediaMap)
+  await insertObservations(manager, obsList)
+  return manager
+}
+
+describe('getMediaForSequencePagination — timeRange filter', () => {
+  test('legacy {start, end} shape continues to work', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { start: 8, end: 18 }
+    })
+    const hours = result.media
+      .map((m) => new Date(m.timestamp).getUTCHours())
+      .sort((a, b) => a - b)
+    assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+  })
+
+  test('new {ranges: [...]} shape with a single range matches legacy', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 8, end: 18 }] }
+    })
+    const hours = result.media
+      .map((m) => new Date(m.timestamp).getUTCHours())
+      .sort((a, b) => a - b)
+    assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
+  })
+
+  test('multi-range shape unions the ranges (Dawn + Dusk)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: {
+        ranges: [
+          { start: 5, end: 8 },
+          { start: 18, end: 21 }
+        ]
+      }
+    })
+    const hours = result.media
+      .map((m) => new Date(m.timestamp).getUTCHours())
+      .sort((a, b) => a - b)
+    assert.deepEqual(hours, [5, 6, 7, 18, 19, 20])
+  })
+
+  test('wrap-around range still works (Night 21 → 5)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 21, end: 5 }] }
+    })
+    const hours = result.media
+      .map((m) => new Date(m.timestamp).getUTCHours())
+      .sort((a, b) => a - b)
+    assert.deepEqual(hours, [0, 1, 2, 3, 4, 21, 22, 23])
+  })
+
+  test('empty ranges means no time filter (all 24 hours match)', async () => {
+    await seedHourlyMedia()
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [] }
+    })
+    assert.equal(result.media.length, 24)
+  })
+})
+
+describe('hasTimestampedMedia — timeRange filter', () => {
+  test('returns true when ranges union covers a populated hour', async () => {
+    await seedHourlyMedia()
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: {
+        ranges: [
+          { start: 5, end: 8 },
+          { start: 18, end: 21 }
+        ]
+      }
+    })
+    assert.equal(result, true)
+  })
+
+  test('returns true when ranges array is empty (no filter)', async () => {
+    await seedHourlyMedia()
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [] }
+    })
+    assert.equal(result, true)
   })
 })

--- a/test/main/database/queries/sequencesTimeRange.test.js
+++ b/test/main/database/queries/sequencesTimeRange.test.js
@@ -179,9 +179,67 @@ describe('getMediaForSequencePagination — timeRange filter', () => {
   })
 })
 
+async function seedSingleHourMedia(hour) {
+  const manager = await createImageDirectoryDatabase(testDbPath)
+  await insertDeployments(manager, {
+    d1: {
+      deploymentID: 'd1',
+      locationID: 'loc1',
+      locationName: 'Site A',
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+      latitude: 1,
+      longitude: 1,
+      cameraID: 'cam1'
+    }
+  })
+  const id = `m-only-${hour}`
+  await insertMedia(manager, {
+    [`${id}.jpg`]: {
+      mediaID: id,
+      deploymentID: 'd1',
+      timestamp: DateTime.fromISO(
+        `2024-06-01T${String(hour).padStart(2, '0')}:30:00`,
+        { zone: 'utc' }
+      ),
+      filePath: `/${id}.jpg`,
+      fileName: `${id}.jpg`
+    }
+  })
+  await insertObservations(manager, [
+    {
+      observationID: `obs-${id}`,
+      mediaID: id,
+      deploymentID: 'd1',
+      eventID: `ev-${id}`,
+      observationType: 'animal',
+      scientificName: 'Sus scrofa'
+    }
+  ])
+  return manager
+}
+
 describe('hasTimestampedMedia — timeRange filter', () => {
-  test('returns true when ranges union covers a populated hour', async () => {
-    await seedHourlyMedia()
+  test('returns true when single range covers the only populated hour', async () => {
+    await seedSingleHourMedia(10)
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 8, end: 18 }] }
+    })
+    assert.equal(result, true)
+  })
+
+  test('returns false when the only range excludes the populated hour', async () => {
+    await seedSingleHourMedia(10)
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 21, end: 5 }] }
+    })
+    assert.equal(result, false)
+  })
+
+  test('returns true when one of multiple ranges covers the populated hour', async () => {
+    await seedSingleHourMedia(7)
     const result = await hasTimestampedMedia(testDbPath, {
       species: ['Sus scrofa'],
       timeRange: {
@@ -194,11 +252,34 @@ describe('hasTimestampedMedia — timeRange filter', () => {
     assert.equal(result, true)
   })
 
+  test('returns false when no range covers the populated hour', async () => {
+    await seedSingleHourMedia(15)
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: {
+        ranges: [
+          { start: 5, end: 8 },
+          { start: 18, end: 21 }
+        ]
+      }
+    })
+    assert.equal(result, false)
+  })
+
   test('returns true when ranges array is empty (no filter)', async () => {
-    await seedHourlyMedia()
+    await seedSingleHourMedia(10)
     const result = await hasTimestampedMedia(testDbPath, {
       species: ['Sus scrofa'],
       timeRange: { ranges: [] }
+    })
+    assert.equal(result, true)
+  })
+
+  test('legacy {start, end} shape continues to work', async () => {
+    await seedSingleHourMedia(10)
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { start: 8, end: 18 }
     })
     assert.equal(result, true)
   })

--- a/test/main/database/queries/sequencesTimeRange.test.js
+++ b/test/main/database/queries/sequencesTimeRange.test.js
@@ -122,9 +122,7 @@ describe('getMediaForSequencePagination — timeRange filter', () => {
       species: ['Sus scrofa'],
       timeRange: { start: 8, end: 18 }
     })
-    const hours = result.media
-      .map((m) => new Date(m.timestamp).getUTCHours())
-      .sort((a, b) => a - b)
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
     assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
   })
 
@@ -134,9 +132,7 @@ describe('getMediaForSequencePagination — timeRange filter', () => {
       species: ['Sus scrofa'],
       timeRange: { ranges: [{ start: 8, end: 18 }] }
     })
-    const hours = result.media
-      .map((m) => new Date(m.timestamp).getUTCHours())
-      .sort((a, b) => a - b)
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
     assert.deepEqual(hours, [8, 9, 10, 11, 12, 13, 14, 15, 16, 17])
   })
 
@@ -151,9 +147,7 @@ describe('getMediaForSequencePagination — timeRange filter', () => {
         ]
       }
     })
-    const hours = result.media
-      .map((m) => new Date(m.timestamp).getUTCHours())
-      .sort((a, b) => a - b)
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
     assert.deepEqual(hours, [5, 6, 7, 18, 19, 20])
   })
 
@@ -163,9 +157,7 @@ describe('getMediaForSequencePagination — timeRange filter', () => {
       species: ['Sus scrofa'],
       timeRange: { ranges: [{ start: 21, end: 5 }] }
     })
-    const hours = result.media
-      .map((m) => new Date(m.timestamp).getUTCHours())
-      .sort((a, b) => a - b)
+    const hours = result.media.map((m) => new Date(m.timestamp).getUTCHours()).sort((a, b) => a - b)
     assert.deepEqual(hours, [0, 1, 2, 3, 4, 21, 22, 23])
   })
 
@@ -198,10 +190,9 @@ async function seedSingleHourMedia(hour) {
     [`${id}.jpg`]: {
       mediaID: id,
       deploymentID: 'd1',
-      timestamp: DateTime.fromISO(
-        `2024-06-01T${String(hour).padStart(2, '0')}:30:00`,
-        { zone: 'utc' }
-      ),
+      timestamp: DateTime.fromISO(`2024-06-01T${String(hour).padStart(2, '0')}:30:00`, {
+        zone: 'utc'
+      }),
       filePath: `/${id}.jpg`,
       fileName: `${id}.jpg`
     }

--- a/test/main/database/queries/sequencesTimeRange.test.js
+++ b/test/main/database/queries/sequencesTimeRange.test.js
@@ -1,0 +1,37 @@
+/**
+ * Unit tests for normalizeTimeRange — accepts both the legacy
+ * {start, end} shape and the new {ranges: [...]} shape.
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { normalizeTimeRange } from '../../../../src/main/database/queries/sequences.js'
+
+describe('normalizeTimeRange', () => {
+  test('returns [] for undefined/null/empty input', () => {
+    assert.deepEqual(normalizeTimeRange(undefined), [])
+    assert.deepEqual(normalizeTimeRange(null), [])
+    assert.deepEqual(normalizeTimeRange({}), [])
+  })
+
+  test('wraps legacy {start, end} into a single-element ranges array', () => {
+    assert.deepEqual(normalizeTimeRange({ start: 5, end: 8 }), [{ start: 5, end: 8 }])
+  })
+
+  test('passes through {ranges: [...]} unchanged', () => {
+    const ranges = [
+      { start: 5, end: 8 },
+      { start: 18, end: 21 }
+    ]
+    assert.deepEqual(normalizeTimeRange({ ranges }), ranges)
+  })
+
+  test('prefers ranges over start/end when both present', () => {
+    const ranges = [{ start: 0, end: 12 }]
+    assert.deepEqual(normalizeTimeRange({ ranges, start: 100, end: 200 }), ranges)
+  })
+
+  test('returns [] when ranges is an empty array', () => {
+    assert.deepEqual(normalizeTimeRange({ ranges: [] }), [])
+  })
+})

--- a/test/renderer/dayPeriods.test.js
+++ b/test/renderer/dayPeriods.test.js
@@ -2,11 +2,13 @@ import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
-  DAY_PERIOD_PRESETS,
-  DAY_PERIOD_ORDER,
-  chipsToRanges,
+  ALL_CHIPS_SELECTED,
   arcToRanges,
-  isFullDayArc
+  chipsToRanges,
+  DAY_PERIOD_ORDER,
+  DAY_PERIOD_PRESETS,
+  isFullDayArc,
+  mergeChipRanges
 } from '../../src/renderer/src/utils/dayPeriods.js'
 
 describe('DAY_PERIOD_PRESETS', () => {
@@ -83,5 +85,77 @@ describe('arcToRanges', () => {
 
   test('wrap-around arc returns single range', () => {
     assert.deepEqual(arcToRanges({ start: 21, end: 5 }), [{ start: 21, end: 5 }])
+  })
+})
+
+describe('ALL_CHIPS_SELECTED', () => {
+  test('contains every chip', () => {
+    assert.deepEqual([...ALL_CHIPS_SELECTED].sort(), ['dawn', 'day', 'dusk', 'night'])
+  })
+})
+
+describe('mergeChipRanges', () => {
+  test('empty input returns empty', () => {
+    assert.deepEqual(mergeChipRanges([]), [])
+  })
+
+  test('single range passes through unchanged', () => {
+    assert.deepEqual(mergeChipRanges([{ start: 8, end: 18 }]), [{ start: 8, end: 18 }])
+  })
+
+  test('two contiguous ranges merge into one', () => {
+    assert.deepEqual(
+      mergeChipRanges([
+        { start: 5, end: 8 },
+        { start: 8, end: 18 }
+      ]),
+      [{ start: 5, end: 18 }]
+    )
+  })
+
+  test('non-contiguous ranges stay separate (Dawn + Dusk)', () => {
+    assert.deepEqual(
+      mergeChipRanges([
+        { start: 5, end: 8 },
+        { start: 18, end: 21 }
+      ]),
+      [
+        { start: 5, end: 8 },
+        { start: 18, end: 21 }
+      ]
+    )
+  })
+
+  test('night + dawn merges across midnight (wrap-around)', () => {
+    assert.deepEqual(
+      mergeChipRanges([
+        { start: 5, end: 8 },
+        { start: 21, end: 5 }
+      ]),
+      [{ start: 21, end: 8 }]
+    )
+  })
+
+  test('all four chips merge to a single full-day sector', () => {
+    assert.deepEqual(
+      mergeChipRanges([
+        { start: 5, end: 8 },
+        { start: 8, end: 18 },
+        { start: 18, end: 21 },
+        { start: 21, end: 5 }
+      ]),
+      [{ start: 0, end: 24 }]
+    )
+  })
+
+  test('three contiguous chips merge into one wide range (dawn + day + dusk)', () => {
+    assert.deepEqual(
+      mergeChipRanges([
+        { start: 5, end: 8 },
+        { start: 8, end: 18 },
+        { start: 18, end: 21 }
+      ]),
+      [{ start: 5, end: 21 }]
+    )
   })
 })

--- a/test/renderer/dayPeriods.test.js
+++ b/test/renderer/dayPeriods.test.js
@@ -1,0 +1,87 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DAY_PERIOD_PRESETS,
+  DAY_PERIOD_ORDER,
+  chipsToRanges,
+  arcToRanges,
+  isFullDayArc
+} from '../../src/renderer/src/utils/dayPeriods.js'
+
+describe('DAY_PERIOD_PRESETS', () => {
+  test('exposes dawn/day/dusk/night with non-overlapping hour ranges', () => {
+    const keys = Object.keys(DAY_PERIOD_PRESETS).sort()
+    assert.deepEqual(keys, ['dawn', 'day', 'dusk', 'night'])
+    assert.deepEqual(DAY_PERIOD_PRESETS.dawn.range, { start: 5, end: 8 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.day.range, { start: 8, end: 18 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.dusk.range, { start: 18, end: 21 })
+    assert.deepEqual(DAY_PERIOD_PRESETS.night.range, { start: 21, end: 5 })
+  })
+
+  test('DAY_PERIOD_ORDER is chronological', () => {
+    assert.deepEqual(DAY_PERIOD_ORDER, ['dawn', 'day', 'dusk', 'night'])
+  })
+})
+
+describe('chipsToRanges', () => {
+  test('empty selection returns empty ranges', () => {
+    assert.deepEqual(chipsToRanges(new Set()), [])
+  })
+
+  test('single chip returns its range', () => {
+    assert.deepEqual(chipsToRanges(new Set(['day'])), [{ start: 8, end: 18 }])
+  })
+
+  test('dawn + dusk returns both ranges (crepuscular)', () => {
+    assert.deepEqual(chipsToRanges(new Set(['dawn', 'dusk'])), [
+      { start: 5, end: 8 },
+      { start: 18, end: 21 }
+    ])
+  })
+
+  test('all four chips returns all four ranges in canonical order', () => {
+    assert.deepEqual(chipsToRanges(new Set(['night', 'day', 'dusk', 'dawn'])), [
+      { start: 5, end: 8 },
+      { start: 8, end: 18 },
+      { start: 18, end: 21 },
+      { start: 21, end: 5 }
+    ])
+  })
+
+  test('ignores unknown chip keys', () => {
+    assert.deepEqual(chipsToRanges(new Set(['day', 'midnight'])), [{ start: 8, end: 18 }])
+  })
+})
+
+describe('isFullDayArc', () => {
+  test('detects 0–24 as full day', () => {
+    assert.equal(isFullDayArc({ start: 0, end: 24 }), true)
+  })
+
+  test('detects start === end as full day', () => {
+    assert.equal(isFullDayArc({ start: 6, end: 6 }), true)
+  })
+
+  test('detects near-full ranges within 0.1h tolerance', () => {
+    assert.equal(isFullDayArc({ start: 0.05, end: 23.95 }), true)
+  })
+
+  test('partial range is not full day', () => {
+    assert.equal(isFullDayArc({ start: 8, end: 18 }), false)
+  })
+})
+
+describe('arcToRanges', () => {
+  test('full-day arc returns empty (no filter)', () => {
+    assert.deepEqual(arcToRanges({ start: 0, end: 24 }), [])
+  })
+
+  test('partial arc returns single range', () => {
+    assert.deepEqual(arcToRanges({ start: 8, end: 18 }), [{ start: 8, end: 18 }])
+  })
+
+  test('wrap-around arc returns single range', () => {
+    assert.deepEqual(arcToRanges({ start: 21, end: 5 }), [{ start: 21, end: 5 }])
+  })
+})


### PR DESCRIPTION
## Summary

- **Four day-period chips** (Dawn/Day/Dusk/Night) below the polar clock in both Media and Activity tabs, with lucide icons (Sunrise/Sun/Sunset/MoonStar). Multi-select with union semantics: Dawn+Dusk yields crepuscular for free, all four collapses to a single full-day sweep. Default is all four (mirrors the timeline's "full date range" default).
- **Polar / X-Y chart-shape toggle** (segmented control, blue active state, floats top-right) — same hourly-bin data rendered as either the existing radar or a line over a 24h x-axis.
- **X-Y drag interactions**:
  - Click near the start or end edge → slides that edge (visible handle dot grows on hover)
  - Click in the middle of the band → pans the whole band, wrapping at midnight
  - Click outside the band / no band → drag-to-create
  - Dynamic cursor preview: `move` for pan, `ew-resize` for edges, `crosshair` for create
  - Drag continues outside the chart via document-level listeners
- **Filter-active indicator**: small blue dot on the FilterChartsToggle button + tooltip line when any time-of-day filter is active.
- **Backend**: `timeRange` filter generalised from `{start, end}` to `{ranges: [{start, end}, ...]}` with `normalizeTimeRange` for backward compat. Refactor covers both `sequences.js` queries and the heatmap chain (`species.js`, `worker.js`, `ipc/sequences.js`, preload).
- **Tests**: 25 new tests — pure helpers (dayPeriods) + DB-integration tests for the multi-range filter and wrap-around cases. All 1271 tests pass.
- **Docs**: spec at \`docs/specs/2026-05-13-day-period-presets-design.md\`, plan at \`docs/plans/2026-05-13-day-period-presets-plan.md\`, IPC API doc updated.

<img width="195" height="199" alt="image" src="https://github.com/user-attachments/assets/87e9abe2-6bc5-4ee0-8b83-4c40d5051783" />
<img width="190" height="197" alt="image" src="https://github.com/user-attachments/assets/5743b943-dac9-4309-b1df-1b505280a292" />


## Test plan

- [x] Media tab: toggle each chip individually, then in pairs (Dawn+Dusk = crepuscular). Confirm gallery filters and refreshes correctly on each chip change.
- [x] Activity tab: same chip behavior; also confirm the species heatmap on the map updates as chips change.
- [x] Deselect all chips → polar shows the drag handles, no highlighted arc.
- [x] Polar: drag the handles, confirm gallery/heatmap respect the new range. Filter-active indicator (blue dot) lights up when not at full day.
- [x] X-Y toggle: switch between polar and line views; same data visible in both shapes.
- [x] X-Y drag: slide each edge, pan the band past midnight (should wrap), drag-to-create when no band.
- [x] X-Y cursor preview: \`move\` (cross) inside band, \`ew-resize\` near edges, \`crosshair\` outside.
- [x] Release the mouse outside the chart while dragging — band still commits at cursor position.
- [x] Tooltip on the filter button shows "Filters active" when ranges are partial.