### PR TITLE
Align CSV import counts with row-level blocking (follow-up to #524)

### DIFF
--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -535,7 +535,9 @@ byte-stable.
    classifies every cell into one of `unchanged | change | warning |
 readonly`. Returns a `PreviewPayload` (see
    [ipc-api.md](./ipc-api.md#deployments-csv-importexport)) plus
-   aggregate counts (`applyCount`, `cellWarningCount`, `rowSkipCount`).
+   aggregate counts (`applyCount`, `rowsBlockedByWarningCount`,
+   `rowSkipCount`). A row with any `warning` cell is blocked from apply
+   entirely — partial-row application is not supported.
    Required column is `deploymentID`; missing it returns
    `{ error: "Required column 'deploymentID' not found in CSV." }`
    before the modal opens.

--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -142,9 +142,10 @@ There is also one preload-only helper (not an IPC channel):
   filePath: string
   fileName: string
   totalRows: number
-  applyCount: number       // rows with at least one 'change' cell
-  cellWarningCount: number // total 'warning' cells
-  rowSkipCount: number     // total 'skipped' rows
+  applyCount: number              // rows that will actually update:
+                                  //   normal + ≥1 'change' cell + no 'warning' cells
+  rowsBlockedByWarningCount: number // normal rows with ≥1 'warning' cell (blocked from apply)
+  rowSkipCount: number            // total 'skipped' rows (empty/unknown deploymentID)
   rows: Array<{
     rowIndex: number       // 1-based
     deploymentID: string

--- a/docs/specs/2026-05-12-deployments-csv-import-export-design.md
+++ b/docs/specs/2026-05-12-deployments-csv-import-export-design.md
@@ -12,8 +12,9 @@ Google Sheets, vim), and re-import to bulk-update `latitude`, `longitude`,
 and `locationName` across many deployments at once. Entry point: two flat
 buttons (**Export CSV** / **Import CSV**) in a new always-visible header
 strip above the conditional timeline header in the Deployments tab.
-Import shows a preview-table modal with cell-level error highlighting
-before any DB write; apply is a single SQLite transaction.
+Import shows a preview-table modal classifying every cell against the
+DB and every row against the apply gate before any write; apply is a
+single SQLite transaction.
 
 ## Motivation
 
@@ -47,8 +48,9 @@ generic location names. That round-trip is in scope.
   each warning. Apply commits in one SQLite transaction.
 - `latitude`, `longitude`, `locationName` are editable. Everything else
   is read-only context (or ignored on import).
-- Out-of-range coords are skipped per-cell with a warning; the rest of
-  the row still applies.
+- Out-of-range coords (and any other cell warning) block the **entire
+  row** from being applied. Partial-row application is not supported:
+  if any cell on a row warns, no field on that row is written.
 - Unknown `deploymentID` rows are skipped per-row with a warning.
 
 ## Non-goals
@@ -171,7 +173,7 @@ A blocking modal occupying ~80% of the viewport. Layout:
 ┌──────────────────────────────────────────────────────────────────────────┐
 │ Import deployments CSV — sample-edits.csv                            ×  │
 │                                                                          │
-│  ✔ 23 rows will update     ⚠ 2 cells skipped     ⊝ 1 row unknown ID     │
+│  ✔ 21 rows will update     ⚠ 2 rows blocked by warnings     ⊝ 1 row unknown ID │
 │                                                                          │
 │  ┌────────────────────────────────────────────────────────────────────┐  │
 │  │ # │ deploymentID │ locationID │ locationName │ latitude │ longitude│  │
@@ -182,9 +184,9 @@ A blocking modal occupying ~80% of the viewport. Layout:
 │  │ 4 │ ⊝ CAM_NEW    │            │              │  45.0    │  6.0    │  │
 │  └────────────────────────────────────────────────────────────────────┘  │
 │                                                                          │
-│  Legend:  ← change   ⚠ warning (cell skipped)   ⊝ row skipped           │
+│  Legend:  ← change   ⚠ warning (blocks row)   ⊝ row unknown ID          │
 │                                                                          │
-│                                          [ Cancel ]   [ Apply (23) ]    │
+│                                          [ Cancel ]   [ Apply (21) ]    │
 └──────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -194,14 +196,15 @@ A blocking modal occupying ~80% of the viewport. Layout:
 | --- | --- | --- | --- |
 | `unchanged` | default text color | CSV value equals current DB value | n/a |
 | `change` | bold + `←` glyph + green tint (`text-green-700` light / `text-green-300` dark) | CSV value differs and will overwrite | yes |
-| `warning` | amber tint (`text-amber-700` / `amber-300`) + `⚠` glyph | parse or validation failure; tooltip on hover | **no — cell skipped, rest of row applies** |
-| `readonly` | gray italic | `deploymentID` / `locationID` cells; not editable | n/a (mismatches surfaced as row warning, see below) |
+| `warning` | amber tint (`text-amber-700` / `amber-300`) + `⚠` glyph; row tinted red | parse or validation failure; tooltip on hover | **no — and the entire row is blocked from apply** |
+| `readonly` | gray italic | `deploymentID` / `locationID` cells; not editable | n/a (a `locationID` mismatch is a cell warning, which blocks its row) |
 
 #### Row states
 
 | State | Visual | Meaning | Applied? |
 | --- | --- | --- | --- |
-| Normal | — | row will participate in update | yes (for `change` cells only) |
+| Normal, clean | green row tint (only if at least one `change` cell) | row has no warning cells | yes (for `change` cells only) |
+| Normal, blocked | red row tint | at least one cell on the row is `warning` | **no — entire row blocked from apply** |
 | `skipped` | row dimmed (50% opacity), `⊝` in the `#` column | `deploymentID` empty or not found in DB | **no — entire row skipped** |
 
 Skipped rows still render in the table so the user can see what was
@@ -210,21 +213,28 @@ for empty: `deploymentID is required.`
 
 #### Hover tooltips
 
-Each warning cell has a tooltip:
+Each warning cell has a tooltip. Any warning on a row blocks the
+**whole row** from apply (not just the offending cell).
 
-- Out-of-range latitude: `Latitude 91.5 is outside [-90, 90]. Cell skipped; other cells in this row still apply.`
-- Out-of-range longitude: `Longitude 999.0 is outside [-180, 180]. Cell skipped; other cells in this row still apply.`
-- Non-numeric: `'abc' is not a valid number. Cell skipped; other cells in this row still apply.`
-- `locationID` mismatch (CSV value differs from DB): `locationID is read-only. Existing value 'LOC_A' will be kept; CSV value 'LOC_B' ignored.`
+- Out-of-range latitude: `Latitude 91.5 is outside [-90, 90].`
+- Out-of-range longitude: `Longitude 999.0 is outside [-180, 180].`
+- Non-numeric: `'abc' is not a valid number.`
+- `locationID` mismatch (CSV value differs from DB): `locationID is read-only. Existing value will be kept; CSV value ignored.`
 - Duplicate `deploymentID` in CSV: `Overridden by row N below.` (on the earlier row's changed cells)
+- Intra-locationID name conflict: `Conflicting names for LOC_A; row N below wins.`
 
 #### Summary banner
 
 Three counts above the table:
 
-- `✔ N rows will update` — number of rows with at least one `change` cell.
-- `⚠ W cells skipped` — count of `warning` cells across all rows.
+- `✔ N rows will update` — number of normal rows with at least one
+  `change` cell **and no warning cells** (this is also `[Apply (N)]`).
+- `⚠ W rows blocked by warnings` — number of normal rows with at
+  least one `warning` cell. These rows contribute zero to apply.
 - `⊝ M rows unknown ID` — count of `skipped` rows.
+
+Each tile doubles as a filter toggle (click to show only those rows;
+click again or click "Show all" to clear).
 
 `[Apply (N)]` is disabled when `N == 0`. Apply count matches "rows will update."
 
@@ -317,9 +327,10 @@ The main process returns this shape from `deployments:parse-csv-for-import`:
   filePath: '/abs/path/to/sample.csv',
   fileName: 'sample.csv',
   totalRows: 26,                  // CSV data rows (excludes header)
-  applyCount: 23,                 // rows with at least one 'change' cell
-  cellWarningCount: 2,            // total warning cells
-  rowSkipCount: 1,                // total skipped rows
+  applyCount: 21,                 // rows that will actually update:
+                                  //   normal + has 'change' cell + no warning cells
+  rowsBlockedByWarningCount: 2,   // normal rows with >=1 warning cell (blocked from apply)
+  rowSkipCount: 1,                // total skipped rows (empty/unknown deploymentID)
   rows: [
     {
       rowIndex: 1,                // 1-based, matches what the user sees in the table
@@ -340,16 +351,22 @@ The main process returns this shape from `deployments:parse-csv-for-import`:
 ```
 
 The renderer is stateless re-validation; it only reads this structure
-and renders. The `applyCount`, `cellWarningCount`, `rowSkipCount`
-fields drive the summary banner directly.
+and renders. The `applyCount`, `rowsBlockedByWarningCount`, `rowSkipCount`
+fields drive the summary banner directly. The renderer rebuilds the
+apply plan locally (see "Apply phase") and the resulting plan length is
+guaranteed to equal `applyCount` — both apply the same row-level
+predicate (`rowState === 'normal'` AND no warning cells AND at least
+one `change` cell).
 
 ## Apply phase
 
 After the user clicks **Apply**:
 
-1. Renderer extracts the **apply plan** from the preview payload — an
-   array of `{ deploymentID, fields }` where `fields` contains only the
-   keys whose cell state is `change`:
+1. Renderer extracts the **apply plan** from the preview payload via
+   `buildDeploymentsCsvApplyPlan` — an array of `{ deploymentID, fields }`
+   where `fields` contains only the keys whose cell state is `change`.
+   Rows in the `skipped` state and rows with any `warning` cell are
+   excluded from the plan entirely.
 
    ```js
    [

--- a/src/main/services/import/parsers/deploymentsCsv.js
+++ b/src/main/services/import/parsers/deploymentsCsv.js
@@ -3,6 +3,10 @@ import csv from 'csv-parser'
 
 const COORD_EPSILON = 1e-9
 
+// The three columns the import flow may write back to the deployments table.
+// Kept in sync with the renderer-side EDITABLE_DEPLOYMENT_IMPORT_KEYS.
+const EDITABLE_KEYS = ['locationName', 'latitude', 'longitude']
+
 function readonlyEqual(csvValue, dbValue) {
   if (csvValue === '' || csvValue == null) return true
   return String(csvValue) === String(dbValue ?? '')
@@ -80,6 +84,11 @@ async function readCsvRows(filePath) {
 /**
  * Parse a deployments CSV and classify every cell against the current DB
  * state. Pure: reads the CSV, never writes.
+ *
+ * Validation is row-level: any warning cell in a normal row blocks the
+ * whole row from being applied. `applyCount` reflects this — it counts
+ * rows that will actually update (no warning cells + at least one change
+ * cell). `rowsBlockedByWarningCount` is the row-level complement.
  *
  * @param {string} filePath - absolute path to the .csv file.
  * @param {Array} dbDeployments - current rows from the deployments table.
@@ -168,7 +177,7 @@ export async function parseDeploymentsCsv(filePath, dbDeployments) {
     if (row.rowState !== 'normal') return
     const lastIndex = lastIndexByDeploymentID.get(row.deploymentID)
     if (lastIndex === i) return
-    for (const key of ['locationName', 'latitude', 'longitude']) {
+    for (const key of EDITABLE_KEYS) {
       const col = row.columns[key]
       if (col.state === 'change') {
         row.columns[key] = {
@@ -211,21 +220,23 @@ export async function parseDeploymentsCsv(filePath, dbDeployments) {
     }
   })
 
+  // Row-level counting: a row with any warning cell is blocked from apply
+  // entirely — partial-row application is not supported (see spec).
   let applyCount = 0
-  let cellWarningCount = 0
+  let rowsBlockedByWarningCount = 0
   let rowSkipCount = 0
   for (const row of previewRows) {
     if (row.rowState === 'skipped') {
       rowSkipCount++
       continue
     }
-    const hasChange = ['locationName', 'latitude', 'longitude'].some(
-      (k) => row.columns[k].state === 'change'
-    )
-    if (hasChange) applyCount++
-    for (const k of Object.keys(row.columns)) {
-      if (row.columns[k].state === 'warning') cellWarningCount++
+    const hasWarning = Object.values(row.columns).some((c) => c.state === 'warning')
+    if (hasWarning) {
+      rowsBlockedByWarningCount++
+      continue
     }
+    const hasChange = EDITABLE_KEYS.some((k) => row.columns[k].state === 'change')
+    if (hasChange) applyCount++
   }
 
   return {
@@ -233,7 +244,7 @@ export async function parseDeploymentsCsv(filePath, dbDeployments) {
     fileName: filePath.split(/[/\\]/).pop(),
     totalRows: rows.length,
     applyCount,
-    cellWarningCount,
+    rowsBlockedByWarningCount,
     rowSkipCount,
     rows: previewRows
   }

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -4,12 +4,9 @@ import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
-  countRowsBlockedByWarnings,
-  EDITABLE_DEPLOYMENT_IMPORT_KEYS,
+  EDITABLE_DEPLOYMENT_IMPORT_KEYS as EDITABLE_KEYS,
   getDeploymentsCsvImportRowClassName
 } from './deploymentsImportPreviewModel'
-
-const EDITABLE_KEYS = EDITABLE_DEPLOYMENT_IMPORT_KEYS
 
 function CellContent({ col }) {
   if (col.state === 'warning') {
@@ -54,10 +51,6 @@ function CellContent({ col }) {
       {String(display)}
     </span>
   )
-}
-
-function rowBackgroundClass(row) {
-  return getDeploymentsCsvImportRowClassName(row)
 }
 
 function renderGutter(row) {
@@ -121,16 +114,10 @@ export default function DeploymentsImportPreviewModal({
     return preview.rows
   }, [preview, filter])
 
-  // Rows (not cells) with at least one warning. Used to disable the
-  // warnings-filter tile when there's nothing to show, and to label it
-  // honestly: cellWarningCount is per-cell, this is per-row.
-  const rowsWithWarningCount = useMemo(() => {
-    return countRowsBlockedByWarnings(preview)
-  }, [preview])
-
   if (!preview) return null
 
-  const applyCount = applyPlan.length
+  const applyCount = preview.applyCount
+  const rowsBlockedByWarningCount = preview.rowsBlockedByWarningCount
   const canApply = applyCount > 0 && !isApplying
 
   const handleBackdropMouseDown = (e) => {
@@ -183,7 +170,7 @@ export default function DeploymentsImportPreviewModal({
           </button>
           <button
             onClick={() => toggleFilter('warnings')}
-            disabled={rowsWithWarningCount === 0}
+            disabled={rowsBlockedByWarningCount === 0}
             title={
               filter === 'warnings'
                 ? 'Click to show all rows'
@@ -195,8 +182,8 @@ export default function DeploymentsImportPreviewModal({
                 : 'border-transparent hover:bg-accent text-amber-700 dark:text-amber-300'
             }`}
           >
-            <AlertTriangle size={12} /> {rowsWithWarningCount}{' '}
-            {rowsWithWarningCount === 1 ? 'row' : 'rows'} blocked by warnings
+            <AlertTriangle size={12} /> {rowsBlockedByWarningCount}{' '}
+            {rowsBlockedByWarningCount === 1 ? 'row' : 'rows'} blocked by warnings
           </button>
           <button
             onClick={() => toggleFilter('skipped')}
@@ -237,7 +224,7 @@ export default function DeploymentsImportPreviewModal({
           resetScrollKey={filter}
           emptyMessage="No rows match the current filter."
           getRowKey={(row) => row.rowIndex}
-          rowClassName={rowBackgroundClass}
+          rowClassName={getDeploymentsCsvImportRowClassName}
           renderGutter={renderGutter}
           renderCell={({ row, key }) => <CellContent col={row.columns[key]} />}
         />
@@ -252,10 +239,6 @@ export default function DeploymentsImportPreviewModal({
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-red-50 dark:bg-red-500/10 border border-red-300/60 dark:border-red-500/30" />
               row blocked by warning
-            </span>
-            <span className="inline-flex items-center gap-1">
-              <span className="inline-block w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-500/5 border border-amber-300/60 dark:border-amber-500/30" />
-              cell warning
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-muted/40 dark:bg-muted/30 border border-border" />

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -250,8 +250,12 @@ export default function DeploymentsImportPreviewModal({
               will update
             </span>
             <span className="inline-flex items-center gap-1">
+              <span className="inline-block w-3 h-3 rounded-sm bg-red-50 dark:bg-red-500/10 border border-red-300/60 dark:border-red-500/30" />
+              row blocked by warning
+            </span>
+            <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-500/5 border border-amber-300/60 dark:border-amber-500/30" />
-              warning row blocked
+              cell warning
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-muted/40 dark:bg-muted/30 border border-border" />
@@ -271,7 +275,7 @@ export default function DeploymentsImportPreviewModal({
               disabled={!canApply}
               className="px-3 py-1.5 text-xs bg-blue-500 hover:bg-blue-600 text-white rounded disabled:opacity-50 disabled:hover:bg-blue-500"
             >
-              {isApplying ? 'Applying…' : `Apply (${preview.applyCount})`}
+              {isApplying ? 'Applying…' : `Apply (${applyCount})`}
             </button>
           </div>
         </div>

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -5,7 +5,8 @@ import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
   countRowsBlockedByWarnings,
-  EDITABLE_DEPLOYMENT_IMPORT_KEYS
+  EDITABLE_DEPLOYMENT_IMPORT_KEYS,
+  getDeploymentsCsvImportRowClassName
 } from './deploymentsImportPreviewModel'
 
 const EDITABLE_KEYS = EDITABLE_DEPLOYMENT_IMPORT_KEYS
@@ -56,16 +57,7 @@ function CellContent({ col }) {
 }
 
 function rowBackgroundClass(row) {
-  if (row.rowState === 'skipped') {
-    return 'bg-muted/40 dark:bg-muted/30 opacity-60'
-  }
-  const hasChange = EDITABLE_KEYS.some((k) => row.columns[k]?.state === 'change')
-  if (hasChange) return 'bg-green-50 dark:bg-green-500/10'
-  // Any column with a warning counts — including readonly mismatches on
-  // locationID — so the visual matches what the warnings filter selects.
-  const hasWarning = Object.values(row.columns).some((c) => c?.state === 'warning')
-  if (hasWarning) return 'bg-amber-50 dark:bg-amber-500/5'
-  return ''
+  return getDeploymentsCsvImportRowClassName(row)
 }
 
 function renderGutter(row) {

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -2,8 +2,12 @@ import { X, AlertTriangle, Ban, ArrowRight, ArrowLeftRight } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
+import {
+  buildDeploymentsCsvApplyPlan,
+  EDITABLE_DEPLOYMENT_IMPORT_KEYS
+} from './deploymentsImportPreviewModel'
 
-const EDITABLE_KEYS = ['locationName', 'latitude', 'longitude']
+const EDITABLE_KEYS = EDITABLE_DEPLOYMENT_IMPORT_KEYS
 
 function CellContent({ col }) {
   if (col.state === 'warning') {
@@ -100,22 +104,7 @@ export default function DeploymentsImportPreviewModal({
   }, [onCancel, isApplying])
 
   const applyPlan = useMemo(() => {
-    if (!preview) return []
-    const plan = []
-    for (const row of preview.rows) {
-      if (row.rowState !== 'normal') continue
-      const fields = {}
-      for (const key of EDITABLE_KEYS) {
-        const col = row.columns[key]
-        if (col.state === 'change') {
-          fields[key] = col.appliedValue
-        }
-      }
-      if (Object.keys(fields).length > 0) {
-        plan.push({ deploymentID: row.deploymentID, fields })
-      }
-    }
-    return plan
+    return buildDeploymentsCsvApplyPlan(preview)
   }, [preview])
 
   const filteredRows = useMemo(() => {

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -4,8 +4,9 @@ import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
-  EDITABLE_DEPLOYMENT_IMPORT_KEYS as EDITABLE_KEYS,
-  getDeploymentsCsvImportRowClassName
+  getDeploymentsCsvImportRowClassName,
+  rowHasEditableChange,
+  rowHasWarning
 } from './deploymentsImportPreviewModel'
 
 function CellContent({ col }) {
@@ -97,16 +98,15 @@ export default function DeploymentsImportPreviewModal({
     if (!preview) return []
     if (filter === 'all') return preview.rows
     if (filter === 'updated') {
-      return preview.rows.filter((row) => {
-        if (row.rowState !== 'normal') return false
-        return EDITABLE_KEYS.some((k) => row.columns[k]?.state === 'change')
-      })
+      // Mirror the parser's applyCount predicate: normal, not warning-blocked,
+      // and has at least one editable change cell. Anything in the result
+      // here is also in the apply plan.
+      return preview.rows.filter(
+        (row) => row.rowState === 'normal' && !rowHasWarning(row) && rowHasEditableChange(row)
+      )
     }
     if (filter === 'warnings') {
-      return preview.rows.filter((row) => {
-        if (row.rowState !== 'normal') return false
-        return Object.values(row.columns).some((c) => c?.state === 'warning')
-      })
+      return preview.rows.filter((row) => row.rowState === 'normal' && rowHasWarning(row))
     }
     if (filter === 'skipped') {
       return preview.rows.filter((row) => row.rowState === 'skipped')

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -4,6 +4,7 @@ import DeploymentsPreviewTable from './DeploymentsPreviewTable'
 import { formatCellValue } from './deploymentsPreviewHelpers'
 import {
   buildDeploymentsCsvApplyPlan,
+  countRowsBlockedByWarnings,
   EDITABLE_DEPLOYMENT_IMPORT_KEYS
 } from './deploymentsImportPreviewModel'
 
@@ -132,13 +133,7 @@ export default function DeploymentsImportPreviewModal({
   // warnings-filter tile when there's nothing to show, and to label it
   // honestly: cellWarningCount is per-cell, this is per-row.
   const rowsWithWarningCount = useMemo(() => {
-    if (!preview) return 0
-    let n = 0
-    for (const row of preview.rows) {
-      if (row.rowState !== 'normal') continue
-      if (Object.values(row.columns).some((c) => c?.state === 'warning')) n++
-    }
-    return n
+    return countRowsBlockedByWarnings(preview)
   }, [preview])
 
   if (!preview) return null
@@ -199,7 +194,7 @@ export default function DeploymentsImportPreviewModal({
             title={
               filter === 'warnings'
                 ? 'Click to show all rows'
-                : 'Click to show only rows with cell warnings'
+                : 'Click to show only rows blocked by warnings'
             }
             className={`inline-flex items-center gap-1 px-2 py-1 rounded border transition-colors disabled:cursor-default disabled:opacity-60 ${
               filter === 'warnings'
@@ -207,8 +202,8 @@ export default function DeploymentsImportPreviewModal({
                 : 'border-transparent hover:bg-accent text-amber-700 dark:text-amber-300'
             }`}
           >
-            <AlertTriangle size={12} /> {preview.cellWarningCount}{' '}
-            {preview.cellWarningCount === 1 ? 'cell' : 'cells'} skipped
+            <AlertTriangle size={12} /> {rowsWithWarningCount}{' '}
+            {rowsWithWarningCount === 1 ? 'row' : 'rows'} blocked by warnings
           </button>
           <button
             onClick={() => toggleFilter('skipped')}
@@ -263,7 +258,7 @@ export default function DeploymentsImportPreviewModal({
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-amber-50 dark:bg-amber-500/5 border border-amber-300/60 dark:border-amber-500/30" />
-              cell warning
+              warning row blocked
             </span>
             <span className="inline-flex items-center gap-1">
               <span className="inline-block w-3 h-3 rounded-sm bg-muted/40 dark:bg-muted/30 border border-border" />

--- a/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
+++ b/src/renderer/src/deployments/DeploymentsImportPreviewModal.jsx
@@ -130,7 +130,8 @@ export default function DeploymentsImportPreviewModal({
 
   if (!preview) return null
 
-  const canApply = preview.applyCount > 0 && !isApplying
+  const applyCount = applyPlan.length
+  const canApply = applyCount > 0 && !isApplying
 
   const handleBackdropMouseDown = (e) => {
     if (e.target === e.currentTarget && !isApplying) onCancel()
@@ -165,7 +166,7 @@ export default function DeploymentsImportPreviewModal({
         <div className="flex items-center gap-2 px-4 py-2 border-b border-border text-xs">
           <button
             onClick={() => toggleFilter('updated')}
-            disabled={preview.applyCount === 0}
+            disabled={applyCount === 0}
             title={
               filter === 'updated'
                 ? 'Click to show all rows'
@@ -177,8 +178,8 @@ export default function DeploymentsImportPreviewModal({
                 : 'border-transparent hover:bg-accent text-green-700 dark:text-green-300'
             }`}
           >
-            <ArrowLeftRight size={12} /> {preview.applyCount}{' '}
-            {preview.applyCount === 1 ? 'row' : 'rows'} will update
+            <ArrowLeftRight size={12} /> {applyCount} {applyCount === 1 ? 'row' : 'rows'} will
+            update
           </button>
           <button
             onClick={() => toggleFilter('warnings')}

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -4,6 +4,16 @@ export function rowHasWarning(row) {
   return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
 }
 
+export function countRowsBlockedByWarnings(preview) {
+  if (!preview) return 0
+  let count = 0
+  for (const row of preview.rows || []) {
+    if (row.rowState !== 'normal') continue
+    if (rowHasWarning(row)) count++
+  }
+  return count
+}
+
 export function buildDeploymentsCsvApplyPlan(preview) {
   if (!preview) return []
 

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -1,0 +1,27 @@
+export const EDITABLE_DEPLOYMENT_IMPORT_KEYS = ['locationName', 'latitude', 'longitude']
+
+export function rowHasWarning(row) {
+  return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
+}
+
+export function buildDeploymentsCsvApplyPlan(preview) {
+  if (!preview) return []
+
+  const plan = []
+  for (const row of preview.rows || []) {
+    if (row.rowState !== 'normal') continue
+    if (rowHasWarning(row)) continue
+
+    const fields = {}
+    for (const key of EDITABLE_DEPLOYMENT_IMPORT_KEYS) {
+      const col = row.columns[key]
+      if (col.state === 'change') {
+        fields[key] = col.appliedValue
+      }
+    }
+    if (Object.keys(fields).length > 0) {
+      plan.push({ deploymentID: row.deploymentID, fields })
+    }
+  }
+  return plan
+}

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -4,6 +4,19 @@ export function rowHasWarning(row) {
   return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
 }
 
+export function rowHasEditableChange(row) {
+  return EDITABLE_DEPLOYMENT_IMPORT_KEYS.some((key) => row?.columns?.[key]?.state === 'change')
+}
+
+export function getDeploymentsCsvImportRowClassName(row) {
+  if (row?.rowState === 'skipped') {
+    return 'bg-muted/40 dark:bg-muted/30 opacity-60'
+  }
+  if (rowHasWarning(row)) return 'bg-red-50 dark:bg-red-500/10'
+  if (rowHasEditableChange(row)) return 'bg-green-50 dark:bg-green-500/10'
+  return ''
+}
+
 export function countRowsBlockedByWarnings(preview) {
   if (!preview) return 0
   let count = 0

--- a/src/renderer/src/deployments/deploymentsImportPreviewModel.js
+++ b/src/renderer/src/deployments/deploymentsImportPreviewModel.js
@@ -1,13 +1,45 @@
+// Pure helpers for the deployments CSV import preview modal.
+// Kept stateless so they can be unit-tested without a DOM.
+
+/**
+ * Columns the import flow may write back to the deployments table.
+ * Kept in sync with the parser-side EDITABLE_KEYS in deploymentsCsv.js.
+ */
 export const EDITABLE_DEPLOYMENT_IMPORT_KEYS = ['locationName', 'latitude', 'longitude']
 
+/**
+ * True if any cell on the row is in the 'warning' state. Under row-level
+ * blocking semantics, a single warning cell disqualifies the entire row
+ * from being applied.
+ *
+ * @param {object} row - preview row from `parseDeploymentsCsv`.
+ * @returns {boolean}
+ */
 export function rowHasWarning(row) {
   return Object.values(row?.columns || {}).some((col) => col?.state === 'warning')
 }
 
+/**
+ * True if the row has at least one editable cell in the 'change' state.
+ * Read-only cells (deploymentID, locationID) are intentionally excluded.
+ *
+ * @param {object} row - preview row from `parseDeploymentsCsv`.
+ * @returns {boolean}
+ */
 export function rowHasEditableChange(row) {
   return EDITABLE_DEPLOYMENT_IMPORT_KEYS.some((key) => row?.columns?.[key]?.state === 'change')
 }
 
+/**
+ * Tailwind class name for the row background. Priority is:
+ *   skipped → muted/dimmed
+ *   warning → red (whole row blocked, even if it also has change cells)
+ *   change  → green (clean update)
+ *   else    → none
+ *
+ * @param {object} row - preview row from `parseDeploymentsCsv`.
+ * @returns {string} space-separated Tailwind classes, or '' if no styling.
+ */
 export function getDeploymentsCsvImportRowClassName(row) {
   if (row?.rowState === 'skipped') {
     return 'bg-muted/40 dark:bg-muted/30 opacity-60'
@@ -17,16 +49,18 @@ export function getDeploymentsCsvImportRowClassName(row) {
   return ''
 }
 
-export function countRowsBlockedByWarnings(preview) {
-  if (!preview) return 0
-  let count = 0
-  for (const row of preview.rows || []) {
-    if (row.rowState !== 'normal') continue
-    if (rowHasWarning(row)) count++
-  }
-  return count
-}
-
+/**
+ * Build the apply plan sent to the main process. Mirrors the parser's
+ * row-level semantics: rows in the 'skipped' state and rows with any
+ * warning cell are excluded entirely. Only editable cells in the
+ * 'change' state contribute fields.
+ *
+ * `plan.length` is guaranteed to equal `preview.applyCount` as produced
+ * by `parseDeploymentsCsv` — keep both in sync if you change one.
+ *
+ * @param {object|null} preview - preview payload from `parseDeploymentsCsv`.
+ * @returns {Array<{deploymentID: string, fields: object}>}
+ */
 export function buildDeploymentsCsvApplyPlan(preview) {
   if (!preview) return []
 

--- a/test/main/services/import/parsers/deploymentsCsv.test.js
+++ b/test/main/services/import/parsers/deploymentsCsv.test.js
@@ -61,7 +61,7 @@ describe('parseDeploymentsCsv — happy path', () => {
       const result = await parseDeploymentsCsv(file, dbRows)
       assert.equal(result.totalRows, 2)
       assert.equal(result.applyCount, 0)
-      assert.equal(result.cellWarningCount, 0)
+      assert.equal(result.rowsBlockedByWarningCount, 0)
       assert.equal(result.rowSkipCount, 0)
       assert.equal(result.rows[0].columns.latitude.state, 'unchanged')
       assert.equal(result.rows[0].columns.locationName.state, 'unchanged')
@@ -95,7 +95,7 @@ describe('parseDeploymentsCsv — per-cell validation', () => {
       const r = await parseDeploymentsCsv(file, dbRows)
       assert.equal(r.rows[0].columns.latitude.state, 'warning')
       assert.match(r.rows[0].columns.latitude.warning, /outside \[-90, 90\]/)
-      assert.equal(r.cellWarningCount, 1)
+      assert.equal(r.rowsBlockedByWarningCount, 1)
       assert.equal(r.applyCount, 0)
     })
   })
@@ -145,6 +145,23 @@ describe('parseDeploymentsCsv — per-cell validation', () => {
       assert.equal(r.rows[0].columns.latitude.state, 'change')
       assert.equal(r.rows[0].columns.latitude.appliedValue, 45.5)
       assert.equal(r.applyCount, 1)
+    })
+  })
+
+  test('row with a warning cell blocks the whole row even when other cells would change', async () => {
+    // locationID mismatch (warning) + valid latitude change in the same row.
+    // Under row-level semantics the whole row is blocked: applyCount stays
+    // at 0, and the row counts toward rowsBlockedByWarningCount.
+    const csv =
+      'deploymentID,locationID,latitude,longitude\n' +
+      'CAM_001,LOC_X,45.5,6.812\n' +
+      'CAM_002,LOC_A,45.241,6.812\n'
+    await withTempCsv(csv, async (file) => {
+      const r = await parseDeploymentsCsv(file, dbRows)
+      assert.equal(r.rows[0].columns.locationID.state, 'warning')
+      assert.equal(r.rows[0].columns.latitude.state, 'change')
+      assert.equal(r.applyCount, 0)
+      assert.equal(r.rowsBlockedByWarningCount, 1)
     })
   })
 })

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -1,0 +1,53 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildDeploymentsCsvApplyPlan } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
+
+describe('buildDeploymentsCsvApplyPlan', () => {
+  test('blocks all editable changes in rows that have any warning cell', () => {
+    const preview = {
+      rows: [
+        {
+          rowState: 'normal',
+          deploymentID: 'CAM_001',
+          columns: {
+            deploymentID: { state: 'readonly' },
+            locationID: { state: 'warning', warning: 'locationID is read-only.' },
+            locationName: {
+              state: 'change',
+              appliedValue: 'Ridge South'
+            },
+            latitude: {
+              state: 'change',
+              appliedValue: 45.5
+            },
+            longitude: { state: 'unchanged' }
+          }
+        },
+        {
+          rowState: 'normal',
+          deploymentID: 'CAM_002',
+          columns: {
+            deploymentID: { state: 'readonly' },
+            locationID: { state: 'readonly' },
+            locationName: { state: 'unchanged' },
+            latitude: {
+              state: 'change',
+              appliedValue: 46.25
+            },
+            longitude: { state: 'unchanged' }
+          }
+        }
+      ]
+    }
+
+    assert.deepEqual(buildDeploymentsCsvApplyPlan(preview), [
+      {
+        deploymentID: 'CAM_002',
+        fields: {
+          latitude: 46.25
+        }
+      }
+    ])
+  })
+})

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 
 import {
   buildDeploymentsCsvApplyPlan,
-  countRowsBlockedByWarnings
+  countRowsBlockedByWarnings,
+  getDeploymentsCsvImportRowClassName
 } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
 
 describe('buildDeploymentsCsvApplyPlan', () => {
@@ -52,6 +53,31 @@ describe('buildDeploymentsCsvApplyPlan', () => {
         }
       }
     ])
+  })
+})
+
+describe('getDeploymentsCsvImportRowClassName', () => {
+  test('uses red highlighting for normal rows blocked by warnings', () => {
+    const className = getDeploymentsCsvImportRowClassName({
+      rowState: 'normal',
+      columns: {
+        locationID: { state: 'warning' },
+        latitude: { state: 'change' }
+      }
+    })
+
+    assert.match(className, /bg-red/)
+  })
+
+  test('keeps green highlighting for clean rows that will update', () => {
+    const className = getDeploymentsCsvImportRowClassName({
+      rowState: 'normal',
+      columns: {
+        latitude: { state: 'change' }
+      }
+    })
+
+    assert.match(className, /bg-green/)
   })
 })
 

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -3,7 +3,6 @@ import assert from 'node:assert/strict'
 
 import {
   buildDeploymentsCsvApplyPlan,
-  countRowsBlockedByWarnings,
   getDeploymentsCsvImportRowClassName
 } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
 
@@ -78,41 +77,5 @@ describe('getDeploymentsCsvImportRowClassName', () => {
     })
 
     assert.match(className, /bg-green/)
-  })
-})
-
-describe('countRowsBlockedByWarnings', () => {
-  test('counts normal rows with warning cells, not warning cells', () => {
-    const preview = {
-      rows: [
-        {
-          rowState: 'normal',
-          columns: {
-            locationID: { state: 'warning' },
-            latitude: { state: 'warning' }
-          }
-        },
-        {
-          rowState: 'normal',
-          columns: {
-            latitude: { state: 'warning' }
-          }
-        },
-        {
-          rowState: 'skipped',
-          columns: {
-            deploymentID: { state: 'readonly' }
-          }
-        },
-        {
-          rowState: 'normal',
-          columns: {
-            latitude: { state: 'change' }
-          }
-        }
-      ]
-    }
-
-    assert.equal(countRowsBlockedByWarnings(preview), 2)
   })
 })

