### PR TITLE
Timeline brush: zoom-on-release, scroll-wheel zoom, line+dot handles, persistence

### DIFF
--- a/docs/specs/2026-05-13-timeline-zoom-design.md
+++ b/docs/specs/2026-05-13-timeline-zoom-design.md
@@ -1,0 +1,149 @@
+# Timeline brush — zoom-on-release + line+dot handles
+
+Status: design
+Author: brainstorm (2026-05-13)
+Scope: `src/renderer/src/ui/timeseries.jsx` (the `TimelineChart` component shared by the media and activity tabs)
+
+## Problem
+
+The date-range brush on the media and activity tabs is a flat selector: dragging or resizing it only narrows the filter; the chart's x-axis always shows the full data extent. Users can't focus on the selected range, and the brush's handles use a different visual language (5px translucent rectangles) than the recently-redesigned day-activity chart edge handles (vertical line + circle dot).
+
+## Goals
+
+1. Resizing or selecting a range on the brush zooms the chart's x-axis to that range on release.
+2. The scroll wheel zooms in or out around the cursor; scrolling all the way out clears the filter.
+3. The brush's edge handles match the visual style of the day-activity chart's edge handles.
+
+## Non-goals
+
+- Sub-day (hour-level) filtering. The data is binned per-day; the minimum range is 1 day.
+- Smooth interpolated zoom-on-release animation. The chart snaps to the new domain in v1; animation is v2 polish.
+- A dedicated "reset zoom" button. Scrolling out to full extent clears the filter; the FilterChartsToggle indicator already shows when a filter is active.
+- Modifier-key gestures (Shift-pan, Ctrl-zoom, etc.).
+- Changes to the parent prop contract. `dateRange`, `setDateRange`, `timeseriesData`, `selectedSpecies`, `palette` stay identical.
+
+## Model
+
+**Unified viewport == filter.** A single piece of state — the parent's `dateRange = [Date|null, Date|null]` — represents both the date filter (what downstream sequence-aware queries return) and the chart's visible x-axis domain.
+
+- `dateRange === [null, null]` is the cleared state. The chart's `XAxis domain = ['dataMin', 'dataMax']`. No filter is applied downstream.
+- `dateRange === [start, end]` with values is the zoomed state. The chart's `XAxis domain = [start, end]`. Downstream queries receive the filter.
+- A clearing rule keeps the model honest: if any commit would expand `dateRange` to `≥ [dataMin, dataMax]` within a 12h tolerance, set `[null, null]` instead. This keeps the active-filter indicator correct.
+
+## Gestures
+
+All four gestures map to the same `[start, end]` state. Local `dragState` follows the shape used by `DailyActivityLine`:
+
+```
+dragState = { mode: 'edge-start' | 'edge-end' | 'pan' | 'create',
+              liveStart: Date, liveEnd: Date }
+```
+
+Handles are always present, always docked at the current viewport edges (`dateRange[0]` and `dateRange[1]`, or `dataMin` and `dataMax` when cleared). `dataMin` and `dataMax` mean the first and last entries of `timeseriesData` (the same convention the current `XAxis domain={['dataMin', 'dataMax']}` uses). The handle's *visual position* is always the chart's left or right edge; its *date value* is whichever endpoint of the current range it represents.
+
+| Where you click | At full extent (cleared) | Zoomed in |
+|---|---|---|
+| Near an edge handle | Narrow from that side → zooms on release | Narrow further from that side |
+| Body of chart | Drag-to-select a sub-range → zooms on release | Pan viewport+filter |
+| Scroll wheel | Zoom in around cursor | Zoom in/out around cursor |
+
+`actionAt(cursor)` resolves the gesture (and the cursor preview) the same way `DailyActivityLine` does, but with a pixel-based edge tolerance instead of a data-space one (because date ranges vary from days to years and a date-space tolerance is meaningless). Within ~10 screen pixels of an edge line → `edge-start` / `edge-end`; otherwise on body → `pan` (zoomed) or `create` (full extent). The 10px is converted to a date delta per-event via the current chart-rect width: `tolDate = 10 * (end - start) / innerWidth`.
+
+### 1. Edge-handle drag
+
+- Visible at all times. Vertical blue line + centered circle dot, docked at the current viewport edges.
+- Mousedown captures the opposite endpoint as fixed.
+- Mousemove updates `liveStart` or `liveEnd` from the cursor's x-position (converted to a date via the same chart-rect math as `DailyActivityLine.eventToHour`, adapted to dates).
+- Clamps during drag: keep `liveStart < liveEnd` with a minimum gap of 1 day; both endpoints stay within `[dataMin, dataMax]`.
+- On mouseup: `setDateRange([liveStart, liveEnd])`, or `[null, null]` if the clearing rule triggers.
+- Hover thickens the line 2→3px and grows the dot radius 4→6.
+
+### 2. Body pan (zoomed in only)
+
+- Mousedown on chart body when zoomed in → pan mode.
+- Mousemove shifts both `liveStart` and `liveEnd` by the cursor delta (in date space).
+- Clamped to data bounds: the pan stops when either endpoint hits `dataMin` or `dataMax`. No wrapping.
+- On mouseup: commit.
+
+### 3. Drag-to-create (full extent only)
+
+- Mousedown on chart body when cleared → create mode.
+- Live preview rectangle (thin blue stroke + 0.2 fill opacity, matching `DailyActivityLine.liveSegments`) follows the cursor.
+- On mouseup with `Math.abs(liveEnd - liveStart) ≥ 1 day`: `setDateRange([min, max])`. Chart zooms.
+- On mouseup with effectively zero drag (a click): no-op.
+
+### 4. Scroll-wheel zoom
+
+- `wheel` listener on the chart wrapper with `e.preventDefault()` (only when the wheel falls inside the wrapper).
+- Factor: `Math.exp(-e.deltaY * 0.0015)` — ~10% per mouse wheel tick, ~5% per touchpad pinch increment.
+- Direction: `deltaY < 0` (scroll up / two-finger up on touchpad) = zoom in.
+- Anchor: the date under the cursor stays put. New range:
+  ```
+  anchorDate = pixelToDate(cursorX)
+  newStart = anchorDate - (anchorDate - start) * factor
+  newEnd   = anchorDate + (end - anchorDate) * factor
+  ```
+  where `start` and `end` are the current viewport endpoints (`dataMin` / `dataMax` when cleared).
+- Zoom-in clamp: minimum range 1 day. Further scroll-in is a no-op.
+- Zoom-out clamp: if the resulting range ≥ full data extent (within 12h tolerance), commit `[null, null]`.
+- Throttle: coalesce wheel commits with `requestAnimationFrame` (≤ ~60/sec). Local state updates per-event; the commit to the parent is rAF-throttled.
+- At full extent (cleared): scroll-up zooms in (creates a filter), scroll-down is a no-op.
+
+## Visual
+
+**Handles.** Identical to `DailyActivityLine`:
+- Vertical line, full chart-plot height, `stroke="rgb(59 130 246)"`, strokeWidth `2` idle / `3` hover.
+- Centered circle dot: `r=4` idle / `r=6` hover, `fill="rgb(59 130 246)"`, `stroke="white"`, strokeWidth `1`.
+- Implemented as Recharts `ReferenceLine` with a custom `label.content` returning a `<circle>` — same pattern as `clock.jsx` lines 696-744.
+
+**Brush body fill.** None. The translucent blue rectangle is removed entirely. The visible x-axis range communicates the filter state.
+
+**Live drag preview** (create + edge + pan during drag). Render exactly like `DailyActivityLine.liveSegments`:
+- `fill="rgb(59 130 246)"`, `fillOpacity={0.2}`, `stroke="rgb(59 130 246)"`, `strokeOpacity={0.7}`, `strokeWidth={1}`.
+- Appears only while `dragState !== null`; replaced by handles + zoomed chart on commit.
+
+**Cursor.** Inline style on the wrapper with `[&_*]:!cursor-[inherit]` so Recharts' SVG defaults don't override:
+- `crosshair` — full extent, hovering chart body
+- `move` — zoomed, hovering chart body (or during pan drag)
+- `ew-resize` — near an edge handle (or during edge drag)
+- `default` otherwise
+
+## Implementation outline
+
+Port `TimelineChart` from the current Recharts `Customized` + `Rectangle` approach to the native-mousedown + container-ref pattern used by `DailyActivityLine`. Concretely:
+
+1. Wrap the chart in a `containerRef` div with `onMouseDown`, `onMouseMove`, `onMouseLeave`, `onWheel`. Document-level `mousemove` and `mouseup` listeners during active drag (matching `clock.jsx` lines 581-605).
+2. Helper `eventToDate(e, { clamp = true })` mirroring `eventToHour` — converts a pointer event to a `Date` accounting for the chart's left/right margin.
+3. `actionAt(cursor)` resolves the gesture (and cursor) based on the current `dateRange` and cursor position.
+4. The chart's `XAxis domain` is derived: `dateRange[0] != null && dateRange[1] != null ? [dateRange[0], dateRange[1]] : ['dataMin', 'dataMax']`.
+5. Two `ReferenceLine` handles render whenever the chart has data, at the current viewport edges. Their `label.content` renders the circle dot.
+6. Live drag preview renders a `ReferenceArea` while `dragState !== null`.
+7. Wheel handler uses rAF coalescing to call `setDateRange` at most once per frame.
+8. Preserve the existing `dragging` ref guard in `timeseries.jsx:36-39` so external `dateRange` prop changes during a drag don't clobber in-flight state.
+
+## Edge cases
+
+- **Empty data** (`timeseriesData.length === 0`): no handles, no listeners attached, chart renders empty (current behavior preserved).
+- **Single day of data** (`dataMin === dataMax`): handles render but every drag is a no-op due to the 1-day min-range clamp. Acceptable degenerate state.
+- **External `dateRange` change mid-drag**: ignored (existing `dragging`/`resizing` ref guard preserved).
+- **Two charts on screen** (media tab has the timeline + day-activity polar/x-y): each chart's wrapper handles its own wheel; no cross-talk.
+- **Drag continues outside the chart**: handled by document-level mousemove/mouseup, same as `DailyActivityLine`.
+- **Text selection during drag**: prevented by `select-none` on the wrapper and `e.preventDefault()` on mousedown.
+
+## Test plan
+
+- Manual: with a multi-month dataset on the media tab —
+  - Drag an edge handle inward → chart zooms to the new range on release; filter chip shows active state.
+  - Scroll up over the chart → zooms in around cursor; date under cursor stays put.
+  - Scroll all the way out → filter clears; `dateRange === [null, null]`; FilterChartsToggle dot disappears.
+  - Drag chart body while zoomed → viewport+filter pans; stops at data edges.
+  - Drag chart body at full extent → live preview rectangle; release commits.
+  - Switch to the activity tab → same gestures work; map markers update with the filter.
+- Edge: single-day dataset, empty dataset, very large dataset (~1 year of daily bins) — chart remains responsive during scroll-wheel zoom.
+
+## Out of scope (v2 candidates)
+
+- Smooth interpolated zoom-on-release (rAF lerp over ~200ms).
+- Hour-level / sub-day filtering.
+- Modifier-key gestures.
+- Visible "Reset zoom" button.

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -18,6 +18,7 @@ import {
   arcToRanges,
   chipsToRanges,
   DAY_PERIOD_ORDER,
+  DAY_PERIOD_PRESETS,
   mergeChipRanges
 } from './utils/dayPeriods'
 import HideLeafletAttribution from './ui/HideLeafletAttribution'
@@ -34,6 +35,7 @@ import { formatScientificName } from './utils/scientificName'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 import { useShowFilterCharts } from './hooks/useShowFilterCharts'
+import { useDateRange } from './hooks/useDateRange'
 
 // Inject the keyframes used by the skeleton markers once per page load.
 // Guarded by an id check so HMR / multiple SpeciesMap mounts don't re-append
