### PR TITLE
UI polish: tooltips, buttons, species rows, filter-row transitions

### DIFF
--- a/src/renderer/src/CacheSection.jsx
+++ b/src/renderer/src/CacheSection.jsx
@@ -61,7 +61,7 @@ export default function CacheSection({ studyId }) {
           <button
             onClick={handleClear}
             disabled={isLoading || isEmpty || clearing}
-            className="cursor-pointer flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-foreground bg-card border border-border rounded-md hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            className="flex items-center justify-center gap-2 h-9 px-4 text-sm font-medium text-foreground bg-card border border-border rounded-md hover:bg-gray-50 dark:hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             {clearing ? (
               <>

--- a/src/renderer/src/StudySettings.jsx
+++ b/src/renderer/src/StudySettings.jsx
@@ -89,7 +89,7 @@ export default function StudySettings({ studyId, studyName }) {
             </div>
             <button
               onClick={() => setIsDeleteModalOpen(true)}
-              className="cursor-pointer flex items-center justify-center px-4 py-2 text-sm font-medium text-red-600 bg-card border border-red-300 rounded-md hover:bg-red-50 transition-colors w-full sm:w-auto dark:text-red-400 dark:border-red-500/30 dark:hover:bg-red-500/10"
+              className="flex items-center justify-center gap-2 h-9 px-4 text-sm font-medium text-red-600 bg-card border border-red-300 rounded-md hover:bg-red-50 transition-colors w-full sm:w-auto dark:text-red-400 dark:border-red-500/30 dark:hover:bg-red-500/10"
             >
               Delete
             </button>

--- a/src/renderer/src/StudySettings.jsx
+++ b/src/renderer/src/StudySettings.jsx
@@ -34,24 +34,24 @@ export default function StudySettings({ studyId, studyName }) {
               <Tooltip.Portal>
                 <Tooltip.Content
                   side="right"
-                  sideOffset={8}
-                  className="z-[10000] max-w-xs px-3 py-2 bg-gray-900 text-white text-xs rounded-md shadow-lg"
+                  sideOffset={10}
+                  className="z-[10000] max-w-[18rem] px-3.5 py-3 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
                 >
-                  <p className="text-muted-foreground mb-1.5">
+                  <p className="text-muted-foreground leading-relaxed mb-3">
                     Groups nearby photos/videos into sequences based on time gaps for easier
                     browsing and analysis.
                   </p>
-                  <ul className="text-muted-foreground space-y-0.5">
+                  <ul className="text-muted-foreground leading-relaxed space-y-1.5">
                     <li>
-                      <span className="text-white font-medium">Off:</span> Preserves original event
-                      groupings from import
+                      <span className="text-popover-foreground font-medium">Off:</span> Preserves
+                      original event groupings from import
                     </li>
                     <li>
-                      <span className="text-white font-medium">On:</span> Groups media taken within
-                      the specified time gap
+                      <span className="text-popover-foreground font-medium">On:</span> Groups media
+                      taken within the specified time gap
                     </li>
                   </ul>
-                  <Tooltip.Arrow className="fill-gray-900" />
+                  <Tooltip.Arrow className="fill-popover" />
                 </Tooltip.Content>
               </Tooltip.Portal>
             </Tooltip.Root>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -640,6 +640,12 @@ export default function Activity({ studyData, studyId }) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
 
+  // Suppress the filter-row's open/close transition until species + temporal
+  // guards have settled. On tab navigation the wrapper otherwise flips
+  // h-0 → h-[180px] when the async timeseries query resolves, which fires
+  // the CSS ease-in animation even though no user toggle happened.
+  const [filterRowTransitionsEnabled, setFilterRowTransitionsEnabled] = useState(false)
+
   // Lightweight deduped deployment-location query (shared cache with the
   // Overview tab). Used to paint the skeleton map immediately while the
   // heavy sequence-aware heatmap SQL runs in the worker.
@@ -752,6 +758,10 @@ export default function Activity({ studyData, studyId }) {
     const endMatch = Math.abs(fullExtent[1].getTime() - dateRange[1].getTime()) < tolerance
     return startMatch && endMatch
   }, [hasTemporalData, fullExtent, dateRange])
+
+  useEffect(() => {
+    if (speciesInitialized && hasTemporalData) setFilterRowTransitionsEnabled(true)
+  }, [speciesInitialized, hasTemporalData])
 
   // For backend queries, fall back to fullExtent when the user hasn't set
   // a date filter. dateRange itself stays [null, null] in the parent so
@@ -947,7 +957,9 @@ export default function Activity({ studyData, studyId }) {
               daily-activity queries as queryKey inputs stabilize. Default
               OFF; when off, the map above grows to reclaim the 130px. */}
           <div
-            className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
+            className={`w-full flex-shrink-0 overflow-hidden ${
+              filterRowTransitionsEnabled ? 'transition-all duration-300 ease-in-out' : ''
+            } ${
               showFilterCharts && hasTemporalData
                 ? 'h-[180px] opacity-100 mt-4'
                 : 'h-0 opacity-0 mt-0'

--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -336,15 +336,15 @@ function AppContent() {
               <Tooltip.Portal>
                 <Tooltip.Content
                   side="bottom"
-                  sideOffset={8}
+                  sideOffset={10}
                   align="end"
-                  className="z-[10000] max-w-xs px-3 py-2 bg-gray-900 text-white text-xs rounded-md shadow-lg"
+                  className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
                 >
-                  <p className="font-medium mb-1">Add Study</p>
-                  <p className="text-muted-foreground">
+                  <p className="font-medium leading-snug mb-1">Add Study</p>
+                  <p className="text-muted-foreground leading-relaxed">
                     Create a new study by importing camera trap images.
                   </p>
-                  <Tooltip.Arrow className="fill-gray-900" />
+                  <Tooltip.Arrow className="fill-popover" />
                 </Tooltip.Content>
               </Tooltip.Portal>
             </Tooltip.Root>

--- a/src/renderer/src/export.jsx
+++ b/src/renderer/src/export.jsx
@@ -32,9 +32,7 @@ function ExportRow({ icon: Icon, title, description, onClick, isFirst, isLast })
       <button
         onClick={handleClick}
         disabled={isExporting}
-        className={`cursor-pointer transition-colors flex justify-center items-center gap-2 border border-border px-4 h-9 text-sm shadow-sm rounded-md hover:bg-accent w-full sm:w-auto ${
-          isExporting ? 'opacity-70' : ''
-        }`}
+        className="flex items-center justify-center gap-2 h-9 px-4 text-sm font-medium text-foreground bg-card border border-border rounded-md hover:bg-gray-50 dark:hover:bg-accent disabled:opacity-50 disabled:cursor-not-allowed transition-colors w-full sm:w-auto"
       >
         {isExporting ? <span className="animate-pulse">Exporting...</span> : 'Export'}
       </button>

--- a/src/renderer/src/hooks/useShowFilterCharts.js
+++ b/src/renderer/src/hooks/useShowFilterCharts.js
@@ -33,7 +33,7 @@ export function useShowFilterCharts(studyId) {
     queryFn: () => readFromStorage(studyId),
     enabled: !!studyId,
     staleTime: Infinity,
-    placeholderData: false
+    initialData: () => (studyId ? readFromStorage(studyId) : false)
   })
 
   const showFilterCharts = data ?? false

--- a/src/renderer/src/media.jsx
+++ b/src/renderer/src/media.jsx
@@ -107,6 +107,12 @@ export default function Activity({ studyData, studyId }) {
   const { sequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
 
+  // Suppress the filter-row's open/close transition until species + temporal
+  // guards have settled. On tab navigation the wrapper otherwise flips
+  // h-0 → h-[180px] when the async timeseries query resolves, which fires
+  // the CSS ease-in animation even though no user toggle happened.
+  const [filterRowTransitionsEnabled, setFilterRowTransitionsEnabled] = useState(false)
+
   const taxonomicData = studyData?.taxonomic || null
 
   // Fetch sequence-aware species distribution data
@@ -250,6 +256,10 @@ export default function Activity({ studyData, studyId }) {
     return startMatch && endMatch
   }, [hasTemporalData, fullExtent, dateRange])
 
+  useEffect(() => {
+    if (speciesInitialized && hasTemporalData) setFilterRowTransitionsEnabled(true)
+  }, [speciesInitialized, hasTemporalData])
+
   // Fetch sequence-aware daily activity data.
   // Effective dateRange falls back to fullExtent so the radar can render
   // before the user has brushed a custom range. Gallery keeps its
@@ -363,7 +373,9 @@ export default function Activity({ studyData, studyId }) {
               during initial load. Default OFF; when off, the row collapses
               and the gallery reclaims the 130px. */}
           <div
-            className={`w-full flex-shrink-0 overflow-hidden transition-all duration-300 ease-in-out ${
+            className={`w-full flex-shrink-0 overflow-hidden ${
+              filterRowTransitionsEnabled ? 'transition-all duration-300 ease-in-out' : ''
+            } ${
               showFilterCharts && hasTemporalData
                 ? 'h-[180px] opacity-100 mt-4'
                 : 'h-0 opacity-0 mt-0'

--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -22,7 +22,10 @@ function SpeciesRow({
   scrollSignal
 }) {
   const commonName = useCommonName(species.scientificName, { storedCommonName })
-  const displayName = commonName || formatScientificName(species.scientificName)
+  const rawDisplayName = commonName || formatScientificName(species.scientificName)
+  const displayName = rawDisplayName
+    ? rawDisplayName.charAt(0).toUpperCase() + rawDisplayName.slice(1)
+    : rawDisplayName
   const showScientific =
     species.scientificName && commonName && commonName !== species.scientificName
   const info = resolveSpeciesInfo(species.scientificName)
@@ -54,7 +57,7 @@ function SpeciesRow({
           <div className="flex items-center gap-3 flex-shrink-0">
             <div className="w-80 flex-shrink-0">
               <span
-                className={`text-sm text-foreground font-medium ${showScientific ? 'capitalize' : 'italic'}`}
+                className={`text-sm text-foreground font-medium ${showScientific ? 'capitalize' : ''}`}
               >
                 {displayName}
               </span>

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -33,7 +33,7 @@ function SpeciesHeading({ scientificName, tone = 'light' }) {
   const common = useCommonName(scientificName)
   const sciClass =
     tone === 'dark'
-      ? 'italic text-muted-foreground font-normal'
+      ? 'italic text-white/70 font-normal'
       : 'italic text-muted-foreground font-normal'
   if (!scientificName) return <>Blank</>
   if (common && common !== scientificName) {

--- a/src/renderer/src/ui/SequenceGapSlider.jsx
+++ b/src/renderer/src/ui/SequenceGapSlider.jsx
@@ -86,7 +86,9 @@ export function SequenceGapSlider({
               onTouchEnd={commit}
               onBlur={commit}
               disabled={disabled}
-              className="flex-1 min-w-0 h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className={`flex-1 min-w-0 h-2 bg-muted rounded-lg appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+                dragValue !== null ? 'accent-blue-500' : 'accent-gray-400 dark:accent-gray-500'
+              }`}
               aria-label={`Sequence grouping: ${formatGapValue(dragValue)}`}
             />
           </Tooltip.Trigger>
@@ -148,7 +150,9 @@ export function SequenceGapSlider({
         onTouchEnd={commit}
         onBlur={commit}
         disabled={disabled}
-        className="w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer accent-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        className={`w-full h-2 bg-muted rounded-lg appearance-none cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+          dragValue !== null ? 'accent-blue-500' : 'accent-gray-400 dark:accent-gray-500'
+        }`}
         aria-label={`Sequence grouping: ${formatGapValue(dragValue)}`}
       />
       {showDescription && (

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -60,7 +60,7 @@ function SpeciesRow({
         isSelected
           ? 'bg-blue-50 hover:bg-blue-100 dark:bg-blue-500/15 dark:hover:bg-blue-500/25'
           : 'hover:bg-blue-50 dark:hover:bg-blue-500/15'
-      } ${isFirstPseudo ? 'border-t border-border mt-1 pt-3' : ''}`}
+      } ${isFirstPseudo ? 'border-t border-border pt-4' : ''}`}
       onClick={() => onToggle(species)}
     >
       <div className="flex justify-between mb-1 items-center cursor-pointer gap-2">

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -35,9 +35,12 @@ function SpeciesRow({
   const resolved = useCommonName(isPseudoEntry ? null : species.scientificName, {
     storedCommonName
   })
-  const displayName = isPseudoEntry
+  const rawDisplayName = isPseudoEntry
     ? pseudoEntry.label
     : resolved || formatScientificName(species.scientificName)
+  const displayName = rawDisplayName
+    ? rawDisplayName.charAt(0).toUpperCase() + rawDisplayName.slice(1)
+    : rawDisplayName
 
   const isSelected = selectedSpecies.some((s) => s.scientificName === species.scientificName)
   const colorIndex = selectedSpecies.findIndex((s) => s.scientificName === species.scientificName)
@@ -70,12 +73,8 @@ function SpeciesRow({
             style={{ backgroundColor: isSelected ? color : null }}
           ></div>
           <span
-            className={`text-sm truncate pr-1 ${
-              isPseudoEntry
-                ? 'text-foreground'
-                : showScientificInItalic
-                  ? 'text-foreground capitalize'
-                  : 'text-foreground italic'
+            className={`text-sm truncate pr-1 text-foreground ${
+              !isPseudoEntry && showScientificInItalic ? 'capitalize' : ''
             }`}
           >
             {displayName}


### PR DESCRIPTION
## Summary
A grab-bag of small UI consistency fixes across the app:

- **Tooltips**: Add Study (+) and Sequence Grouping (?) tooltips now use the theme-aware `bg-popover` style (with border + arrow matching the popover), instead of the hardcoded dark `bg-gray-900`. Sequence Grouping tooltip also gets roomier spacing.
- **Study Settings buttons**: Export, Clear (cache) and Delete now share one flat secondary button style (`h-9 px-4`, no shadow, `font-medium`). Hover uses `bg-gray-50 dark:bg-accent` matching the Sources page's "Add images directory" button; cursor stays the native default arrow.
- **Species list spacing**: hover/active bg on the row above the pseudo-species divider now reaches the divider line (replaced the 4px outside `mt-1` with `pt-4` inside the row).
- **Filter row transitions**: navigating between Media and Activity tabs no longer animates the bottom filter row open from collapsed. `useShowFilterCharts` reads localStorage synchronously via `initialData`, and a `filterRowTransitionsEnabled` gate suppresses CSS transitions until species/temporal guards have settled. User toggles still animate.
- **Sequence-gap slider**: thumb accent color is now muted (gray) when the slider is in the Off state instead of blue.
- **Species rows**: scientific-only fallback names (e.g. `Crypturellus`) render straight instead of italic; lowercase species labels (`bear`, `wolf`) get a JS first-letter uppercase so they render `Bear`, `Wolf`. Pseudo labels ("Vegetation obstruction") unaffected.
- **Best-media modal**: the parenthesized scientific name in the dark heading pill switched from `text-muted-foreground` to `text-white/70` so it's actually readable on `bg-black/60`. (The previous ternary returned the same class for both tones — dead code path.)

## Test plan
- [x] Hover the `+` button next to Studies and the (?) icon on Sequence Grouping — tooltips render with the popover style in both light and dark themes.
- [x] Study Settings → Export / Clear / Delete buttons are visually consistent (same height, weight, hover). Delete keeps its red destructive variant.
- [x] Species panel: hover the last real-species row and a pseudo row (Blank/Vehicle) — hover bg touches the divider on both sides.
- [x] Toggle the filter row, navigate Media ↔ Activity — bottom row appears already open with no ease-in animation. Then click the filter-charts toggle — it still animates.
- [x] Turn the sequence-gap slider to Off — thumb is gray, not blue.
- [x] Species list (overview / media / activity) — fallback labels render straight + first letter capitalized.
- [x] Open the best-captures modal — parenthesized scientific name is readable on the dark pill.