--- a/test/renderer/deployments/importPreviewModel.test.js
+++ b/test/renderer/deployments/importPreviewModel.test.js
@@ -1,7 +1,10 @@
 import { describe, test } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { buildDeploymentsCsvApplyPlan } from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
+import {
+  buildDeploymentsCsvApplyPlan,
+  countRowsBlockedByWarnings
+} from '../../../src/renderer/src/deployments/deploymentsImportPreviewModel.js'
 
 describe('buildDeploymentsCsvApplyPlan', () => {
   test('blocks all editable changes in rows that have any warning cell', () => {
@@ -49,5 +52,41 @@ describe('buildDeploymentsCsvApplyPlan', () => {
         }
       }
     ])
+  })
+})
+
+describe('countRowsBlockedByWarnings', () => {
+  test('counts normal rows with warning cells, not warning cells', () => {
+    const preview = {
+      rows: [
+        {
+          rowState: 'normal',
+          columns: {
+            locationID: { state: 'warning' },
+            latitude: { state: 'warning' }
+          }
+        },
+        {
+          rowState: 'normal',
+          columns: {
+            latitude: { state: 'warning' }
+          }
+        },
+        {
+          rowState: 'skipped',
+          columns: {
+            deploymentID: { state: 'readonly' }
+          }
+        },
+        {
+          rowState: 'normal',
+          columns: {
+            latitude: { state: 'change' }
+          }
+        }
+      ]
+    }
+
+    assert.equal(countRowsBlockedByWarnings(preview), 2)
   })
 })