@@ -584,7 +586,7 @@ export default function Activity({ studyData, studyId }) {
 
   const [selectedSpecies, setSelectedSpecies] = useState([])
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
-  const [dateRange, setDateRange] = useState([null, null])
+  const { dateRange, setDateRange } = useDateRange(actualStudyId)
   const [fullExtent, setFullExtent] = useState([null, null])
   const [chipSelection, setChipSelection] = useState(() => new Set(ALL_CHIPS_SELECTED))
   const [arc, setArc] = useState({ start: 0, end: 24 })
@@ -607,7 +609,33 @@ export default function Activity({ studyData, studyId }) {
     return arcToRanges(arc)
   }, [chipSelection, arc])
 
-  const isFiltering = useMemo(() => timeRange.ranges.length > 0, [timeRange])
+  const hasDateFilter = useMemo(() => !!(dateRange[0] && dateRange[1]), [dateRange])
+  const isFiltering = useMemo(
+    () => timeRange.ranges.length > 0 || hasDateFilter,
+    [timeRange, hasDateFilter]
+  )
+
+  const dayFilterLabel = useMemo(() => {
+    if (timeRange.ranges.length === 0) return null
+    if (chipSelection.size > 0) {
+      return DAY_PERIOD_ORDER.filter((k) => chipSelection.has(k))
+        .map((k) => DAY_PERIOD_PRESETS[k].label)
+        .join(', ')
+    }
+    const fmt = (h) => `${String(Math.floor(h)).padStart(2, '0')}:00`
+    return `${fmt(arc.start)} → ${fmt(arc.end)}`
+  }, [timeRange, chipSelection, arc])
+  const dateFilterLabel = useMemo(() => {
+    if (!hasDateFilter) return null
+    const fmt = (d) =>
+      d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    return `${fmt(dateRange[0])} → ${fmt(dateRange[1])}`
+  }, [hasDateFilter, dateRange])
+  const handleResetFilters = useCallback(() => {
+    setChipSelection(new Set(ALL_CHIPS_SELECTED))
+    setArc({ start: 0, end: 24 })
+    setDateRange([null, null])
+  }, [setDateRange])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
@@ -699,58 +727,52 @@ export default function Activity({ studyData, studyId }) {
     return timeseriesData && timeseriesData.length > 0
   }, [timeseriesData])
 
-  // Initialize dateRange and fullExtent from timeseries data (side effect, keep as useEffect)
+  // Set fullExtent from the timeseries data so downstream `isFullRange`
+  // and components can reason about the data's outer bounds. dateRange
+  // itself is NOT auto-initialised — [null, null] is the "no filter"
+  // sentinel in the unified model, and a persisted range (if any) is
+  // already restored by useDateRange.
   useEffect(() => {
-    if (hasTemporalData && dateRange[0] === null && dateRange[1] === null) {
-      const startIndex = 0
-      const endIndex = timeseriesData.length - 1
+    if (!hasTemporalData) return
+    const startDate = new Date(timeseriesData[0].date)
+    const endDate = new Date(timeseriesData[timeseriesData.length - 1].date)
+    setFullExtent([startDate, endDate])
+  }, [hasTemporalData, timeseriesData])
 
-      const startDate = new Date(timeseriesData[startIndex].date)
-      const endDate = new Date(timeseriesData[endIndex].date)
-
-      setDateRange([startDate, endDate])
-      setFullExtent([startDate, endDate])
-    }
-  }, [hasTemporalData, timeseriesData, dateRange])
-
-  // Compute if user has selected full temporal range (with 1 day tolerance)
-  // Also true when dataset has no temporal data (to include all null-timestamp media)
+  // Compute if user has selected full temporal range (with 1 day tolerance).
+  // True when dataset has no temporal data (to include all null-timestamp
+  // media) AND when dateRange is [null, null] — the "no filter" sentinel
+  // semantically means "include everything" (matches media.jsx).
   const isFullRange = useMemo(() => {
     if (!hasTemporalData) return true
-    if (!fullExtent[0] || !fullExtent[1] || !dateRange[0] || !dateRange[1]) {
-      return false
-    }
+    if (!dateRange[0] || !dateRange[1]) return true
+    if (!fullExtent[0] || !fullExtent[1]) return false
     const tolerance = 86400000 // 1 day in milliseconds
     const startMatch = Math.abs(fullExtent[0].getTime() - dateRange[0].getTime()) < tolerance
     const endMatch = Math.abs(fullExtent[1].getTime() - dateRange[1].getTime()) < tolerance
     return startMatch && endMatch
   }, [hasTemporalData, fullExtent, dateRange])
 
