### PR TITLE
chore: bump version to 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Biowatch will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-05-14
+
+### Added
+
+- **Deployments CSV import/export** on the Deployments tab: always-visible header strip with segmented Export / Import actions, visible even when a study has no timestamps (LILA, COCO — the studies that most need this). Export opens a preview modal (read-only table + editable-column hints) then writes a CSV. Import opens a drag-and-drop picker modal → virtualised diff-preview modal (`old → new` cells, row-level highlighting, cell tooltips, clickable summary tiles that filter rows) → single-transaction apply. Edits `latitude`, `longitude`, and `locationName`; `locationName` propagates across `locationID`. Backed by a pure parser/validator + Drizzle transactional applier with 24 unit/integration tests. (#519)
+
+### Changed
+
+- CSV import gating switched from cell-level skipping to row-level blocking: any row with a warning is excluded from apply. Preview counts, row highlighting, legend, and `Apply (N)` button reflect the row-level model; parser exposes `applyCount` + `rowsBlockedByWarningCount` as the single source of truth. (#524, #532)
+- Study-page tabs: tighter vertical padding; map-only top padding on the Deployments tab
+- Deployments actions strip aligned with the timeline header (padding, right edge to the sparkline toggle)
+
+### Fixed
+
+- Study layout `gap-4` restored after deployments-specific offsets had been over-reverted
+
 ## [1.9.0] - 2026-05-13
 
 ### Added
@@ -625,6 +641,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Activity heatmaps
 - Overview statistics
 
+[1.9.1]: https://github.com/earthtoolsmaker/biowatch/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/earthtoolsmaker/biowatch/compare/v1.8.7...v1.9.0
 [1.8.7]: https://github.com/earthtoolsmaker/biowatch/compare/v1.8.6...v1.8.7
 [1.8.6]: https://github.com/earthtoolsmaker/biowatch/compare/v1.8.5...v1.8.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "biowatch",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "biowatch",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biowatch",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Analyse and visualise camera trap datasets",
   "main": "./out/main/index.js",
   "author": "earthtoolsmaker.org",


### PR DESCRIPTION
## Summary

Release PR for **v1.9.1**. See `CHANGELOG.md` for the full notes — single theme:

- **Deployments CSV import/export** on the Deployments tab (#519): always-visible Export / Import strip (visible even when a study has no timestamps), drag-and-drop import picker, virtualised diff-preview modal with `old → new` cells and clickable summary tiles, single-transaction apply. Edits `latitude`, `longitude`, `locationName`.
- **Row-level blocking** for CSV import (#524, #532): rows with any warning are excluded from apply; parser now exposes `applyCount` + `rowsBlockedByWarningCount` as the single source of truth for the preview UI.
- Small layout fixes: study-page tab padding tightened, map-only top padding on Deployments, CSV strip aligned to the timeline header right edge, and the `gap-4` study layout regression restored.

## Test plan

- [x] CI passes on all three runners (windows-latest, macos-latest, ubuntu-22.04)
- [x] After merge: tag `v1.9.1` from `main` and push to trigger the Build/Release workflow
- [ ] Verify GitHub Release artifacts are produced (`Biowatch-setup.exe`, `Biowatch.dmg`, `Biowatch.AppImage`, `Biowatch_1.9.1_amd64.deb`)
- [ ] Fill in the GitHub Release notes (empty by default) using the v1.9.0 release as a template