### PR DESCRIPTION
Stacks on top of #524. Closes the renderer/backend drift introduced when #524 switched the apply gate from cell-level skipping to row-level blocking but only changed the renderer — the parser kept emitting cell-level counts that the modal then ignored and recomputed.

## Summary

- **Parser** (`deploymentsCsv.js`): `applyCount` now counts rows that will *actually* update (normal + no warning cells + at least one change cell). The cell-level `cellWarningCount` is replaced by row-level `rowsBlockedByWarningCount`. Single source of truth for both counts.
- **Renderer** (`DeploymentsImportPreviewModal.jsx` + `deploymentsImportPreviewModel.js`): reads `preview.applyCount` / `preview.rowsBlockedByWarningCount` directly — no more `useMemo` recompute. Drops the now-redundant `countRowsBlockedByWarnings` helper. Drops the `EDITABLE_KEYS` alias variable and the thin `rowBackgroundClass` wrapper.
- **Legend cleanup**: drops the amber "cell warning" swatch — the three remaining swatches (green / red / muted) all map to row backgrounds, matching the row-level model. Cell warnings stay visible via the `⚠` icon + strikethrough.
- **Hygiene**: JSDoc on every export in `deploymentsImportPreviewModel.js`; parser's editable-keys literal extracted into a shared `EDITABLE_KEYS` constant; parser JSDoc explains the row-level contract.
- **Spec doc** (`2026-05-12-deployments-csv-import-export-design.md`): summary, goals, ASCII mockup, row-state table, tooltip list, summary-banner section, and preview-payload schema all updated for row-level blocking. New "Normal, blocked" row in the row-state table.

## Test plan

- [x] `npm test` — all 1270 tests pass, including a new parser test pinning the row-blocking contract (a row with both a `locationID` warning and a valid latitude change → `applyCount=0`, `rowsBlockedByWarningCount=1`).
- [x] `npm run lint` — 0 errors (the 37 warnings are all pre-existing on the #524 branch).
- [x] `npm run format` — clean.
- [x] Open a study, **Import CSV** with a row that has one warning cell + one valid change cell, confirm the row is red-tinted and `Apply (N)` excludes it.
- [x] Confirm the bottom legend no longer has the amber swatch; cell warnings still show the `⚠` icon + strikethrough inside cells.

## Notes

- `preview.cellWarningCount` is removed (not deprecated) since it had no other consumer. If any external script reads the preview payload, this is a breaking field rename — but the preview payload is in-process only (main → renderer via IPC), so the blast radius is contained.
- Targeting `arthur/feat-deployment-import-export` rather than `main` so it merges cleanly together with #519 + #524.