-  // Fetch sequence-aware heatmap data.
-  //
-  // The `enabled` gate defers the fetch until every queryKey input has
-  // settled, so the expensive (~11s on gmu8_leuven) heatmap query fires
-  // exactly once instead of twice:
-  //
-  //   1. sequenceGap undefined → skip (useSequenceGap still resolving).
-  //   2. timeseriesQueryData undefined → skip. Without this, the heatmap
-  //      would fire once with dateRange=[null,null] (because isFullRange
-  //      defaults to true when hasTemporalData=false), and then again
-  //      when the timeseries useEffect fills in dateRange — two 11s
-  //      hits of the worker for the same semantic query.
-  //   3. Datasets WITH temporal data: require dateRange to be populated
-  //      (via the useEffect that runs one tick after timeseries resolves).
-  //   4. Datasets WITHOUT temporal data: dateRange stays [null, null] and
-  //      we fire with isFullRange=true (includeNullTimestamps semantics).
-  //
-  // Mirrors media.jsx's b5c4dca "defer mounting until inputs stable" guard.
+  // For backend queries, fall back to fullExtent when the user hasn't set
+  // a date filter. dateRange itself stays [null, null] in the parent so
+  // TimelineChart can render its cleared/zoomed visual state correctly;
+  // this fallback is local to the query calls. Mirrors media.jsx.
+  const effectiveStart = dateRange[0] ?? fullExtent[0]
+  const effectiveEnd = dateRange[1] ?? fullExtent[1]
+
+  // Fetch sequence-aware heatmap data. The `enabled` gate defers the
+  // fetch until every queryKey input has settled (sequenceGap resolved,
+  // timeseriesQueryData loaded), so the expensive (~11s on gmu8_leuven)
+  // heatmap query fires once. dateRange=[null,null] is the "no filter"
+  // sentinel — the backend treats it as "include everything," so we
+  // don't need to gate on dateRange being populated.
   const { data: heatmapData, isLoading: isHeatmapLoading } = useQuery({
     queryKey: [
       'sequenceAwareHeatmap',
       actualStudyId,
       [...speciesNames].sort(),
-      dateRange[0]?.toISOString(),
-      dateRange[1]?.toISOString(),
+      effectiveStart?.toISOString(),
+      effectiveEnd?.toISOString(),
       JSON.stringify(timeRange.ranges),
       isFullRange,
       sequenceGap
@@ -759,8 +781,8 @@ export default function Activity({ studyData, studyId }) {
       const response = await window.api.getSequenceAwareHeatmap(
         actualStudyId,
         speciesNames,
-        dateRange[0]?.toISOString(),
-        dateRange[1]?.toISOString(),
+        effectiveStart?.toISOString(),
+        effectiveEnd?.toISOString(),
         timeRange,
         isFullRange
       )
@@ -772,7 +794,11 @@ export default function Activity({ studyData, studyId }) {
       speciesNames.length > 0 &&
       sequenceGap !== undefined &&
       timeseriesQueryData !== undefined &&
-      (!hasTemporalData || (!!dateRange[0] && !!dateRange[1])),
+      // Studies without temporal data (e.g. ENA24): fullExtent stays
+      // [null, null] forever; fire anyway and let the backend's
+      // noDateFilter path return all media (heatmap is keyed by
+      // species/lat/lng, not by timestamp).
+      (!hasTemporalData || (!!effectiveStart && !!effectiveEnd)),
     placeholderData: (prev) => prev,
     staleTime: Infinity
   })
@@ -791,16 +817,16 @@ export default function Activity({ studyData, studyId }) {
       'sequenceAwareDailyActivity',
       actualStudyId,
       [...speciesNames].sort(),
-      dateRange[0]?.toISOString(),
-      dateRange[1]?.toISOString(),
+      effectiveStart?.toISOString(),
+      effectiveEnd?.toISOString(),
       sequenceGap
     ],
     queryFn: async () => {
       const response = await window.api.getSequenceAwareDailyActivity(
         actualStudyId,
         speciesNames,
-        dateRange[0]?.toISOString(),
-        dateRange[1]?.toISOString()
+        effectiveStart?.toISOString(),
+        effectiveEnd?.toISOString()
       )
       if (response.error) throw new Error(response.error)
       return response.data
@@ -808,9 +834,9 @@ export default function Activity({ studyData, studyId }) {
     enabled:
       !!actualStudyId &&
       speciesNames.length > 0 &&
-      !!dateRange[0] &&
-      !!dateRange[1] &&
-      sequenceGap !== undefined,
+      sequenceGap !== undefined &&
+      !!effectiveStart &&
+      !!effectiveEnd,
     placeholderData: (prev) => prev,
     staleTime: Infinity
   })
@@ -889,6 +915,9 @@ export default function Activity({ studyData, studyId }) {
                       // (ENA24, Biome Health Project, etc).
                       hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
                       isFiltering={isFiltering}
+                      dayFilterLabel={dayFilterLabel}
+                      dateFilterLabel={dateFilterLabel}
+                      onResetFilters={handleResetFilters}
                     />
                   </div>
                 </div>

--- a/src/renderer/src/hooks/useDateRange.js
+++ b/src/renderer/src/hooks/useDateRange.js
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+const storageKey = (studyId) => `dateRange:${studyId}`
+
+function readFromStorage(studyId) {
+  try {
+    const raw = localStorage.getItem(storageKey(studyId))
+    if (raw === null) return [null, null]
+    const [s, e] = JSON.parse(raw)
+    return [s ? new Date(s) : null, e ? new Date(e) : null]
+  } catch {
+    return [null, null]
+  }
+}
+
+/**
+ * Per-study persistence for the timeline brush's date filter. Same shape
+ * as {@link useShowFilterCharts}: backed by localStorage, broadcast
+ * through the React Query cache so the Media and Activity tabs share the
+ * same range and the value survives navigating away and back to the tab.
+ *
+ * Returns `[null, null]` when no filter is set (the cleared / full-extent
+ * sentinel that downstream queries treat as "include everything").
+ *
+ * @param {string} studyId
+ * @returns {{ dateRange: [Date|null, Date|null], setDateRange: (next: [Date|null, Date|null] | ((prev: [Date|null, Date|null]) => [Date|null, Date|null])) => void }}
+ */
+export function useDateRange(studyId) {
+  const queryClient = useQueryClient()
+  const queryKey = useMemo(() => ['dateRange', studyId], [studyId])
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: () => readFromStorage(studyId),
+    enabled: !!studyId,
+    staleTime: Infinity,
+    initialData: () => readFromStorage(studyId)
+  })
+
+  const dateRange = data ?? [null, null]
+
+  const setDateRange = useCallback(
+    (next) => {
+      const prev = queryClient.getQueryData(queryKey) ?? [null, null]
+      const value = typeof next === 'function' ? next(prev) : next
+      queryClient.setQueryData(queryKey, value)
+      try {
+        localStorage.setItem(
+          storageKey(studyId),
+          JSON.stringify([value[0]?.toISOString() ?? null, value[1]?.toISOString() ?? null])
+        )
+      } catch {
+        // ignore quota / disabled storage
+      }
+    },
+    [queryClient, queryKey, studyId]
+  )
+
+  return { dateRange, setDateRange }
+}

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -9,6 +9,7 @@ import {
   arcToRanges,
   chipsToRanges,
   DAY_PERIOD_ORDER,
+  DAY_PERIOD_PRESETS,
   mergeChipRanges
 } from './utils/dayPeriods'
 import SpeciesDistribution from './ui/speciesDistribution'
@@ -16,6 +17,7 @@ import TimelineChart from './ui/timeseries'
 import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 import { useShowFilterCharts } from './hooks/useShowFilterCharts'
+import { useDateRange } from './hooks/useDateRange'
 import { useImportStatus } from './hooks/import'
 import Gallery from './media/Gallery'
 import GalleryDisplayStrip from './media/GalleryDisplayStrip'
@@ -41,7 +43,7 @@ export default function Activity({ studyData, studyId }) {
   // Timeline, Radar) only mount once their queryKey inputs are stable
   // rather than fetching on every cascading state update.
   const [speciesInitialized, setSpeciesInitialized] = useState(false)
-  const [dateRange, setDateRange] = useState([null, null])
+  const { dateRange, setDateRange } = useDateRange(actualStudyId)
   const [fullExtent, setFullExtent] = useState([null, null])
   const [chipSelection, setChipSelection] = useState(() => new Set(ALL_CHIPS_SELECTED))
   const [arc, setArc] = useState({ start: 0, end: 24 })
@@ -67,8 +69,38 @@ export default function Activity({ studyData, studyId }) {
   }, [chipSelection, arc])
 
   // Indicator dot on the filter-charts toggle: true when any time-of-day
-  // filter is active (chips or partial drag-arc).
-  const isFiltering = useMemo(() => timeRange.ranges.length > 0, [timeRange])
+  // filter is active (chips or partial drag-arc) OR a date-range filter
+  // is set (timeline brush narrowed below the full extent).
+  const hasDateFilter = useMemo(() => !!(dateRange[0] && dateRange[1]), [dateRange])
+  const isFiltering = useMemo(
+    () => timeRange.ranges.length > 0 || hasDateFilter,
+    [timeRange, hasDateFilter]
+  )
+
+  // Human-readable labels for the filter-toggle tooltip. Day filter is
+  // either chip names (e.g. "Dawn, Dusk") or an hour range from the
+  // freeform drag-arc ("18:00 → 21:00"). Date filter is the calendar range.
+  const dayFilterLabel = useMemo(() => {
+    if (timeRange.ranges.length === 0) return null
+    if (chipSelection.size > 0) {
+      return DAY_PERIOD_ORDER.filter((k) => chipSelection.has(k))
+        .map((k) => DAY_PERIOD_PRESETS[k].label)
+        .join(', ')
+    }
+    const fmt = (h) => `${String(Math.floor(h)).padStart(2, '0')}:00`
+    return `${fmt(arc.start)} → ${fmt(arc.end)}`
+  }, [timeRange, chipSelection, arc])
+  const dateFilterLabel = useMemo(() => {
+    if (!hasDateFilter) return null
+    const fmt = (d) =>
+      d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+    return `${fmt(dateRange[0])} → ${fmt(dateRange[1])}`
+  }, [hasDateFilter, dateRange])
+  const handleResetFilters = useCallback(() => {
+    setChipSelection(new Set(ALL_CHIPS_SELECTED))
+    setArc({ start: 0, end: 24 })
+    setDateRange([null, null])
+  }, [setDateRange])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
 
   // Sequence gap - uses React Query for sync across components
@@ -301,6 +333,9 @@ export default function Activity({ studyData, studyId }) {
                   // we've confirmed the study has none.
                   hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
                   isFiltering={isFiltering}
+                  dayFilterLabel={dayFilterLabel}
+                  dateFilterLabel={dateFilterLabel}
+                  onResetFilters={handleResetFilters}
                 />
               )}
               {speciesDistributionData && (
@@ -377,7 +412,7 @@ export default function Activity({ studyData, studyId }) {
                   <TimelineChart
                     timeseriesData={timeseriesData}
                     selectedSpecies={selectedSpecies}
-                    dateRange={[dateRange[0] ?? fullExtent[0], dateRange[1] ?? fullExtent[1]]}
+                    dateRange={dateRange}
                     setDateRange={setDateRange}
                     palette={palette}
                   />

--- a/src/renderer/src/media/GalleryDisplayStrip.jsx
+++ b/src/renderer/src/media/GalleryDisplayStrip.jsx
@@ -15,7 +15,14 @@ import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
  * `hasTemporalData` is forwarded to {@link FilterChartsToggle} so studies
  * without media timestamps don't show a toggle that can't do anything.
  */
-export default function GalleryDisplayStrip({ studyId, hasTemporalData, isFiltering = false }) {
+export default function GalleryDisplayStrip({
+  studyId,
+  hasTemporalData,
+  isFiltering = false,
+  dayFilterLabel = null,
+  dateFilterLabel = null,
+  onResetFilters = null
+}) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(studyId)
   const { showThumbnailBboxes, setShowThumbnailBboxes } = useShowThumbnailBboxes(studyId)
 
@@ -76,6 +83,9 @@ export default function GalleryDisplayStrip({ studyId, hasTemporalData, isFilter
           studyId={studyId}
           hasTemporalData={hasTemporalData}
           isFiltering={isFiltering}
+          dayFilterLabel={dayFilterLabel}
+          dateFilterLabel={dateFilterLabel}
+          onResetFilters={onResetFilters}
         />
       </div>
     </div>

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -19,7 +19,10 @@ import { useShowFilterCharts } from '../hooks/useShowFilterCharts'
 export default function FilterChartsToggle({
   studyId,
   hasTemporalData = true,
-  isFiltering = false
+  isFiltering = false,
+  dayFilterLabel = null,
+  dateFilterLabel = null,
+  onResetFilters = null
 }) {
   const { showFilterCharts, setShowFilterCharts } = useShowFilterCharts(studyId)
 
@@ -53,17 +56,46 @@ export default function FilterChartsToggle({
           align="end"
           className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
         >
-          <p className="font-medium mb-1">
-            {showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
-          </p>
+          <div className="flex items-start justify-between gap-3 mb-1">
+            <p className="font-medium">
+              {showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
+            </p>
+            {isFiltering && (
+              <p className="text-blue-600 dark:text-blue-400 whitespace-nowrap leading-snug">
+                <span className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 mr-1 align-middle" />
+                Active
+              </p>
+            )}
+          </div>
           <p className="text-muted-foreground leading-snug">
             Daily-activity clock and timeline filters.
           </p>
-          {isFiltering && (
-            <p className="mt-1.5 text-blue-600 dark:text-blue-400 leading-snug">
-              <span className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 mr-1 align-middle" />
-              Filters active
-            </p>
+          {isFiltering && (dayFilterLabel || dateFilterLabel) && (
+            <ul className="mt-1.5 space-y-0.5 text-popover-foreground/90">
+              {dayFilterLabel && (
+                <li>
+                  <span className="text-muted-foreground">Time of day: </span>
+                  {dayFilterLabel}
+                </li>
+              )}
+              {dateFilterLabel && (
+                <li>
+                  <span className="text-muted-foreground">Date range: </span>
+                  {dateFilterLabel}
+                </li>
+              )}
+            </ul>
+          )}
+          {isFiltering && onResetFilters && (
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={onResetFilters}
+                className="text-[11px] text-blue-600 dark:text-blue-400 hover:underline cursor-pointer"
+              >
+                Reset filters
+              </button>
+            </div>
           )}
           <Tooltip.Arrow className="fill-popover" />
         </Tooltip.Content>

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -54,10 +54,10 @@ export default function FilterChartsToggle({
           side="bottom"
           sideOffset={10}
           align="end"
-          className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+          className="z-[10000] max-w-[18rem] px-3.5 py-3 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
         >
-          <div className="flex items-start justify-between gap-3 mb-1">
-            <p className="font-medium">
+          <div className="flex items-start justify-between gap-4 mb-2">
+            <p className="font-medium leading-snug">
               {showFilterCharts ? 'Hide filter charts' : 'Show filter charts'}
             </p>
             {isFiltering && (
@@ -67,27 +67,27 @@ export default function FilterChartsToggle({
               </p>
             )}
           </div>
-          <p className="text-muted-foreground leading-snug">
+          <p className="text-muted-foreground leading-relaxed">
             Daily-activity clock and timeline filters.
           </p>
           {isFiltering && (dayFilterLabel || dateFilterLabel) && (
-            <ul className="mt-1.5 space-y-0.5 text-popover-foreground/90">
+            <ul className="mt-3 pt-3 border-t border-border space-y-1.5 text-popover-foreground/90 leading-snug">
               {dayFilterLabel && (
-                <li>
-                  <span className="text-muted-foreground">Time of day: </span>
-                  {dayFilterLabel}
+                <li className="flex gap-2">
+                  <span className="text-muted-foreground shrink-0">Time of day</span>
+                  <span className="flex-1">{dayFilterLabel}</span>
                 </li>
               )}
               {dateFilterLabel && (
-                <li>
-                  <span className="text-muted-foreground">Date range: </span>
-                  {dateFilterLabel}
+                <li className="flex gap-2">
+                  <span className="text-muted-foreground shrink-0">Date range</span>
+                  <span className="flex-1">{dateFilterLabel}</span>
                 </li>
               )}
             </ul>
           )}
           {isFiltering && onResetFilters && (
-            <div className="mt-2 flex justify-end">
+            <div className="mt-3 flex justify-end">
               <button
                 type="button"
                 onClick={onResetFilters}

--- a/src/renderer/src/ui/timeseries.jsx
+++ b/src/renderer/src/ui/timeseries.jsx
@@ -1,284 +1,388 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   CartesianGrid,
-  Customized,
+  ComposedChart,
   Line,
-  LineChart,
-  Rectangle,
+  ReferenceArea,
+  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis
 } from 'recharts'
 
-// TimelineChart component using Recharts.
-//
-// dragDateRange is local state for the visual brush position during a drag;
-// setDateRange (the parent prop) is only called on pointer release, so the
-// downstream sequence-aware queries don't refetch once per mousemove.
+import {
+  clientXToDate,
+  clampMinRange,
+  clampPanToBounds,
+  resolveAction,
+  shouldClearToFullExtent,
+  pxToDateMs,
+  EDGE_PX_TOLERANCE,
+  MIN_RANGE_MS
+} from '../utils/timelineZoom.js'
+
+const MARGIN_X = 4 // matches the LineChart margin used below
+
+/**
+ * TimelineChart — date-range brush over a per-day species time-series.
+ *
+ * The brush range, the chart's visible x-axis, and the parent's date
+ * filter are the same state (`dateRange`). When dateRange is [null, null]
+ * the chart shows the full data extent and no filter is applied.
+ *
+ * Gesture model — see docs/specs/2026-05-13-timeline-zoom-design.md.
+ */
 const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRange, palette }) => {
-  const draggingRef = useRef(false)
-  const resizingRef = useRef(null) // null, 'left', or 'right'
-  const dragStartXRef = useRef(null)
-  const initialRangeRef = useRef(null)
-  const chartRef = useRef(null)
+  const containerRef = useRef(null)
+  const [dragState, setDragState] = useState(null)
+  const isDragging = dragState !== null
+  const [hoverAction, setHoverAction] = useState(null)
 
-  const [dragDateRange, setDragDateRange] = useState(dateRange)
-  // Mirror dragDateRange into a ref so handleMouseUp (a long-lived
-  // document event listener) can read the latest without the useCallback
-  // being recreated mid-drag and leaking a stale listener reference.
-  const dragDateRangeRef = useRef(dateRange)
-  useEffect(() => {
-    dragDateRangeRef.current = dragDateRange
-  }, [dragDateRange])
-  useEffect(() => {
-    // Sync from prop only when not actively dragging, so external updates
-    // don't clobber in-flight drag state.
-    if (!draggingRef.current && resizingRef.current === null) {
-      setDragDateRange(dateRange)
-    }
-  }, [dateRange])
-
-  // Format data for Recharts
-  const formatData = useCallback(() => {
+  const data = useMemo(() => {
     if (!timeseriesData) return []
-
     return timeseriesData.map((day) => {
-      const item = {
-        date: new Date(day.date),
-        displayDate: new Date(day.date).toLocaleDateString(undefined, {
-          month: 'short',
-          day: 'numeric',
-          year: '2-digit'
-        })
-      }
-
-      // Add data for each selected species
+      const item = { date: new Date(day.date).getTime() }
       selectedSpecies.forEach((species) => {
         item[species.scientificName] = day[species.scientificName] || 0
       })
-
       return item
     })
   }, [timeseriesData, selectedSpecies])
 
-  const data = formatData()
+  const fullExtent = useMemo(() => {
+    if (!data.length) return null
+    return [new Date(data[0].date), new Date(data[data.length - 1].date)]
+  }, [data])
 
-  // Custom component for the selection rectangle
-  const SelectionRangeRectangle = (props) => {
-    const { height, margin, xAxisMap } = props
+  // `domain` is the date space the chart's XAxis is showing — used to
+  // convert cursor-x to dates. In Task 2 the XAxis is still pinned to the
+  // full data extent, so this must be fullExtent (otherwise dragging a
+  // handle outward would clamp the cursor inside the narrowed dateRange
+  // and the handle couldn't widen). Task 3 will switch this (and the
+  // XAxis) to follow dateRange.
+  const domain = fullExtent
 
-    if (!dragDateRange[0] || !dragDateRange[1] || !data || data.length === 0 || !xAxisMap) {
-      return null
-    }
+  const cleared = !dateRange[0] || !dateRange[1]
 
-    // Use the xAxisMap scale function directly with actual Date objects
-    const scale = xAxisMap ? xAxisMap[0].scale : null
-
-    if (!scale) {
-      return null
-    }
-
-    // Get the x positions using the scale function from xAxisMap with actual Date objects
-    const x1 = scale(dragDateRange[0])
-    const x2 = scale(dragDateRange[1])
-
-    // Handle edge cases
-    if (isNaN(x1) || isNaN(x2)) {
-      console.log('Invalid x positions')
-      return null
-    }
-
-    // Calculate width and get available height
-    const rectWidth = Math.abs(x2 - x1)
-    const rectHeight = height - margin.top - margin.bottom
-
-    const handleMouseDown = (e, type) => {
-      e.stopPropagation()
-      e.preventDefault()
-
-      if (type === 'move') {
-        draggingRef.current = true
-      } else {
-        resizingRef.current = type
-      }
-
-      dragStartXRef.current = e.clientX
-      initialRangeRef.current = [...dragDateRange]
-
-      // Add global event listeners
-      document.addEventListener('mousemove', handleMouseMove)
-      document.addEventListener('mouseup', handleMouseUp)
-    }
-
-    return (
-      <g>
-        {/* Main selection rectangle */}
-        <Rectangle
-          x={x1}
-          y={margin.top}
-          width={rectWidth}
-          height={rectHeight}
-          fill="rgb(59 130 246 / 0.15)"
-          stroke="rgb(59 130 246 / 0.6)"
-          onMouseDown={(e) => handleMouseDown(e, 'move')}
-          style={{ cursor: 'move' }}
-        />
-
-        {/* Left resize handle */}
-        <Rectangle
-          x={x1}
-          y={margin.top}
-          width={5}
-          height={rectHeight}
-          fill="rgb(59 130 246 / 0.3)"
-          stroke="rgb(59 130 246 / 0.8)"
-          onMouseDown={(e) => handleMouseDown(e, 'left')}
-          style={{ cursor: 'ew-resize' }}
-        />
-
-        {/* Right resize handle */}
-        <Rectangle
-          x={x1 + rectWidth - 5}
-          y={margin.top}
-          width={5}
-          height={rectHeight}
-          fill="rgb(59 130 246 / 0.3)"
-          stroke="rgb(59 130 246 / 0.8)"
-          onMouseDown={(e) => handleMouseDown(e, 'right')}
-          style={{ cursor: 'ew-resize' }}
-        />
-      </g>
-    )
-  }
-
-  const handleMouseMove = useCallback(
-    (e) => {
-      if (!draggingRef.current && !resizingRef.current) return
-      if (!initialRangeRef.current || dragStartXRef.current === null || !chartRef.current) return
-
-      const chartElement = chartRef.current
-      if (!chartElement) return
-
-      const chartRect = chartElement.getBoundingClientRect()
-      const deltaX = e.clientX - dragStartXRef.current
-      const percentDelta = deltaX / chartRect.width
-
-      // Calculate how many days that represents
-      const timeRange = data[data.length - 1].date.getTime() - data[0].date.getTime()
-      const daysDelta = Math.round((percentDelta * timeRange) / (24 * 60 * 60 * 1000))
-
-      let newStartDate, newEndDate
-
-      if (draggingRef.current) {
-        // Move the entire selection
-        newStartDate = new Date(
-          initialRangeRef.current[0].getTime() + daysDelta * 24 * 60 * 60 * 1000
-        )
-        newEndDate = new Date(
-          initialRangeRef.current[1].getTime() + daysDelta * 24 * 60 * 60 * 1000
-        )
-
-        console.log('NEW START', newStartDate)
-        console.log('NEW END', newEndDate)
-
-        // Make sure we don't go out of bounds
-        if (newStartDate < data[0].date) {
-          const adjustment = data[0].date.getTime() - newStartDate.getTime()
-          newStartDate = new Date(data[0].date)
-          newEndDate = new Date(newEndDate.getTime() + adjustment)
-        }
-
-        if (newEndDate > data[data.length - 1].date) {
-          const adjustment = newEndDate.getTime() - data[data.length - 1].date.getTime()
-          newEndDate = new Date(data[data.length - 1].date)
-          newStartDate = new Date(newStartDate.getTime() - adjustment)
-        }
-      } else if (resizingRef.current === 'left') {
-        // Resize from the left side
-        newStartDate = new Date(
-          initialRangeRef.current[0].getTime() + daysDelta * 24 * 60 * 60 * 1000
-        )
-        newEndDate = initialRangeRef.current[1]
-
-        // Make sure start doesn't go beyond end or start of data
-        newStartDate = new Date(
-          Math.max(
-            data[0].date.getTime(),
-            Math.min(
-              newStartDate.getTime(),
-              initialRangeRef.current[1].getTime() - 24 * 60 * 60 * 1000
-            )
-          )
-        )
-      } else if (resizingRef.current === 'right') {
-        // Resize from the right side
-        newStartDate = initialRangeRef.current[0]
-        newEndDate = new Date(
-          initialRangeRef.current[1].getTime() + daysDelta * 24 * 60 * 60 * 1000
-        )
-
-        // Make sure end doesn't go before start or beyond end of data
-        newEndDate = new Date(
-          Math.min(
-            data[data.length - 1].date.getTime(),
-            Math.max(
-              newEndDate.getTime(),
-              initialRangeRef.current[0].getTime() + 24 * 60 * 60 * 1000
-            )
-          )
-        )
-      }
-
-      // Update only the local brush state during drag — parent's
-      // setDateRange is deferred to mouseup so queries don't refetch
-      // once per mousemove.
-      setDragDateRange([newStartDate, newEndDate])
+  const eventToDate = useCallback(
+    (e, { clamp = true } = {}) => {
+      if (!containerRef.current || !domain) return null
+      const rect = containerRef.current.getBoundingClientRect()
+      return clientXToDate({
+        clientX: e.clientX,
+        rect,
+        marginX: MARGIN_X,
+        domain,
+        clamp
+      })
     },
-    [data]
+    [domain]
   )
 
-  const handleMouseUp = useCallback(() => {
-    const wasDragging = draggingRef.current || resizingRef.current !== null
-    draggingRef.current = false
-    resizingRef.current = null
-    dragStartXRef.current = null
-    initialRangeRef.current = null
+  const edgeTolMs = useMemo(() => {
+    if (!containerRef.current || !domain) return 0
+    const rect = containerRef.current.getBoundingClientRect()
+    return pxToDateMs({ px: EDGE_PX_TOLERANCE, rect, marginX: MARGIN_X, domain })
+  }, [domain])
 
-    // Remove global event listeners
-    document.removeEventListener('mousemove', handleMouseMove)
-    document.removeEventListener('mouseup', handleMouseUp)
+  const actionAt = useCallback(
+    (cursorDate) => {
+      if (!fullExtent) return null
+      return resolveAction({
+        cursorDate,
+        range: dateRange,
+        fullExtent,
+        edgeTolMs
+      })
+    },
+    [dateRange, fullExtent, edgeTolMs]
+  )
 
-    // Commit-on-release: fire setDateRange once with the final range,
-    // unless the drag was effectively a no-op.
-    if (wasDragging) {
-      setDateRange(dragDateRangeRef.current)
+  const commitDragOnRelease = useCallback(() => {
+    setDragState((prev) => {
+      if (!prev || !fullExtent) return null
+      const { mode, liveStart, liveEnd } = prev
+      let candidate
+      if (mode === 'pan') {
+        candidate = clampPanToBounds({
+          start: liveStart,
+          end: liveEnd,
+          fullExtent
+        })
+      } else if (mode === 'create') {
+        if (Math.abs(liveEnd.getTime() - liveStart.getTime()) < MIN_RANGE_MS) {
+          return null
+        }
+        const s = liveStart < liveEnd ? liveStart : liveEnd
+        const e = liveStart < liveEnd ? liveEnd : liveStart
+        candidate = [s, e]
+      } else {
+        candidate = [liveStart, liveEnd]
+      }
+      if (shouldClearToFullExtent({ range: candidate, fullExtent })) {
+        setDateRange([null, null])
+      } else {
+        setDateRange(candidate)
+      }
+      return null
+    })
+  }, [fullExtent, setDateRange])
+
+  useEffect(() => {
+    if (!isDragging) return
+    const onDocMove = (e) => {
+      setDragState((prev) => {
+        if (!prev) return prev
+        const cursor = clientXToDate({
+          clientX: e.clientX,
+          rect: containerRef.current.getBoundingClientRect(),
+          marginX: MARGIN_X,
+          domain,
+          clamp: prev.mode !== 'pan'
+        })
+        if (!cursor || !fullExtent) return prev
+        if (prev.mode === 'pan') {
+          const newStartMs = cursor.getTime() - prev.panOffsetMs
+          const [s, e] = clampPanToBounds({
+            start: new Date(newStartMs),
+            end: new Date(newStartMs + prev.panWidthMs),
+            fullExtent
+          })
+          return { ...prev, liveStart: s, liveEnd: e }
+        }
+        if (prev.mode === 'edge-start') {
+          const [s, e] = clampMinRange({
+            start: cursor,
+            end: prev.liveEnd,
+            anchorSide: 'end'
+          })
+          return { ...prev, liveStart: s, liveEnd: e }
+        }
+        if (prev.mode === 'edge-end') {
+          const [s, e] = clampMinRange({
+            start: prev.liveStart,
+            end: cursor,
+            anchorSide: 'start'
+          })
+          return { ...prev, liveStart: s, liveEnd: e }
+        }
+        return { ...prev, liveEnd: cursor }
+      })
     }
-  }, [handleMouseMove, setDateRange])
+    const onDocUp = () => commitDragOnRelease()
+    document.addEventListener('mousemove', onDocMove)
+    document.addEventListener('mouseup', onDocUp)
+    return () => {
+      document.removeEventListener('mousemove', onDocMove)
+      document.removeEventListener('mouseup', onDocUp)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragging, domain, fullExtent])
+
+  const handleNativeDown = (e) => {
+    if (!fullExtent) return
+    e.preventDefault()
+    const cursor = eventToDate(e)
+    if (!cursor) return
+    const action = actionAt(cursor)
+    if (action === 'pan') {
+      const start = dateRange[0]
+      const end = dateRange[1]
+      setDragState({
+        mode: 'pan',
+        liveStart: start,
+        liveEnd: end,
+        panOffsetMs: cursor.getTime() - start.getTime(),
+        panWidthMs: end.getTime() - start.getTime()
+      })
+      return
+    }
+    if (action === 'edge-start') {
+      const end = cleared ? fullExtent[1] : dateRange[1]
+      setDragState({ mode: 'edge-start', liveStart: cursor, liveEnd: end })
+      return
+    }
+    if (action === 'edge-end') {
+      const start = cleared ? fullExtent[0] : dateRange[0]
+      setDragState({ mode: 'edge-end', liveStart: start, liveEnd: cursor })
+      return
+    }
+    setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+  }
+
+  const handleNativeMove = (e) => {
+    if (isDragging) return
+    const cursor = eventToDate(e)
+    if (!cursor) return
+    setHoverAction(actionAt(cursor))
+  }
+
+  const handleNativeLeave = () => {
+    if (!isDragging) setHoverAction(null)
+  }
+
+  const handleStart = (() => {
+    if (isDragging) return dragState.liveStart
+    if (!cleared) return dateRange[0]
+    return fullExtent ? fullExtent[0] : null
+  })()
+  const handleEnd = (() => {
+    if (isDragging) return dragState.liveEnd
+    if (!cleared) return dateRange[1]
+    return fullExtent ? fullExtent[1] : null
+  })()
+
+  const livePreview = (() => {
+    if (!isDragging || dragState.mode !== 'create') return null
+    const s = dragState.liveStart < dragState.liveEnd ? dragState.liveStart : dragState.liveEnd
+    const e = dragState.liveStart < dragState.liveEnd ? dragState.liveEnd : dragState.liveStart
+    return { x1: s.getTime(), x2: e.getTime() }
+  })()
+
+  // Filled band between the two handles, communicating "this is the
+  // active filter." Shown when dateRange is set (handles narrowed) or
+  // during an edge/pan drag. Suppressed during create (live preview
+  // takes over) and when cleared (no filter to highlight).
+  const selectedBand = (() => {
+    if (livePreview) return null
+    if (
+      isDragging &&
+      dragState.mode !== 'pan' &&
+      dragState.mode !== 'edge-start' &&
+      dragState.mode !== 'edge-end'
+    )
+      return null
+    if (!handleStart || !handleEnd) return null
+    const s = handleStart < handleEnd ? handleStart : handleEnd
+    const e = handleStart < handleEnd ? handleEnd : handleStart
+    if (s.getTime() === e.getTime()) return null
+    if (cleared && !isDragging) return null
+    return { x1: s.getTime(), x2: e.getTime() }
+  })()
+
+  const hoveredEdge = (() => {
+    if (isDragging) {
+      if (dragState.mode === 'edge-start') return 'start'
+      if (dragState.mode === 'edge-end') return 'end'
+      return null
+    }
+    if (hoverAction === 'edge-start') return 'start'
+    if (hoverAction === 'edge-end') return 'end'
+    return null
+  })()
+
+  const cursorStyle = (() => {
+    const action = isDragging ? dragState.mode : hoverAction
+    if (action === 'pan') return 'move'
+    if (action === 'edge-start' || action === 'edge-end') return 'ew-resize'
+    if (action === 'create') return 'crosshair'
+    return 'default'
+  })()
 
   return (
-    <div className="w-full h-full">
-      <ResponsiveContainer width="100%" height="100%" ref={chartRef}>
-        <LineChart data={data} margin={{ top: 0, right: 4, bottom: 0, left: 4 }}>
+    <div
+      ref={containerRef}
+      className="w-full h-full select-none [&_*]:!cursor-[inherit]"
+      style={{ cursor: cursorStyle }}
+      onMouseDown={handleNativeDown}
+      onMouseMove={handleNativeMove}
+      onMouseLeave={handleNativeLeave}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={{ top: 0, right: MARGIN_X, bottom: 0, left: MARGIN_X }}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis
             dataKey="date"
-            type="category"
+            type="number"
             scale="time"
             domain={['dataMin', 'dataMax']}
             tick={{ fontSize: 10 }}
-            tickFormatter={(date) => {
-              return date.toLocaleDateString(undefined, {
+            tickFormatter={(ms) =>
+              new Date(ms).toLocaleDateString(undefined, {
                 month: 'short',
                 day: 'numeric',
                 year: '2-digit'
               })
-            }}
+            }
             interval="preserveStartEnd"
             minTickGap={50}
             height={25}
           />
-          <YAxis hide={true} />
-          {/* <Tooltip content={<CustomTooltip />} /> */}
+          <YAxis hide domain={[0, 'auto']} />
+
+          {selectedBand && (
+            <ReferenceArea
+              x1={selectedBand.x1}
+              x2={selectedBand.x2}
+              fill="rgb(59 130 246)"
+              fillOpacity={0.15}
+              stroke="rgb(59 130 246)"
+              strokeOpacity={0.5}
+              strokeWidth={1}
+            />
+          )}
+          {livePreview && (
+            <ReferenceArea
+              x1={livePreview.x1}
+              x2={livePreview.x2}
+              fill="rgb(59 130 246)"
+              fillOpacity={0.2}
+              stroke="rgb(59 130 246)"
+              strokeOpacity={0.7}
+              strokeWidth={1}
+            />
+          )}
+
+          {handleStart && (
+            <ReferenceLine
+              x={handleStart.getTime()}
+              stroke="rgb(59 130 246)"
+              strokeWidth={hoveredEdge === 'start' ? 3 : 2}
+              isFront
+              label={{
+                position: 'center',
+                content: ({ viewBox }) => {
+                  if (!viewBox || viewBox.x === undefined) return null
+                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                  return (
+                    <circle
+                      cx={viewBox.x}
+                      cy={cy}
+                      r={hoveredEdge === 'start' ? 6 : 4}
+                      fill="rgb(59 130 246)"
+                      stroke="white"
+                      strokeWidth={1}
+                    />
+                  )
+                }
+              }}
+            />
+          )}
+          {handleEnd && handleEnd.getTime() !== handleStart?.getTime() && (
+            <ReferenceLine
+              x={handleEnd.getTime()}
+              stroke="rgb(59 130 246)"
+              strokeWidth={hoveredEdge === 'end' ? 3 : 2}
+              isFront
+              label={{
+                position: 'center',
+                content: ({ viewBox }) => {
+                  if (!viewBox || viewBox.x === undefined) return null
+                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                  return (
+                    <circle
+                      cx={viewBox.x}
+                      cy={cy}
+                      r={hoveredEdge === 'end' ? 6 : 4}
+                      fill="rgb(59 130 246)"
+                      stroke="white"
+                      strokeWidth={1}
+                    />
+                  )
+                }
+              }}
+            />
+          )}
 
           {selectedSpecies.map((species, index) => (
             <Line
@@ -291,11 +395,10 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
               name={species.scientificName}
               fillOpacity={0.2}
               fill={palette[index % palette.length]}
+              isAnimationActive={false}
             />
           ))}
-
-          <Customized component={SelectionRangeRectangle} />
-        </LineChart>
+        </ComposedChart>
       </ResponsiveContainer>
     </div>
   )

--- a/src/renderer/src/ui/timeseries.jsx
+++ b/src/renderer/src/ui/timeseries.jsx
@@ -9,6 +9,7 @@ import {
   XAxis,
   YAxis
 } from 'recharts'
+import { X } from 'lucide-react'
 
 import {
   clientXToDate,
@@ -17,11 +18,15 @@ import {
   resolveAction,
   shouldClearToFullExtent,
   pxToDateMs,
+  zoomAroundAnchor,
   EDGE_PX_TOLERANCE,
   MIN_RANGE_MS
 } from '../utils/timelineZoom.js'
 
 const MARGIN_X = 4 // matches the LineChart margin used below
+
+const formatPillDate = (d) =>
+  d ? d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) : ''
 
 /**
  * TimelineChart — date-range brush over a per-day species time-series.
@@ -37,6 +42,8 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
   const [dragState, setDragState] = useState(null)
   const isDragging = dragState !== null
   const [hoverAction, setHoverAction] = useState(null)
+  const wheelRafRef = useRef(null)
+  const wheelPendingRef = useRef(null)
 
   const data = useMemo(() => {
     if (!timeseriesData) return []
@@ -136,24 +143,30 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     if (!isDragging) return
     const onDocMove = (e) => {
       setDragState((prev) => {
-        if (!prev) return prev
+        if (!prev || !fullExtent) return prev
+        if (prev.mode === 'pan') {
+          const rect = containerRef.current.getBoundingClientRect()
+          const innerWidth = rect.width - MARGIN_X * 2
+          if (innerWidth <= 0) return prev
+          const initialDomainMs = prev.panInitialEnd.getTime() - prev.panInitialStart.getTime()
+          const deltaPx = e.clientX - prev.panStartClientX
+          const deltaMs = deltaPx * (initialDomainMs / innerWidth)
+          const newStartMs = prev.panInitialStart.getTime() + deltaMs
+          const [panStart, panEnd] = clampPanToBounds({
+            start: new Date(newStartMs),
+            end: new Date(newStartMs + initialDomainMs),
+            fullExtent
+          })
+          return { ...prev, liveStart: panStart, liveEnd: panEnd }
+        }
         const cursor = clientXToDate({
           clientX: e.clientX,
           rect: containerRef.current.getBoundingClientRect(),
           marginX: MARGIN_X,
           domain,
-          clamp: prev.mode !== 'pan'
+          clamp: true
         })
-        if (!cursor || !fullExtent) return prev
-        if (prev.mode === 'pan') {
-          const newStartMs = cursor.getTime() - prev.panOffsetMs
-          const [s, e] = clampPanToBounds({
-            start: new Date(newStartMs),
-            end: new Date(newStartMs + prev.panWidthMs),
-            fullExtent
-          })
-          return { ...prev, liveStart: s, liveEnd: e }
-        }
+        if (!cursor) return prev
         if (prev.mode === 'edge-start') {
           const [s, e] = clampMinRange({
             start: cursor,
@@ -192,12 +205,17 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     if (action === 'pan') {
       const start = dateRange[0]
       const end = dateRange[1]
+      // Pan uses pixel-delta math against a frozen domain so the chart
+      // can live-update its XAxis to liveStart/liveEnd without creating a
+      // feedback loop (cursor→date based on a moving domain would zero
+      // out the delta).
       setDragState({
         mode: 'pan',
         liveStart: start,
         liveEnd: end,
-        panOffsetMs: cursor.getTime() - start.getTime(),
-        panWidthMs: end.getTime() - start.getTime()
+        panStartClientX: e.clientX,
+        panInitialStart: start,
+        panInitialEnd: end
       })
       return
     }
@@ -225,6 +243,59 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     if (!isDragging) setHoverAction(null)
   }
 
+  const handleWheel = (e) => {
+    if (!fullExtent || !domain) return
+    e.preventDefault()
+    const cursor = eventToDate(e)
+    if (!cursor) return
+    // deltaY<0 (scroll up / two-finger up) → factor<1 → zoom in
+    const factor = Math.exp(e.deltaY * 0.0015)
+    const [zoomed0, zoomed1] = zoomAroundAnchor({
+      start: domain[0],
+      end: domain[1],
+      anchor: cursor,
+      factor
+    })
+    let nextStartMs = zoomed0.getTime()
+    let nextEndMs = zoomed1.getTime()
+    // Clamp to full extent on zoom-out.
+    if (nextStartMs < fullExtent[0].getTime()) nextStartMs = fullExtent[0].getTime()
+    if (nextEndMs > fullExtent[1].getTime()) nextEndMs = fullExtent[1].getTime()
+    // Clamp to min range on zoom-in.
+    if (nextEndMs - nextStartMs < MIN_RANGE_MS) {
+      const anchorMs = cursor.getTime()
+      nextStartMs = anchorMs - MIN_RANGE_MS / 2
+      nextEndMs = anchorMs + MIN_RANGE_MS / 2
+      if (nextStartMs < fullExtent[0].getTime()) {
+        nextStartMs = fullExtent[0].getTime()
+        nextEndMs = nextStartMs + MIN_RANGE_MS
+      }
+      if (nextEndMs > fullExtent[1].getTime()) {
+        nextEndMs = fullExtent[1].getTime()
+        nextStartMs = nextEndMs - MIN_RANGE_MS
+      }
+    }
+    const candidate = [new Date(nextStartMs), new Date(nextEndMs)]
+    wheelPendingRef.current = shouldClearToFullExtent({ range: candidate, fullExtent })
+      ? [null, null]
+      : candidate
+    if (wheelRafRef.current !== null) return
+    wheelRafRef.current = requestAnimationFrame(() => {
+      wheelRafRef.current = null
+      if (wheelPendingRef.current) {
+        setDateRange(wheelPendingRef.current)
+        wheelPendingRef.current = null
+      }
+    })
+  }
+
+  useEffect(
+    () => () => {
+      if (wheelRafRef.current !== null) cancelAnimationFrame(wheelRafRef.current)
+    },
+    []
+  )
+
   const handleStart = (() => {
     if (isDragging) return dragState.liveStart
     if (!cleared) return dateRange[0]
@@ -240,27 +311,6 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     if (!isDragging || dragState.mode !== 'create') return null
     const s = dragState.liveStart < dragState.liveEnd ? dragState.liveStart : dragState.liveEnd
     const e = dragState.liveStart < dragState.liveEnd ? dragState.liveEnd : dragState.liveStart
-    return { x1: s.getTime(), x2: e.getTime() }
-  })()
-
-  // Filled band between the two handles, communicating "this is the
-  // active filter." Shown when dateRange is set (handles narrowed) or
-  // during an edge/pan drag. Suppressed during create (live preview
-  // takes over) and when cleared (no filter to highlight).
-  const selectedBand = (() => {
-    if (livePreview) return null
-    if (
-      isDragging &&
-      dragState.mode !== 'pan' &&
-      dragState.mode !== 'edge-start' &&
-      dragState.mode !== 'edge-end'
-    )
-      return null
-    if (!handleStart || !handleEnd) return null
-    const s = handleStart < handleEnd ? handleStart : handleEnd
-    const e = handleStart < handleEnd ? handleEnd : handleStart
-    if (s.getTime() === e.getTime()) return null
-    if (cleared && !isDragging) return null
     return { x1: s.getTime(), x2: e.getTime() }
   })()
 
@@ -283,128 +333,200 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     return 'default'
   })()
 
+  // During pan we override the chart's visible domain so the line data
+  // pans live under the cursor. Other modes keep the committed domain
+  // (chart stays still; only handles slide).
+  const displayedDomain = useMemo(
+    () =>
+      isDragging && dragState?.mode === 'pan' ? [dragState.liveStart, dragState.liveEnd] : domain,
+    [isDragging, dragState?.mode, dragState?.liveStart, dragState?.liveEnd, domain]
+  )
+
+  // Handle color reflects the zoom/filter state: muted slate when the
+  // chart is at full extent (no filter), saturated blue when zoomed in.
+  // During a drag (edge/create) we use the saturated blue regardless,
+  // since the user is actively narrowing.
+  const handleColor = cleared && !isDragging ? 'rgb(148 163 184)' : 'rgb(59 130 246)'
+
+  // Explicit ticks across the visible domain. Recharts' default tick
+  // generation (with `interval="preserveStartEnd"` and a numeric XAxis)
+  // pins the first and last ticks to the underlying data array's
+  // extremes, which ignores our zoom domain. Generating ticks ourselves
+  // guarantees the labels reflect what the user actually sees.
+  const xAxisTicks = useMemo(() => {
+    if (!displayedDomain) return undefined
+    const startMs = displayedDomain[0].getTime()
+    const endMs = displayedDomain[1].getTime()
+    if (endMs <= startMs) return [startMs]
+    const tickCount = 5
+    const step = (endMs - startMs) / (tickCount - 1)
+    return Array.from({ length: tickCount }, (_, i) => Math.round(startMs + i * step))
+  }, [displayedDomain])
+
+  // Custom tick renderer: anchors the leftmost label at start, rightmost
+  // at end, so the dates of the zoom (first and last) stay visible at
+  // the chart edges instead of being culled by Recharts' default
+  // middle-anchored layout.
+  const renderTick = ({ x, y, payload, index }) => {
+    let textAnchor = 'middle'
+    if (index === 0) textAnchor = 'start'
+    else if (xAxisTicks && index === xAxisTicks.length - 1) textAnchor = 'end'
+    return (
+      <text
+        x={x}
+        y={y + 10}
+        textAnchor={textAnchor}
+        fontSize={10}
+        fill="var(--color-muted-foreground)"
+      >
+        {new Date(payload.value).toLocaleDateString(undefined, {
+          month: 'short',
+          day: 'numeric',
+          year: '2-digit'
+        })}
+      </text>
+    )
+  }
+
   return (
-    <div
-      ref={containerRef}
-      className="w-full h-full select-none [&_*]:!cursor-[inherit]"
-      style={{ cursor: cursorStyle }}
-      onMouseDown={handleNativeDown}
-      onMouseMove={handleNativeMove}
-      onMouseLeave={handleNativeLeave}
-    >
-      <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={data} margin={{ top: 0, right: MARGIN_X, bottom: 0, left: MARGIN_X }}>
-          <CartesianGrid strokeDasharray="3 3" vertical={false} />
-          <XAxis
-            dataKey="date"
-            type="number"
-            scale="time"
-            domain={domain ? [domain[0].getTime(), domain[1].getTime()] : ['dataMin', 'dataMax']}
-            allowDataOverflow
-            tick={{ fontSize: 10 }}
-            tickFormatter={(ms) =>
-              new Date(ms).toLocaleDateString(undefined, {
-                month: 'short',
-                day: 'numeric',
-                year: '2-digit'
-              })
-            }
-            interval="preserveStartEnd"
-            minTickGap={50}
-            height={25}
-          />
-          <YAxis hide domain={[0, 'auto']} />
+    <div className="relative w-full h-full">
+      <div
+        ref={containerRef}
+        className="absolute inset-0 select-none [&_*]:!cursor-[inherit]"
+        style={{ cursor: cursorStyle }}
+        onMouseDown={handleNativeDown}
+        onMouseMove={handleNativeMove}
+        onMouseLeave={handleNativeLeave}
+        onWheel={handleWheel}
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart
+            data={data}
+            margin={{ top: 0, right: MARGIN_X, bottom: 0, left: MARGIN_X }}
+          >
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="date"
+              type="number"
+              scale="time"
+              domain={
+                displayedDomain
+                  ? [displayedDomain[0].getTime(), displayedDomain[1].getTime()]
+                  : ['dataMin', 'dataMax']
+              }
+              allowDataOverflow
+              ticks={xAxisTicks}
+              tick={renderTick}
+              minTickGap={10}
+              height={25}
+            />
+            <YAxis hide domain={[0, 'auto']} />
 
-          {selectedBand && (
-            <ReferenceArea
-              x1={selectedBand.x1}
-              x2={selectedBand.x2}
-              fill="rgb(59 130 246)"
-              fillOpacity={0.15}
-              stroke="rgb(59 130 246)"
-              strokeOpacity={0.5}
-              strokeWidth={1}
-            />
-          )}
-          {livePreview && (
-            <ReferenceArea
-              x1={livePreview.x1}
-              x2={livePreview.x2}
-              fill="rgb(59 130 246)"
-              fillOpacity={0.2}
-              stroke="rgb(59 130 246)"
-              strokeOpacity={0.7}
-              strokeWidth={1}
-            />
-          )}
+            {livePreview && (
+              <ReferenceArea
+                x1={livePreview.x1}
+                x2={livePreview.x2}
+                fill="rgb(59 130 246)"
+                fillOpacity={0.2}
+                stroke="rgb(59 130 246)"
+                strokeOpacity={0.7}
+                strokeWidth={1}
+              />
+            )}
 
-          {handleStart && (
-            <ReferenceLine
-              x={handleStart.getTime()}
-              stroke="rgb(59 130 246)"
-              strokeWidth={hoveredEdge === 'start' ? 3 : 2}
-              isFront
-              label={{
-                position: 'center',
-                content: ({ viewBox }) => {
-                  if (!viewBox || viewBox.x === undefined) return null
-                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
-                  return (
-                    <circle
-                      cx={viewBox.x}
-                      cy={cy}
-                      r={hoveredEdge === 'start' ? 6 : 4}
-                      fill="rgb(59 130 246)"
-                      stroke="white"
-                      strokeWidth={1}
-                    />
-                  )
-                }
-              }}
-            />
-          )}
-          {handleEnd && handleEnd.getTime() !== handleStart?.getTime() && (
-            <ReferenceLine
-              x={handleEnd.getTime()}
-              stroke="rgb(59 130 246)"
-              strokeWidth={hoveredEdge === 'end' ? 3 : 2}
-              isFront
-              label={{
-                position: 'center',
-                content: ({ viewBox }) => {
-                  if (!viewBox || viewBox.x === undefined) return null
-                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
-                  return (
-                    <circle
-                      cx={viewBox.x}
-                      cy={cy}
-                      r={hoveredEdge === 'end' ? 6 : 4}
-                      fill="rgb(59 130 246)"
-                      stroke="white"
-                      strokeWidth={1}
-                    />
-                  )
-                }
-              }}
-            />
-          )}
+            {handleStart && (
+              <ReferenceLine
+                x={handleStart.getTime()}
+                stroke={handleColor}
+                strokeWidth={hoveredEdge === 'start' ? 3 : 2}
+                isFront
+                label={{
+                  position: 'center',
+                  content: ({ viewBox }) => {
+                    if (!viewBox || viewBox.x === undefined) return null
+                    const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                    return (
+                      <circle
+                        cx={viewBox.x}
+                        cy={cy}
+                        r={hoveredEdge === 'start' ? 6 : 4}
+                        fill={handleColor}
+                        stroke="white"
+                        strokeWidth={1}
+                      />
+                    )
+                  }
+                }}
+              />
+            )}
+            {handleEnd && handleEnd.getTime() !== handleStart?.getTime() && (
+              <ReferenceLine
+                x={handleEnd.getTime()}
+                stroke={handleColor}
+                strokeWidth={hoveredEdge === 'end' ? 3 : 2}
+                isFront
+                label={{
+                  position: 'center',
+                  content: ({ viewBox }) => {
+                    if (!viewBox || viewBox.x === undefined) return null
+                    const cy = viewBox.y + (viewBox.height ?? 0) / 2
+                    return (
+                      <circle
+                        cx={viewBox.x}
+                        cy={cy}
+                        r={hoveredEdge === 'end' ? 6 : 4}
+                        fill={handleColor}
+                        stroke="white"
+                        strokeWidth={1}
+                      />
+                    )
+                  }
+                }}
+              />
+            )}
 
-          {selectedSpecies.map((species, index) => (
-            <Line
-              key={species.scientificName}
-              type="monotone"
-              dataKey={species.scientificName}
-              stroke={palette[index % palette.length]}
-              dot={false}
-              activeDot={{ r: 5 }}
-              name={species.scientificName}
-              fillOpacity={0.2}
-              fill={palette[index % palette.length]}
-              isAnimationActive={false}
-            />
-          ))}
-        </ComposedChart>
-      </ResponsiveContainer>
+            {selectedSpecies.map((species, index) => (
+              <Line
+                key={species.scientificName}
+                type="monotone"
+                dataKey={species.scientificName}
+                stroke={palette[index % palette.length]}
+                dot={false}
+                activeDot={{ r: 5 }}
+                name={species.scientificName}
+                fillOpacity={0.2}
+                fill={palette[index % palette.length]}
+                isAnimationActive={false}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+      {!cleared && (
+        <div
+          className="absolute top-1 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 pl-2 pr-1 py-0.5 rounded-full text-[10px] font-medium text-blue-700 dark:text-blue-300 bg-blue-50/90 dark:bg-blue-500/15 border border-blue-200/70 dark:border-blue-500/30 pointer-events-none"
+          aria-label="Date filter range"
+        >
+          <span>
+            {formatPillDate(displayedDomain?.[0])}
+            {' → '}
+            {formatPillDate(displayedDomain?.[1])}
+          </span>
+          <button
+            type="button"
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              setDateRange([null, null])
+            }}
+            className="pointer-events-auto cursor-pointer inline-flex items-center justify-center w-3.5 h-3.5 rounded-full hover:bg-blue-200/70 dark:hover:bg-blue-500/30 transition-colors"
+            aria-label="Clear date filter"
+            title="Clear date filter"
+          >
+            <X size={10} strokeWidth={2.5} />
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/ui/timeseries.jsx
+++ b/src/renderer/src/ui/timeseries.jsx
@@ -54,13 +54,17 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
     return [new Date(data[0].date), new Date(data[data.length - 1].date)]
   }, [data])
 
-  // `domain` is the date space the chart's XAxis is showing — used to
-  // convert cursor-x to dates. In Task 2 the XAxis is still pinned to the
-  // full data extent, so this must be fullExtent (otherwise dragging a
-  // handle outward would clamp the cursor inside the narrowed dateRange
-  // and the handle couldn't widen). Task 3 will switch this (and the
-  // XAxis) to follow dateRange.
-  const domain = fullExtent
+  // `domain` is the date space the chart's XAxis is showing. Must always
+  // match what XAxis renders so cursor-x → date conversions stay correct.
+  // Unified viewport == filter: when dateRange is set, the chart zooms to
+  // it; when cleared, the chart shows the full data extent. Widening past
+  // the current viewport is via scroll wheel (see Task 4), not via
+  // dragging a handle past the chart edge.
+  const domain = useMemo(() => {
+    if (!fullExtent) return null
+    if (dateRange[0] && dateRange[1]) return [dateRange[0], dateRange[1]]
+    return fullExtent
+  }, [dateRange, fullExtent])
 
   const cleared = !dateRange[0] || !dateRange[1]
 
@@ -295,7 +299,8 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
             dataKey="date"
             type="number"
             scale="time"
-            domain={['dataMin', 'dataMax']}
+            domain={domain ? [domain[0].getTime(), domain[1].getTime()] : ['dataMin', 'dataMax']}
+            allowDataOverflow
             tick={{ fontSize: 10 }}
             tickFormatter={(ms) =>
               new Date(ms).toLocaleDateString(undefined, {

--- a/src/renderer/src/utils/timelineZoom.js
+++ b/src/renderer/src/utils/timelineZoom.js
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for the TimelineChart brush + zoom + filter behavior.
+ *
+ * Vocabulary:
+ *   - "range"      → [Date, Date] viewport+filter window. Equal to the
+ *                    chart's visible x-axis domain and the date filter.
+ *   - "fullExtent" → [Date, Date] full data extent (dataMin/dataMax),
+ *                    typically derived from the first and last entries
+ *                    of timeseriesData.
+ *   - "domain"     → [Date, Date] the chart's current XAxis domain,
+ *                    either equal to range or to fullExtent when cleared.
+ *
+ * All math is in millisecond time. No DOM. No React.
+ */
+
+export const DAY_MS = 24 * 60 * 60 * 1000
+export const MIN_RANGE_MS = DAY_MS
+export const CLEAR_TOLERANCE_MS = 12 * 60 * 60 * 1000
+export const EDGE_PX_TOLERANCE = 10
+
+export function clientXToDate({ clientX, rect, marginX, domain, clamp = true }) {
+  const innerWidth = rect.width - marginX * 2
+  if (innerWidth <= 0) return null
+  const xPx = clientX - rect.left - marginX
+  const rawRatio = xPx / innerWidth
+  const ratio = clamp ? Math.max(0, Math.min(1, rawRatio)) : rawRatio
+  const ms = domain[0].getTime() + ratio * (domain[1].getTime() - domain[0].getTime())
+  return new Date(ms)
+}
+
+export function zoomAroundAnchor({ start, end, anchor, factor }) {
+  const startMs = start.getTime()
+  const endMs = end.getTime()
+  const anchorMs = anchor.getTime()
+  return [
+    new Date(anchorMs - (anchorMs - startMs) * factor),
+    new Date(anchorMs + (endMs - anchorMs) * factor)
+  ]
+}
+
+export function shouldClearToFullExtent({
+  range,
+  fullExtent,
+  toleranceMs = CLEAR_TOLERANCE_MS
+}) {
+  if (!range[0] || !range[1] || !fullExtent[0] || !fullExtent[1]) return false
+  const startDiff = range[0].getTime() - fullExtent[0].getTime()
+  const endDiff = fullExtent[1].getTime() - range[1].getTime()
+  return startDiff <= toleranceMs && endDiff <= toleranceMs
+}
+
+export function clampPanToBounds({ start, end, fullExtent }) {
+  const width = end.getTime() - start.getTime()
+  const minMs = fullExtent[0].getTime()
+  const maxMs = fullExtent[1].getTime()
+  let s = start.getTime()
+  let e = end.getTime()
+  if (s < minMs) {
+    s = minMs
+    e = s + width
+  }
+  if (e > maxMs) {
+    e = maxMs
+    s = e - width
+  }
+  if (s < minMs) s = minMs
+  return [new Date(s), new Date(e)]
+}
+
+export function clampMinRange({ start, end, minMs = MIN_RANGE_MS, anchorSide }) {
+  if (end.getTime() - start.getTime() >= minMs) return [start, end]
+  if (anchorSide === 'start') return [start, new Date(start.getTime() + minMs)]
+  return [new Date(end.getTime() - minMs), end]
+}
+
+export function pxToDateMs({ px, rect, marginX, domain }) {
+  const innerWidth = rect.width - marginX * 2
+  if (innerWidth <= 0) return 0
+  return (px * (domain[1].getTime() - domain[0].getTime())) / innerWidth
+}
+
+export function resolveAction({ cursorDate, range, fullExtent, edgeTolMs }) {
+  const cursorMs = cursorDate.getTime()
+  const cleared = !range[0] || !range[1]
+  if (cleared) {
+    const leftEdgeMs = fullExtent[0].getTime() + edgeTolMs
+    const rightEdgeMs = fullExtent[1].getTime() - edgeTolMs
+    if (cursorMs <= leftEdgeMs) return 'edge-start'
+    if (cursorMs >= rightEdgeMs) return 'edge-end'
+    return 'create'
+  }
+  const startMs = range[0].getTime()
+  const endMs = range[1].getTime()
+  if (Math.abs(cursorMs - startMs) <= edgeTolMs) return 'edge-start'
+  if (Math.abs(cursorMs - endMs) <= edgeTolMs) return 'edge-end'
+  return 'pan'
+}

--- a/src/renderer/src/utils/timelineZoom.js
+++ b/src/renderer/src/utils/timelineZoom.js
@@ -38,11 +38,7 @@ export function zoomAroundAnchor({ start, end, anchor, factor }) {
   ]
 }
 
-export function shouldClearToFullExtent({
-  range,
-  fullExtent,
-  toleranceMs = CLEAR_TOLERANCE_MS
-}) {
+export function shouldClearToFullExtent({ range, fullExtent, toleranceMs = CLEAR_TOLERANCE_MS }) {
   if (!range[0] || !range[1] || !fullExtent[0] || !fullExtent[1]) return false
   const startDiff = range[0].getTime() - fullExtent[0].getTime()
   const endDiff = fullExtent[1].getTime() - range[1].getTime()

--- a/test/renderer/timelineZoom.test.js
+++ b/test/renderer/timelineZoom.test.js
@@ -160,10 +160,7 @@ describe('shouldClearToFullExtent', () => {
   })
 
   test('null range → false', () => {
-    assert.equal(
-      shouldClearToFullExtent({ range: [null, null], fullExtent: FULL_EXTENT }),
-      false
-    )
+    assert.equal(shouldClearToFullExtent({ range: [null, null], fullExtent: FULL_EXTENT }), false)
   })
 })
 

--- a/test/renderer/timelineZoom.test.js
+++ b/test/renderer/timelineZoom.test.js
@@ -1,0 +1,308 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  clientXToDate,
+  zoomAroundAnchor,
+  shouldClearToFullExtent,
+  clampPanToBounds,
+  clampMinRange,
+  resolveAction,
+  pxToDateMs,
+  DAY_MS,
+  MIN_RANGE_MS,
+  CLEAR_TOLERANCE_MS,
+  EDGE_PX_TOLERANCE
+} from '../../src/renderer/src/utils/timelineZoom.js'
+
+const D = (iso) => new Date(iso)
+const RECT = { left: 0, width: 1000 }
+const MARGIN = 4
+const INNER = RECT.width - MARGIN * 2
+const DOMAIN = [D('2024-01-01T00:00:00Z'), D('2024-12-31T00:00:00Z')]
+const FULL_EXTENT = DOMAIN
+
+describe('constants', () => {
+  test('DAY_MS = 24h in ms', () => {
+    assert.equal(DAY_MS, 24 * 60 * 60 * 1000)
+  })
+  test('MIN_RANGE_MS defaults to one day', () => {
+    assert.equal(MIN_RANGE_MS, DAY_MS)
+  })
+  test('CLEAR_TOLERANCE_MS = 12h', () => {
+    assert.equal(CLEAR_TOLERANCE_MS, 12 * 60 * 60 * 1000)
+  })
+  test('EDGE_PX_TOLERANCE = 10', () => {
+    assert.equal(EDGE_PX_TOLERANCE, 10)
+  })
+})
+
+describe('clientXToDate', () => {
+  test('left edge maps to domain[0]', () => {
+    const d = clientXToDate({
+      clientX: MARGIN,
+      rect: RECT,
+      marginX: MARGIN,
+      domain: DOMAIN
+    })
+    assert.equal(d.getTime(), DOMAIN[0].getTime())
+  })
+
+  test('right edge maps to domain[1]', () => {
+    const d = clientXToDate({
+      clientX: RECT.width - MARGIN,
+      rect: RECT,
+      marginX: MARGIN,
+      domain: DOMAIN
+    })
+    assert.equal(d.getTime(), DOMAIN[1].getTime())
+  })
+
+  test('midpoint maps to midpoint of domain', () => {
+    const d = clientXToDate({
+      clientX: MARGIN + INNER / 2,
+      rect: RECT,
+      marginX: MARGIN,
+      domain: DOMAIN
+    })
+    const midMs = (DOMAIN[0].getTime() + DOMAIN[1].getTime()) / 2
+    assert.equal(d.getTime(), midMs)
+  })
+
+  test('clamp=true keeps result inside domain when cursor is outside', () => {
+    const d = clientXToDate({
+      clientX: -50,
+      rect: RECT,
+      marginX: MARGIN,
+      domain: DOMAIN,
+      clamp: true
+    })
+    assert.equal(d.getTime(), DOMAIN[0].getTime())
+  })
+
+  test('clamp=false lets result fall outside domain (for pan)', () => {
+    const d = clientXToDate({
+      clientX: -50,
+      rect: RECT,
+      marginX: MARGIN,
+      domain: DOMAIN,
+      clamp: false
+    })
+    assert.ok(d.getTime() < DOMAIN[0].getTime())
+  })
+
+  test('returns null when chart inner width is zero or negative', () => {
+    const d = clientXToDate({
+      clientX: 10,
+      rect: { left: 0, width: 4 },
+      marginX: MARGIN,
+      domain: DOMAIN
+    })
+    assert.equal(d, null)
+  })
+})
+
+describe('zoomAroundAnchor', () => {
+  test('factor=1 returns unchanged range', () => {
+    const [s, e] = zoomAroundAnchor({
+      start: DOMAIN[0],
+      end: DOMAIN[1],
+      anchor: D('2024-06-01'),
+      factor: 1
+    })
+    assert.equal(s.getTime(), DOMAIN[0].getTime())
+    assert.equal(e.getTime(), DOMAIN[1].getTime())
+  })
+
+  test('factor=0.5 halves both halves around the anchor', () => {
+    const anchor = D('2024-06-01T12:00:00Z')
+    const [s, e] = zoomAroundAnchor({
+      start: D('2024-01-01'),
+      end: D('2024-12-01'),
+      anchor,
+      factor: 0.5
+    })
+    const halfStart = anchor.getTime() - (anchor.getTime() - D('2024-01-01').getTime()) * 0.5
+    const halfEnd = anchor.getTime() + (D('2024-12-01').getTime() - anchor.getTime()) * 0.5
+    assert.equal(s.getTime(), halfStart)
+    assert.equal(e.getTime(), halfEnd)
+  })
+
+  test('factor=2 doubles both halves (zoom out)', () => {
+    const anchor = D('2024-06-15')
+    const start = D('2024-06-01')
+    const end = D('2024-07-01')
+    const [s, e] = zoomAroundAnchor({ start, end, anchor, factor: 2 })
+    assert.equal(s.getTime(), anchor.getTime() - (anchor.getTime() - start.getTime()) * 2)
+    assert.equal(e.getTime(), anchor.getTime() + (end.getTime() - anchor.getTime()) * 2)
+  })
+})
+
+describe('shouldClearToFullExtent', () => {
+  test('exact match → true', () => {
+    assert.equal(
+      shouldClearToFullExtent({ range: [DOMAIN[0], DOMAIN[1]], fullExtent: FULL_EXTENT }),
+      true
+    )
+  })
+
+  test('within 12h tolerance on both ends → true', () => {
+    const r = [
+      new Date(DOMAIN[0].getTime() - 6 * 60 * 60 * 1000),
+      new Date(DOMAIN[1].getTime() + 6 * 60 * 60 * 1000)
+    ]
+    assert.equal(shouldClearToFullExtent({ range: r, fullExtent: FULL_EXTENT }), true)
+  })
+
+  test('beyond tolerance → false', () => {
+    const r = [DOMAIN[0], new Date(DOMAIN[1].getTime() - 7 * 24 * 60 * 60 * 1000)]
+    assert.equal(shouldClearToFullExtent({ range: r, fullExtent: FULL_EXTENT }), false)
+  })
+
+  test('null range → false', () => {
+    assert.equal(
+      shouldClearToFullExtent({ range: [null, null], fullExtent: FULL_EXTENT }),
+      false
+    )
+  })
+})
+
+describe('clampPanToBounds', () => {
+  test('range inside bounds → unchanged', () => {
+    const start = D('2024-03-01')
+    const end = D('2024-04-01')
+    const [s, e] = clampPanToBounds({ start, end, fullExtent: FULL_EXTENT })
+    assert.equal(s.getTime(), start.getTime())
+    assert.equal(e.getTime(), end.getTime())
+  })
+
+  test('range overshoots left → shifted right, width preserved', () => {
+    const width = 30 * DAY_MS
+    const start = new Date(DOMAIN[0].getTime() - 10 * DAY_MS)
+    const end = new Date(start.getTime() + width)
+    const [s, e] = clampPanToBounds({ start, end, fullExtent: FULL_EXTENT })
+    assert.equal(s.getTime(), DOMAIN[0].getTime())
+    assert.equal(e.getTime() - s.getTime(), width)
+  })
+
+  test('range overshoots right → shifted left, width preserved', () => {
+    const width = 30 * DAY_MS
+    const end = new Date(DOMAIN[1].getTime() + 10 * DAY_MS)
+    const start = new Date(end.getTime() - width)
+    const [s, e] = clampPanToBounds({ start, end, fullExtent: FULL_EXTENT })
+    assert.equal(e.getTime(), DOMAIN[1].getTime())
+    assert.equal(e.getTime() - s.getTime(), width)
+  })
+})
+
+describe('clampMinRange', () => {
+  test('range above minimum → unchanged', () => {
+    const start = D('2024-03-01')
+    const end = D('2024-03-10')
+    const [s, e] = clampMinRange({ start, end, anchorSide: 'start' })
+    assert.equal(s.getTime(), start.getTime())
+    assert.equal(e.getTime(), end.getTime())
+  })
+
+  test('range below minimum, anchorSide=start → end pushed out', () => {
+    const start = D('2024-03-01T00:00:00Z')
+    const end = D('2024-03-01T01:00:00Z')
+    const [s, e] = clampMinRange({ start, end, anchorSide: 'start' })
+    assert.equal(s.getTime(), start.getTime())
+    assert.equal(e.getTime() - s.getTime(), MIN_RANGE_MS)
+  })
+
+  test('range below minimum, anchorSide=end → start pulled back', () => {
+    const start = D('2024-03-01T23:00:00Z')
+    const end = D('2024-03-02T00:00:00Z')
+    const [s, e] = clampMinRange({ start, end, anchorSide: 'end' })
+    assert.equal(e.getTime(), end.getTime())
+    assert.equal(e.getTime() - s.getTime(), MIN_RANGE_MS)
+  })
+})
+
+describe('pxToDateMs', () => {
+  test('10px on a 992-wide chart of 365-day domain', () => {
+    const tol = pxToDateMs({ px: 10, rect: RECT, marginX: MARGIN, domain: DOMAIN })
+    const totalMs = DOMAIN[1].getTime() - DOMAIN[0].getTime()
+    assert.equal(tol, (10 * totalMs) / INNER)
+  })
+
+  test('zero inner width → 0', () => {
+    const tol = pxToDateMs({
+      px: 10,
+      rect: { left: 0, width: 4 },
+      marginX: MARGIN,
+      domain: DOMAIN
+    })
+    assert.equal(tol, 0)
+  })
+})
+
+describe('resolveAction', () => {
+  const range = [D('2024-04-01'), D('2024-08-01')]
+  const edgeTolMs = 2 * DAY_MS
+
+  test('cursor near start edge → edge-start', () => {
+    const cursor = D('2024-04-02')
+    assert.equal(
+      resolveAction({ cursorDate: cursor, range, fullExtent: FULL_EXTENT, edgeTolMs }),
+      'edge-start'
+    )
+  })
+
+  test('cursor near end edge → edge-end', () => {
+    const cursor = D('2024-07-31')
+    assert.equal(
+      resolveAction({ cursorDate: cursor, range, fullExtent: FULL_EXTENT, edgeTolMs }),
+      'edge-end'
+    )
+  })
+
+  test('cursor inside band, away from edges → pan', () => {
+    const cursor = D('2024-06-01')
+    assert.equal(
+      resolveAction({ cursorDate: cursor, range, fullExtent: FULL_EXTENT, edgeTolMs }),
+      'pan'
+    )
+  })
+
+  test('null range, cursor near full-extent left edge → edge-start', () => {
+    const cursor = new Date(FULL_EXTENT[0].getTime() + DAY_MS)
+    assert.equal(
+      resolveAction({
+        cursorDate: cursor,
+        range: [null, null],
+        fullExtent: FULL_EXTENT,
+        edgeTolMs
+      }),
+      'edge-start'
+    )
+  })
+
+  test('null range, cursor near full-extent right edge → edge-end', () => {
+    const cursor = new Date(FULL_EXTENT[1].getTime() - DAY_MS)
+    assert.equal(
+      resolveAction({
+        cursorDate: cursor,
+        range: [null, null],
+        fullExtent: FULL_EXTENT,
+        edgeTolMs
+      }),
+      'edge-end'
+    )
+  })
+
+  test('null range, cursor in middle → create', () => {
+    const cursor = D('2024-06-01')
+    assert.equal(
+      resolveAction({
+        cursorDate: cursor,
+        range: [null, null],
+        fullExtent: FULL_EXTENT,
+        edgeTolMs
+      }),
+      'create'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Reworks the date-range brush on the **Media** and **Activity** tabs so the chart's x-axis follows the selection — narrowing or scroll-wheeling zooms the chart in, scrolling out clears the filter — and visually aligns it with the recently-redesigned day-activity chart.

<img width="668" height="203" alt="image" src="https://github.com/user-attachments/assets/2d879063-892e-4000-a733-05ee43ed8398" />


- **Unified viewport == filter.** The brush range, the chart's visible x-axis, and the date filter are the same state. `[null, null]` is the cleared / no-filter sentinel.
- **New gestures:** drag handles to narrow, drag chart body to pan (live-updates the axis), scroll wheel to zoom around the cursor, scroll past full extent to clear.
- **Visual:** line+dot handles matching `DailyActivityLine`; slate-400 when no filter, blue-500 when zoomed. Floating pill at the top of the chart shows the current range with an X to clear.
- **Per-study persistence:** new `useDateRange(studyId)` hook (mirrors `useShowFilterCharts`) backs the filter to localStorage, broadcast through the React Query cache. Survives tab navigation and is shared between Media and Activity.
- **Filter tooltip:** the toggle's tooltip now lists active filter values (time-of-day chips/arc + date range) and has a "Reset filters" link. "Active" badge moved to the top-right.
- **Pure helpers:** extracted `src/renderer/src/utils/timelineZoom.js` (clientXToDate, zoomAroundAnchor, clampPanToBounds, clampMinRange, resolveAction, shouldClearToFullExtent, pxToDateMs) with 31 unit tests under `node --test`.

Spec: `docs/specs/2026-05-13-timeline-zoom-design.md`.

## Test plan

- [x] Drag handles inward to narrow → on release, chart zooms; handles dock at the edges.
- [x] Drag chart body while zoomed → pan; line data updates live; handles stay at edges.
- [x] Scroll wheel up/down → zoom in/out around the cursor; date under cursor stays put.
- [x] Scroll out past full extent → filter clears; pill disappears; FilterChartsToggle dot disappears.
- [x] Drag handles outward (at full extent) → narrows via opposite edge motion.
- [x] Pill X button clears the filter.
- [x] Switch tabs (Media ↔ Activity) → range persists.
- [x] Filter tooltip shows the active values (chips and/or date range) and "Reset filters" works.
- [x] Adding/removing species → all charts and queries refetch.
- [x] ENA24-style study (no temporal data) → map still loads (heatmap query fires via the `!hasTemporalData` bypass).