### PR TITLE
feat(import): show 'Starting import…' modal with live progress

### DIFF
--- a/docs/plans/2026-05-15-add-source-starting-state-plan.md
+++ b/docs/plans/2026-05-15-add-source-starting-state-plan.md
@@ -1,0 +1,480 @@
+# Add-source modal: "Starting import…" transitional state — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Add Source modal open in a transitional "Starting import…" view from the moment Import is clicked until the first job completes (or the user dismisses), replacing the current insta-close behaviour.
+
+**Architecture:** All changes are confined to `src/renderer/src/AddSourceModal.jsx`. The modal subscribes to the existing `useImportStatus(studyId)` hook so it can watch `importStatus.done` and auto-close on `done > 0`. A new `waitingForFirstBatch` state drives a swapped body + footer. A 15-second failsafe timer guarantees the modal never traps the user.
+
+**Tech Stack:** React (Electron renderer), Radix-style Tailwind classes already in the file, `lucide-react` icons, `@tanstack/react-query` (already wired via the hook).
+
+**Reference spec:** [`docs/specs/2026-05-15-add-source-starting-state-design.md`](../specs/2026-05-15-add-source-starting-state-design.md).
+
+**Testing approach:** This project doesn't have React component tests for the renderer (see `test/`, which covers backend/shared modules). Each task pairs a lint pass with concrete manual verification steps via `npm run dev`. Don't skip the manual checks — they are the test plan.
+
+---
+
+## Files
+
+- **Modify:** `src/renderer/src/AddSourceModal.jsx` (all changes live here)
+
+The file is ~350 lines and already does a few things (form, validation, browse, submit). The new transitional state adds a body branch and a small piece of state — it does not justify splitting the file.
+
+---
+
+## Task 1: Add state + hook subscription scaffolding (no behaviour change yet)
+
+**Files:**
+- Modify: `src/renderer/src/AddSourceModal.jsx`
+
+- [ ] **Step 1: Add imports**
+
+Add the import status hook and the spinner icon. Replace the existing icon-import line and add the hook import after the existing `useNavigate`/`useQueryClient` imports.
+
+In `src/renderer/src/AddSourceModal.jsx`, change:
+
+```jsx
+import { Lock, FolderOpen, X } from 'lucide-react'
+```
+
+to:
+
+```jsx
+import { Lock, FolderOpen, X, Loader2 } from 'lucide-react'
+```
+
+And add this import below the existing `@tanstack/react-query` import:
+
+```jsx
+import { useImportStatus } from './hooks/import'
+```
+
+- [ ] **Step 2: Add `waitingForFirstBatch` state**
+
+Add a new piece of state next to the existing `submitting` declaration (`AddSourceModal.jsx:29`):
+
+```jsx
+const [submitting, setSubmitting] = useState(false)
+const [waitingForFirstBatch, setWaitingForFirstBatch] = useState(false)
+```
+
+- [ ] **Step 3: Subscribe to the import status hook**
+
+Add the subscription right after `useQueryClient()` (around `AddSourceModal.jsx:23`):
+
+```jsx
+const { importStatus } = useImportStatus(studyId)
+```
+
+This is safe to call unconditionally — the hook is gated on `!!id` inside (see `src/renderer/src/hooks/import.js:55`), so it's a no-op when `studyId` is falsy, and it only polls while `isRunning`.
+
+- [ ] **Step 4: Reset `waitingForFirstBatch` when the modal closes**
+
+Extend the existing reset effect (`AddSourceModal.jsx:82-88`) to clear the new flag:
+
+```jsx
+useEffect(() => {
+  if (!isOpen) {
+    setFolder('')
+    setError(null)
+    setSubmitting(false)
+    setWaitingForFirstBatch(false)
+  }
+}, [isOpen])
+```
+
+- [ ] **Step 5: Allow ESC during the transitional state**
+
+The existing ESC handler (`AddSourceModal.jsx:91-98`) only blocks ESC while `submitting`. The transitional state is safely dismissable (the import keeps running), so no change is needed — but read the handler to confirm; it already does the right thing because `submitting` is `false` during `waitingForFirstBatch`.
+
+No code change in this step; just verify by reading.
+
+- [ ] **Step 6: Lint**
+
+Run: `npx eslint src/renderer/src/AddSourceModal.jsx`
+Expected: clean (no errors).
+
+- [ ] **Step 7: Manual verification — no regression**
+
+Run: `npm run dev`
+- Open a study with a model and click "+ Add images directory".
+- Confirm the form renders as before (model, country if applicable, folder picker).
+- Confirm Browse → pick a folder → Cancel works.
+- Confirm Import still closes the modal on success (we haven't changed that behaviour yet).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/renderer/src/AddSourceModal.jsx
+git commit -m "refactor(add-source): scaffold waitingForFirstBatch state and import-status subscription"
+```
+
+---
+
+## Task 2: Keep the modal open after Import — auto-close on first completion
+
+**Files:**
+- Modify: `src/renderer/src/AddSourceModal.jsx`
+
+- [ ] **Step 1: Stop closing the modal in `handleImport`**
+
+Replace the success branch in `handleImport` (`AddSourceModal.jsx:134-145`). The cache update + invalidate stay; remove `onImported?.()` and `onClose()` here, and flip `waitingForFirstBatch` on. Also keep `submitting=true` until we enter the waiting state, then drop it so the new footer renders normally.
+
+Old (`AddSourceModal.jsx:134-145`):
+
+```jsx
+if (res?.success) {
+  // Kick the import-status query so the global progress bar picks up the
+  // new run on its next refetch. Setting isRunning=true here also
+  // re-arms the polling interval (hooks/import.js refetches only while
+  // isRunning is truthy).
+  queryClient.setQueryData(['importStatus', studyId], (prev) => ({
+    ...(prev || { total: 0, done: 0 }),
+    isRunning: true
+  }))
+  queryClient.invalidateQueries({ queryKey: ['importStatus', studyId] })
+  onImported?.()
+  onClose()
+} else {
+```
+
+New:
+
+```jsx
+if (res?.success) {
+  // Kick the import-status query so the global progress bar picks up the
+  // new run on its next refetch. Setting isRunning=true here also
+  // re-arms the polling interval (hooks/import.js refetches only while
+  // isRunning is truthy).
+  queryClient.setQueryData(['importStatus', studyId], (prev) => ({
+    ...(prev || { total: 0, done: 0 }),
+    isRunning: true
+  }))
+  queryClient.invalidateQueries({ queryKey: ['importStatus', studyId] })
+  setWaitingForFirstBatch(true)
+  setSubmitting(false)
+} else {
+```
+
+- [ ] **Step 2: Auto-close when the first job completes**
+
+Add a new effect below the ESC handler (after `AddSourceModal.jsx:98`):
+
+```jsx
+// Auto-close once the first job completes — gives the user concrete
+// evidence the import is making progress before dismissing the modal.
+useEffect(() => {
+  if (!waitingForFirstBatch) return
+  if ((importStatus?.done ?? 0) > 0) {
+    onImported?.()
+    onClose()
+  }
+}, [waitingForFirstBatch, importStatus?.done, onImported, onClose])
+```
+
+- [ ] **Step 3: Lint**
+
+Run: `npx eslint src/renderer/src/AddSourceModal.jsx`
+Expected: clean.
+
+- [ ] **Step 4: Manual verification — modal stays open until first result**
+
+Run: `npm run dev`
+- Open the modal, pick a small folder (~10–20 images), click Import.
+- Expect: modal does **not** close immediately. It stays open while jobs queue up.
+- Expect: within a few seconds (after the first job completes), the modal auto-closes.
+- Expect: the header progress bar appears and continues filling normally.
+- Optional but valuable: pick a larger folder (200+ images), verify modal still auto-closes when the first job lands (not when all do).
+
+Note: at this point the modal body still shows the *form*, not the transitional view. That's the next task. We're verifying the timing first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/AddSourceModal.jsx
+git commit -m "feat(add-source): keep modal open until first import job completes"
+```
+
+---
+
+## Task 3: Render the transitional view (body, header text, footer)
+
+**Files:**
+- Modify: `src/renderer/src/AddSourceModal.jsx`
+
+- [ ] **Step 1: Swap the modal header text in the transitional state**
+
+Replace the header `<h3>` (`AddSourceModal.jsx:168`):
+
+Old:
+
+```jsx
+<h3 className="text-base font-medium text-foreground">Add images directory</h3>
+```
+
+New:
+
+```jsx
+<h3 className="text-base font-medium text-foreground">
+  {waitingForFirstBatch ? 'Starting import…' : 'Add images directory'}
+</h3>
+```
+
+- [ ] **Step 2: Replace the form body with the transitional view when waiting**
+
+Wrap the existing body block (`AddSourceModal.jsx:178-335` — the `<div className="px-5 py-4 space-y-4">` containing all form fields) so it only renders when `!waitingForFirstBatch`. Insert the transitional view as the alternative branch.
+
+The cleanest edit is to wrap the existing body in a ternary at the parent. Locate this line (`AddSourceModal.jsx:178`):
+
+```jsx
+        <div className="px-5 py-4 space-y-4">
+```
+
+…and the matching closing `</div>` that ends the form body (just before `<footer …>` at `AddSourceModal.jsx:337`).
+
+Replace the entire body block with this structure:
+
+```jsx
+        {waitingForFirstBatch ? (
+          <div className="px-5 py-6 space-y-4">
+            <div className="flex items-start gap-3">
+              <Loader2
+                size={20}
+                className="animate-spin text-blue-600 dark:text-blue-400 mt-0.5 shrink-0"
+              />
+              <div className="min-w-0">
+                <p className="text-sm text-foreground font-medium">
+                  Queueing images for analysis
+                </p>
+                <p
+                  className="text-xs font-mono text-muted-foreground truncate mt-0.5"
+                  style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
+                  title={folder || ''}
+                >
+                  {folder ? `‎${folder}` : ''}
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3">
+              <p className="text-xs font-medium text-foreground mb-2">What happens next</p>
+              <ul className="text-xs text-muted-foreground space-y-1.5 leading-relaxed">
+                <li>
+                  A progress bar appears in the top-right header — pause or resume from there.
+                </li>
+                <li>
+                  Images appear in the Media tab as they get classified. No need to refresh.
+                </li>
+                <li>You can keep using the app while this runs in the background.</li>
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <div className="px-5 py-4 space-y-4">
+            {/* …existing form body, unchanged… */}
+          </div>
+        )}
+```
+
+When pasting, keep the *entire existing form body content* (the no-models CTA, Model section, Country section, Folder section, error block) verbatim inside the `else` branch's `<div>`. Do not edit any field markup.
+
+- [ ] **Step 3: Swap the footer buttons in the transitional state**
+
+Replace the footer block (`AddSourceModal.jsx:337-344`):
+
+Old:
+
+```jsx
+<footer className="flex justify-end gap-2 px-5 py-3 border-t border-gray-200 dark:border-border bg-gray-50 dark:bg-muted">
+  <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
+    Cancel
+  </Button>
+  <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
+    {submitting ? 'Starting…' : 'Import'}
+  </Button>
+</footer>
+```
+
+New:
+
+```jsx
+<footer className="flex justify-end gap-2 px-5 py-3 border-t border-gray-200 dark:border-border bg-gray-50 dark:bg-muted">
+  {waitingForFirstBatch ? (
+    <Button size="sm" onClick={onClose}>
+      Continue in background
+    </Button>
+  ) : (
+    <>
+      <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
+        Cancel
+      </Button>
+      <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
+        {submitting ? 'Starting…' : 'Import'}
+      </Button>
+    </>
+  )}
+</footer>
+```
+
+- [ ] **Step 4: Lint and format**
+
+Run: `npx eslint --fix src/renderer/src/AddSourceModal.jsx && npx eslint src/renderer/src/AddSourceModal.jsx`
+Expected: clean (no errors, no warnings).
+
+- [ ] **Step 5: Manual verification — full visual pass**
+
+Run: `npm run dev`
+- Open the modal, pick a folder, click Import.
+- Expect: header text flips to "Starting import…".
+- Expect: form is gone; you see a spinning blue Loader2, "Queueing images for analysis", and the folder path (truncated with the same tail-visible behaviour as the picker).
+- Expect: a "What happens next" panel with three bullet points.
+- Expect: footer shows a single "Continue in background" button.
+- Click "Continue in background" → modal closes immediately. Header progress bar continues — the import is still running.
+- Repeat in dark mode (toggle theme).
+- Repeat: this time don't click "Continue in background"; wait. Once the first image finishes processing, the modal closes itself.
+
+- [ ] **Step 6: Manual verification — error path still works**
+
+Run: `npm run dev`
+- Force `addFolder` to fail. Easiest path: pick a folder you don't have read permission for, or temporarily edit `src/main/index.js`'s `addFolder` handler to `throw new Error('forced')` and revert after.
+- Expect: modal stays on the form view with the red error block. The transitional view never appears.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/src/AddSourceModal.jsx
+git commit -m "feat(add-source): show transitional starting view with progress copy"
+```
+
+---
+
+## Task 4: 15-second failsafe auto-close
+
+**Files:**
+- Modify: `src/renderer/src/AddSourceModal.jsx`
+
+- [ ] **Step 1: Add the failsafe timer effect**
+
+Add this effect immediately below the auto-close-on-done effect from Task 2:
+
+```jsx
+// Failsafe: if no job completes within 15s, dismiss the modal anyway.
+// The import is genuinely running by this point (addFolder resolved),
+// so trapping the user behind the spinner would be worse than closing.
+useEffect(() => {
+  if (!waitingForFirstBatch) return
+  const id = setTimeout(() => {
+    onImported?.()
+    onClose()
+  }, 15000)
+  return () => clearTimeout(id)
+}, [waitingForFirstBatch, onImported, onClose])
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `npx eslint src/renderer/src/AddSourceModal.jsx`
+Expected: clean.
+
+- [ ] **Step 3: Manual verification — failsafe fires**
+
+Temporarily change the `15000` to `1500` (1.5 seconds) so you can confirm the effect without waiting a long time.
+
+Run: `npm run dev`
+- Pick a folder, click Import.
+- Expect: even if the first job hasn't completed yet, the modal auto-dismisses after ~1.5s.
+
+Revert the timeout to `15000` after verifying.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/src/AddSourceModal.jsx
+git commit -m "feat(add-source): add 15s failsafe to avoid trapping user on slow first batch"
+```
+
+---
+
+## Task 5: Final pass — format, full lint, and end-to-end manual run
+
+**Files:**
+- Modify: (none — verification only)
+
+- [ ] **Step 1: Prettier**
+
+Run: `npm run format -- src/renderer/src/AddSourceModal.jsx`
+Expected: file is already formatted (no diff), or a clean reformat.
+
+- [ ] **Step 2: Project lint**
+
+Run: `npm run lint -- src/renderer/src/AddSourceModal.jsx`
+Expected: clean.
+
+- [ ] **Step 3: End-to-end manual check**
+
+Run: `npm run dev` and walk through these scenarios in order:
+
+1. **Happy path, small folder**: Pick a folder with 5–10 images → click Import → see the transitional view → modal auto-closes within a few seconds when the first job completes → header progress bar runs to 100%.
+2. **Happy path, large folder**: Pick 200+ images → same expectation; the modal closes after first job completes (not after all). Verify the header progress bar is doing its thing afterward.
+3. **Dismiss during transition**: Pick a folder → click Import → click "Continue in background" before first job lands → modal closes; header progress bar still appears and progresses.
+4. **ESC during transition**: Same as #3 but press ESC instead of clicking the button. Modal should close.
+5. **Backdrop click during transition**: Same as #3 but click outside the modal. Modal should close.
+6. **`addFolder` error path**: Force an error → form stays visible with the red error block; the transitional view never renders.
+7. **Dark mode pass**: Repeat #1 in dark mode. Spinner is blue, copy is readable, panel border/background looks right.
+
+- [ ] **Step 4: Commit if anything changed**
+
+If steps 1–2 produced any formatting changes:
+
+```bash
+git add src/renderer/src/AddSourceModal.jsx
+git commit -m "style(add-source): prettier pass"
+```
+
+Otherwise skip.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+GH_TOKEN="" gh pr create --title "feat(add-source): keep modal open with starting-state view until first job lands" --body "$(cat <<'EOF'
+## Summary
+
+Address customer feedback that the moment after clicking Import is unclear — the upper-right "Starting" button is too subtle to be noticed when looking at the page body.
+
+Instead of closing the modal immediately, keep it open in a transitional "Starting import…" view until the first job actually completes. Concrete copy tells the user where to look for ongoing progress (top-right) and results (Media tab), so by the time the modal closes the user already knows what to expect.
+
+- Modal stays open after Import is clicked; switches header to "Starting import…" and body to a spinner + folder + "What happens next" panel.
+- Auto-closes when \`importStatus.done > 0\` (first job done) or when the user clicks **Continue in background**.
+- 15s failsafe so an unexpectedly-slow first batch can't trap the user.
+- Dismiss-only semantics: ✕, ESC, backdrop click, and **Continue in background** all just close the modal; the import keeps running. To stop it, pause from the header (existing UX).
+- All changes confined to \`src/renderer/src/AddSourceModal.jsx\`.
+
+Spec: [docs/specs/2026-05-15-add-source-starting-state-design.md](docs/specs/2026-05-15-add-source-starting-state-design.md)
+
+## Test plan
+
+- [ ] Small folder happy path → modal auto-closes after first job completes
+- [ ] Large folder happy path → same; header progress bar continues
+- [ ] Continue in background → modal closes, import keeps running
+- [ ] ESC during transitional state → closes; import keeps running
+- [ ] Backdrop click during transitional state → closes; import keeps running
+- [ ] \`addFolder\` error path → form stays visible with error block; no transitional view
+- [ ] Dark mode visual pass
+EOF
+)"
+```
+
+---
+
+## Self-Review (run after writing the plan)
+
+- **Spec coverage:** All 7 behaviour-table rows from the spec map to tasks: rows 1–3 (existing/error path) are unchanged; row 2's transition is Task 2 + Task 3; row 4 auto-close on `done>0` is Task 2; row 5 "Continue in background" is Task 3; row 6 ✕/backdrop is unchanged (already calls `onClose`); row 7 failsafe is Task 4. The "What happens next" copy is in Task 3 Step 2.
+- **Placeholders:** None. Every code block is complete.
+- **Type consistency:** `waitingForFirstBatch` (boolean), `setWaitingForFirstBatch`, and `importStatus.done` are used consistently across Tasks 1–4. The hook returns `{ importStatus, resumeImport, pauseImport }` (see `src/renderer/src/hooks/import.js:75-79`), matching the destructure in Task 1 Step 3.
+- **Scope:** All changes in one file; no spec section left without a task.

--- a/docs/plans/2026-05-15-add-source-starting-state-plan.md
+++ b/docs/plans/2026-05-15-add-source-starting-state-plan.md
@@ -29,9 +29,21 @@ The file is ~350 lines and already does a few things (form, validation, browse, 
 
 - [ ] **Step 1: Add imports**
 
-Add the import status hook and the spinner icon. Replace the existing icon-import line and add the hook import after the existing `useNavigate`/`useQueryClient` imports.
+Add `useRef` to the React import, the spinner icon, and the import status hook.
 
-In `src/renderer/src/AddSourceModal.jsx`, change:
+In `src/renderer/src/AddSourceModal.jsx`, change the first import:
+
+```jsx
+import { useEffect, useMemo, useState } from 'react'
+```
+
+to:
+
+```jsx
+import { useEffect, useMemo, useRef, useState } from 'react'
+```
+
+Change the lucide import:
 
 ```jsx
 import { Lock, FolderOpen, X } from 'lucide-react'
@@ -49,14 +61,17 @@ And add this import below the existing `@tanstack/react-query` import:
 import { useImportStatus } from './hooks/import'
 ```
 
-- [ ] **Step 2: Add `waitingForFirstBatch` state**
+- [ ] **Step 2: Add `waitingForFirstBatch` state and the done-snapshot ref**
 
-Add a new piece of state next to the existing `submitting` declaration (`AddSourceModal.jsx:29`):
+Add a new piece of state next to the existing `submitting` declaration (`AddSourceModal.jsx:29`), and a ref to snapshot `importStatus.done` at the moment we enter the transitional state:
 
 ```jsx
 const [submitting, setSubmitting] = useState(false)
 const [waitingForFirstBatch, setWaitingForFirstBatch] = useState(false)
+const doneAtStartRef = useRef(0)
 ```
+
+**Why the ref?** `importStatus.done` is study-wide. A study that already has completed imports (e.g. a previously-paused run, or a prior session) has `done > 0` the instant we flip `waitingForFirstBatch=true`. Without the snapshot, the auto-close in Task 2 would fire immediately. The ref captures the baseline so we can wait for a *new* completion.
 
 - [ ] **Step 3: Subscribe to the import status hook**
 
@@ -151,21 +166,25 @@ if (res?.success) {
     isRunning: true
   }))
   queryClient.invalidateQueries({ queryKey: ['importStatus', studyId] })
+  doneAtStartRef.current = importStatus?.done ?? 0
   setWaitingForFirstBatch(true)
   setSubmitting(false)
 } else {
 ```
 
-- [ ] **Step 2: Auto-close when the first job completes**
+- [ ] **Step 2: Auto-close when the first new job completes**
 
-Add a new effect below the ESC handler (after `AddSourceModal.jsx:98`):
+Add a new effect below the ESC handler (after `AddSourceModal.jsx:98`). Compare against the snapshotted `done` so we close on the first *new* completion, not on any pre-existing progress for this study:
 
 ```jsx
-// Auto-close once the first job completes — gives the user concrete
+// Auto-close once a new job completes — gives the user concrete
 // evidence the import is making progress before dismissing the modal.
+// Compares against the snapshot taken when we entered the transitional
+// state, because importStatus.done is study-wide and may already be
+// non-zero from prior runs.
 useEffect(() => {
   if (!waitingForFirstBatch) return
-  if ((importStatus?.done ?? 0) > 0) {
+  if ((importStatus?.done ?? 0) > doneAtStartRef.current) {
     onImported?.()
     onClose()
   }

--- a/docs/specs/2026-05-15-add-source-starting-state-design.md
+++ b/docs/specs/2026-05-15-add-source-starting-state-design.md
@@ -1,0 +1,164 @@
+# Add-source modal: "Starting import…" transitional state
+
+**Date:** 2026-05-15
+**Status:** Design — approved
+**Area:** renderer (`src/renderer/src/AddSourceModal.jsx`; reads from `src/renderer/src/hooks/import.js`)
+
+## Summary
+
+After the user clicks **Import** in the Add Source modal, keep the modal
+open in a transitional "Starting import…" view instead of closing
+immediately. The view shows a spinner, the folder path being processed,
+and a short panel explaining where progress and results will appear.
+The modal auto-closes when the first job actually completes
+(`importStatus.done > 0`), or when the user clicks
+**Continue in background**.
+
+## Motivation
+
+A customer reported that the moment after clicking Import is confusing:
+
+> Right after I selected a folder, it was a little unclear what was
+> happening, or whether it was stuck, or had properly loaded my images,
+> because the "starting" button in the upper-right is subtle. Once I
+> saw results pop up it was more obvious that it wasn't stuck. Consider
+> a more salient message at this stage.
+
+There are two distinct gaps in the current flow:
+
+1. **No UI feedback for ~1 second** between modal close and the first
+   `getImportStatus` poll that returns `total > 0`. The header row only
+   renders when `total > 0 && total > done`
+   (`src/renderer/src/study.jsx:79-83`), so it is hidden during the
+   first poll cycle.
+2. **The header "Starting" state is intentionally compact** — a 28×28
+   icon button in the page chrome
+   (`src/renderer/src/study.jsx:114-138`). Users who are looking at the
+   page body don't notice it.
+
+This spec addresses (1) directly and converts (2) from a problem into
+non-issue: by the time the modal closes, the user has been told
+exactly where to look.
+
+## Design
+
+### Behavior
+
+| Step | Trigger | Modal state |
+|------|---------|-------------|
+| 1 | User clicks **Import** | `submitting=true` (existing) — Import button text becomes "Starting…" (existing) |
+| 2 | `addFolder` resolves successfully | Enter `waitingForFirstBatch`. Body swaps to the transitional view below. Cache update + invalidate run as today. |
+| 3 | `addFolder` rejects | Stay on the form, show `error` (existing behaviour, unchanged) |
+| 4 | `importStatus.done > 0` (polled via `useImportStatus`) | Call `onClose()` |
+| 5 | User clicks **Continue in background** | Call `onClose()` immediately; import keeps running |
+| 6 | User clicks `✕` or backdrop | Same as step 5 — dismiss only |
+| 7 | 15s have elapsed in `waitingForFirstBatch` | Call `onClose()` (failsafe — backend is slow but the import is genuinely running) |
+
+There is **no in-modal cancel** in the transitional state. To stop a
+running import, the user pauses from the header (existing UX). This
+keeps the modal scope tight and avoids needing a new backend cancel
+hook.
+
+### Transitional view
+
+```
+┌──────────────────────────────────────────────────┐
+│ Starting import…                              ✕  │
+├──────────────────────────────────────────────────┤
+│                                                  │
+│             ⟳   Queueing images for analysis     │
+│                 ./trail-cam-2025-spring          │
+│                                                  │
+│  ┌────────────────────────────────────────────┐  │
+│  │ What happens next                          │  │
+│  │                                            │  │
+│  │ • A progress bar appears in the top-right  │  │
+│  │   header — pause/resume from there.        │  │
+│  │ • Images appear in the Media tab as they   │  │
+│  │   get classified. No need to refresh.      │  │
+│  │ • You can keep using the app while this    │  │
+│  │   runs in the background.                  │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+├──────────────────────────────────────────────────┤
+│                       [ Continue in background ] │
+└──────────────────────────────────────────────────┘
+```
+
+- Modal width stays at the existing `w-[480px] max-w-[92vw]`.
+- Header text changes from "Add images directory" to "Starting import…".
+- Spinner is a `Loader2` from `lucide-react` with `animate-spin` (same
+  icon already used for the header "Starting" state for consistency).
+- Folder path is the value the user picked; truncate with the same
+  RTL-direction trick used in the current folder display
+  (`AddSourceModal.jsx:307-310`) so the tail of long paths is visible.
+- The "What happens next" panel uses the muted card styling already
+  used elsewhere in the modal (e.g. the disabled folder display) so it
+  reads as informational, not interactive.
+- Footer has a single primary-style button: **Continue in background**.
+  The Cancel button is hidden during this state.
+
+### Component changes
+
+`AddSourceModal.jsx`:
+
+- Add a new piece of state: `waitingForFirstBatch: boolean`. Distinct
+  from `submitting`, which still covers only the `addFolder` round-trip.
+- In `handleImport`, after `res?.success` and before the existing
+  `onImported?.(); onClose()`:
+  - Drop `onClose()` from this branch.
+  - Set `waitingForFirstBatch = true`.
+  - Keep `setSubmitting(false)` so the footer reflects the new state.
+- New `useEffect` watching `importStatus.done` from
+  `useImportStatus(studyId)`: when `waitingForFirstBatch && done > 0`,
+  call `onImported?.(); onClose()`.
+- Second `useEffect` for the 15s failsafe timer, started when
+  `waitingForFirstBatch` flips to true; cleared on unmount/close.
+- Existing reset effect (`AddSourceModal.jsx:82-88`) clears
+  `waitingForFirstBatch` on close.
+- ESC handler (`AddSourceModal.jsx:91-98`) already gates on
+  `!submitting`; extend the gate to also allow ESC during
+  `waitingForFirstBatch` (dismissing in this state is safe).
+
+### Data the modal needs while open
+
+Currently the modal doesn't subscribe to `useImportStatus`. It will
+need to during `waitingForFirstBatch` so the auto-close trigger works.
+Two acceptable shapes:
+
+- **A. Always subscribe** (simplest): call `useImportStatus(studyId)`
+  unconditionally. The hook is keyed on `studyId` and only polls while
+  `isRunning`, so the cost when idle is one cache read.
+- **B. Subscribe only after** `waitingForFirstBatch=true`: requires
+  conditional hook usage (against React rules) or a wrapper sub-component.
+
+**Choice: A.** It's simpler and the existing poll cadence (1s) is
+exactly what we want anyway.
+
+## Out of scope
+
+- Header status-row changes. The recently-shipped icon-only button
+  with behaviour tooltip stays as-is.
+- Backend cancel API. There is no "Cancel import" affordance in this
+  new state.
+- Toast/banner alternatives outside the modal.
+- Animations/transitions between the form view and the transitional
+  view beyond the existing fade-in.
+
+## Open questions
+
+None remaining. The dismiss-only semantics for `✕` / backdrop / the
+footer button were explicitly chosen during brainstorming.
+
+## Risks
+
+- **`addFolder` returns before jobs are visible to the queue**: if the
+  backend resolves before `total` is queryable, the modal could sit on
+  `done=0` for longer than expected. The 15s failsafe covers this; if
+  it fires often we'll need to revisit the auto-close trigger.
+- **First job slow to complete**: `done > 0` waits for the first ML
+  inference to finish, which can take several seconds for the first
+  batch (model warmup). Acceptable — the spinner + copy explains that
+  work is in progress. If the wait is consistently too long, we can
+  switch the trigger to `total > 0` (jobs queued, not yet processed)
+  in a follow-up.

--- a/src/renderer/src/AddSourceModal.jsx
+++ b/src/renderer/src/AddSourceModal.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { Lock, FolderOpen, X } from 'lucide-react'
+import { Lock, FolderOpen, X, Loader2 } from 'lucide-react'
+import { useImportStatus } from './hooks/import'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
 import { Button } from './ui/button.jsx'
 import { modelZoo } from '../../shared/mlmodels.js'
@@ -21,12 +22,15 @@ import { countries } from '../../shared/countries.js'
 export default function AddSourceModal({ isOpen, studyId, onClose, onImported }) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const { importStatus } = useImportStatus(studyId)
   const [latestModel, setLatestModel] = useState(null) // {id, version} | null
   const [latestCountry, setLatestCountry] = useState(null) // string | null
   const [pickedModelKey, setPickedModelKey] = useState('') // 'speciesnet-4.0.1a'
   const [pickedCountry, setPickedCountry] = useState('')
   const [folder, setFolder] = useState('')
   const [submitting, setSubmitting] = useState(false)
+  const [waitingForFirstBatch, setWaitingForFirstBatch] = useState(false)
+  const doneAtStartRef = useRef(0)
   const [error, setError] = useState(null)
   const [installedModels, setInstalledModels] = useState([])
   const [installedEnvironments, setInstalledEnvironments] = useState([])
@@ -84,6 +88,7 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
       setFolder('')
       setError(null)
       setSubmitting(false)
+      setWaitingForFirstBatch(false)
     }
   }, [isOpen])
 
@@ -96,6 +101,29 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [isOpen, submitting, onClose])
+
+  // Auto-close once a new job completes. importStatus.done is study-wide
+  // and may already be non-zero from prior runs, so we compare against
+  // the snapshot captured when we entered the transitional state.
+  useEffect(() => {
+    if (!waitingForFirstBatch) return
+    if ((importStatus?.done ?? 0) > doneAtStartRef.current) {
+      onImported?.()
+      onClose()
+    }
+  }, [waitingForFirstBatch, importStatus?.done, onImported, onClose])
+
+  // Failsafe: if no job completes within 15s, dismiss the modal anyway.
+  // The import is genuinely running by this point (addFolder resolved),
+  // so trapping the user behind the spinner would be worse than closing.
+  useEffect(() => {
+    if (!waitingForFirstBatch) return
+    const id = setTimeout(() => {
+      onImported?.()
+      onClose()
+    }, 15000)
+    return () => clearTimeout(id)
+  }, [waitingForFirstBatch, onImported, onClose])
 
   const modelLocked = !!latestModel
   const pickedModel = useMemo(() => {
@@ -141,8 +169,9 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
           isRunning: true
         }))
         queryClient.invalidateQueries({ queryKey: ['importStatus', studyId] })
-        onImported?.()
-        onClose()
+        doneAtStartRef.current = importStatus?.done ?? 0
+        setWaitingForFirstBatch(true)
+        setSubmitting(false)
       } else {
         setError(res?.error || res?.message || 'Import failed')
         setSubmitting(false)
@@ -165,7 +194,9 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-5 py-4 border-b border-border">
-          <h3 className="text-base font-medium text-foreground">Add images directory</h3>
+          <h3 className="text-base font-medium text-foreground">
+            {waitingForFirstBatch ? 'Starting import…' : 'Add images directory'}
+          </h3>
           <button
             onClick={onClose}
             disabled={submitting}
@@ -175,84 +206,44 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
           </button>
         </header>
 
-        <div className="px-5 py-4 space-y-4">
-          {/* No-models-installed CTA: dead-end for users with a fresh install */}
-          {!modelLocked && !hasAnyInstalledModel && (
-            <div className="border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 rounded-md p-3 text-sm text-amber-900 dark:text-amber-200">
-              <p className="font-medium mb-1">No models installed</p>
-              <p className="text-amber-800 dark:text-amber-300 mb-2 text-xs">
-                Install at least one model before adding images for analysis.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  onClose()
-                  navigate('/settings/ml_zoo')
-                }}
-              >
-                Open Models settings
-              </Button>
-            </div>
-          )}
-
-          {/* Model */}
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Model</label>
-            {modelLocked ? (
-              <div className="flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-sm text-gray-700 dark:text-foreground">
-                <Lock size={12} className="text-muted-foreground" />
-                <span>
-                  {pickedModel
-                    ? `${pickedModel.name} v${pickedModel.reference.version}`
-                    : `${latestModel.id} v${latestModel.version}`}
-                </span>
+        {waitingForFirstBatch ? (
+          <div className="px-5 py-6 space-y-4">
+            <div className="flex items-start gap-3">
+              <Loader2
+                size={20}
+                className="animate-spin text-blue-600 dark:text-blue-400 mt-0.5 shrink-0"
+              />
+              <div className="min-w-0">
+                <p className="text-sm text-foreground font-medium">Queueing images for analysis</p>
+                <p
+                  className="text-xs font-mono text-muted-foreground truncate mt-0.5"
+                  style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
+                  title={folder || ''}
+                >
+                  {folder ? `‎${folder}` : ''}
+                </p>
               </div>
-            ) : (
-              <Select
-                value={pickedModelKey}
-                onValueChange={(value) => {
-                  const [id, ...rest] = value.split('-')
-                  const version = rest.join('-')
-                  const model = modelZoo.find(
-                    (m) => m.reference.id === id && m.reference.version === version
-                  )
-                  if (model && isModelCompletelyInstalled(model)) {
-                    setPickedModelKey(value)
-                  }
-                }}
-              >
-                <SelectTrigger className="w-full bg-card border-border">
-                  <SelectValue placeholder="Select a model" />
-                </SelectTrigger>
-                <SelectContent>
-                  {modelZoo.map((m) => {
-                    const installed = isModelCompletelyInstalled(m)
-                    const modelOk = installedModels.some(
-                      (im) => im.id === m.reference.id && im.version === m.reference.version
-                    )
-                    let suffix = ''
-                    if (!modelOk) suffix = ' (not installed)'
-                    else if (!installed) suffix = ' (environment missing)'
-                    return (
-                      <SelectItem
-                        key={`${m.reference.id}-${m.reference.version}`}
-                        value={`${m.reference.id}-${m.reference.version}`}
-                        disabled={!installed}
-                        className={!installed ? 'opacity-50 cursor-not-allowed' : ''}
-                      >
-                        {m.name} v{m.reference.version}
-                        {suffix}
-                      </SelectItem>
-                    )
-                  })}
-                </SelectContent>
-              </Select>
-            )}
-            {modelLocked && pickedModel && !isModelCompletelyInstalled(pickedModel) && (
-              <div className="mt-1.5 flex items-center gap-2">
-                <p className="text-xs text-amber-700 dark:text-amber-300">
-                  This model is no longer installed. Reinstall it to add a new directory.
+            </div>
+
+            <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3">
+              <p className="text-xs font-medium text-foreground mb-2">What happens next</p>
+              <ul className="text-xs text-muted-foreground space-y-1.5 leading-relaxed list-disc list-inside">
+                <li>
+                  A progress bar appears in the top-right header — pause or resume from there.
+                </li>
+                <li>Images appear in the Media tab as they get classified. No need to refresh.</li>
+                <li>You can keep using the app while this runs in the background.</li>
+              </ul>
+            </div>
+          </div>
+        ) : (
+          <div className="px-5 py-4 space-y-4">
+            {/* No-models-installed CTA: dead-end for users with a fresh install */}
+            {!modelLocked && !hasAnyInstalledModel && (
+              <div className="border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 rounded-md p-3 text-sm text-amber-900 dark:text-amber-200">
+                <p className="font-medium mb-1">No models installed</p>
+                <p className="text-amber-800 dark:text-amber-300 mb-2 text-xs">
+                  Install at least one model before adding images for analysis.
                 </p>
                 <Button
                   variant="outline"
@@ -262,85 +253,169 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
                     navigate('/settings/ml_zoo')
                   }}
                 >
-                  Open Models
+                  Open Models settings
                 </Button>
               </div>
             )}
-            {modelLocked && (!pickedModel || isModelCompletelyInstalled(pickedModel)) && (
-              <p className="text-xs text-muted-foreground mt-1.5">
-                Same model as the previous run for this study.
-              </p>
-            )}
-          </div>
 
-          {/* Country (only when model uses geofencing) */}
-          {needsCountry && (
+            {/* Model */}
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                Country <span className="text-muted-foreground font-normal">(geofencing)</span>
+                Model
               </label>
-              <Select value={pickedCountry} onValueChange={setPickedCountry}>
-                <SelectTrigger className="w-full bg-card border-border">
-                  <SelectValue placeholder="Select a country" />
-                </SelectTrigger>
-                <SelectContent className="max-h-72">
-                  {countries.map((c) => (
-                    <SelectItem key={c.code} value={c.code}>
-                      {c.name} ({c.code})
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {latestCountry && (
+              {modelLocked ? (
+                <div className="flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-sm text-gray-700 dark:text-foreground">
+                  <Lock size={12} className="text-muted-foreground" />
+                  <span>
+                    {pickedModel
+                      ? `${pickedModel.name} v${pickedModel.reference.version}`
+                      : `${latestModel.id} v${latestModel.version}`}
+                  </span>
+                </div>
+              ) : (
+                <Select
+                  value={pickedModelKey}
+                  onValueChange={(value) => {
+                    const [id, ...rest] = value.split('-')
+                    const version = rest.join('-')
+                    const model = modelZoo.find(
+                      (m) => m.reference.id === id && m.reference.version === version
+                    )
+                    if (model && isModelCompletelyInstalled(model)) {
+                      setPickedModelKey(value)
+                    }
+                  }}
+                >
+                  <SelectTrigger className="w-full bg-card border-border">
+                    <SelectValue placeholder="Select a model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {modelZoo.map((m) => {
+                      const installed = isModelCompletelyInstalled(m)
+                      const modelOk = installedModels.some(
+                        (im) => im.id === m.reference.id && im.version === m.reference.version
+                      )
+                      let suffix = ''
+                      if (!modelOk) suffix = ' (not installed)'
+                      else if (!installed) suffix = ' (environment missing)'
+                      return (
+                        <SelectItem
+                          key={`${m.reference.id}-${m.reference.version}`}
+                          value={`${m.reference.id}-${m.reference.version}`}
+                          disabled={!installed}
+                          className={!installed ? 'opacity-50 cursor-not-allowed' : ''}
+                        >
+                          {m.name} v{m.reference.version}
+                          {suffix}
+                        </SelectItem>
+                      )
+                    })}
+                  </SelectContent>
+                </Select>
+              )}
+              {modelLocked && pickedModel && !isModelCompletelyInstalled(pickedModel) && (
+                <div className="mt-1.5 flex items-center gap-2">
+                  <p className="text-xs text-amber-700 dark:text-amber-300">
+                    This model is no longer installed. Reinstall it to add a new directory.
+                  </p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      onClose()
+                      navigate('/settings/ml_zoo')
+                    }}
+                  >
+                    Open Models
+                  </Button>
+                </div>
+              )}
+              {modelLocked && (!pickedModel || isModelCompletelyInstalled(pickedModel)) && (
                 <p className="text-xs text-muted-foreground mt-1.5">
-                  Pre-filled from the previous run; change it for this folder if needed.
+                  Same model as the previous run for this study.
                 </p>
               )}
             </div>
-          )}
 
-          {/* Folder */}
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Folder</label>
-            <div className="flex gap-2">
-              <div
-                className="flex-1 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-xs font-mono text-gray-600 dark:text-muted-foreground truncate"
-                style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
-                title={folder || ''}
-              >
-                {folder ? (
-                  `‎${folder}`
-                ) : (
-                  <span className="text-muted-foreground font-sans">No folder selected</span>
+            {/* Country (only when model uses geofencing) */}
+            {needsCountry && (
+              <div>
+                <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                  Country <span className="text-muted-foreground font-normal">(geofencing)</span>
+                </label>
+                <Select value={pickedCountry} onValueChange={setPickedCountry}>
+                  <SelectTrigger className="w-full bg-card border-border">
+                    <SelectValue placeholder="Select a country" />
+                  </SelectTrigger>
+                  <SelectContent className="max-h-72">
+                    {countries.map((c) => (
+                      <SelectItem key={c.code} value={c.code}>
+                        {c.name} ({c.code})
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {latestCountry && (
+                  <p className="text-xs text-muted-foreground mt-1.5">
+                    Pre-filled from the previous run; change it for this folder if needed.
+                  </p>
                 )}
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleBrowse}
-                disabled={submitting}
-                className="gap-1.5"
-              >
-                <FolderOpen size={14} />
-                {folder ? 'Change' : 'Browse'}
-              </Button>
-            </div>
-          </div>
+            )}
 
-          {error && (
-            <div className="text-sm text-red-600 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md px-3 py-2 dark:text-red-400 dark:bg-red-500/15">
-              {error}
+            {/* Folder */}
+            <div>
+              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
+                Folder
+              </label>
+              <div className="flex gap-2">
+                <div
+                  className="flex-1 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-xs font-mono text-gray-600 dark:text-muted-foreground truncate"
+                  style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
+                  title={folder || ''}
+                >
+                  {folder ? (
+                    `‎${folder}`
+                  ) : (
+                    <span className="text-muted-foreground font-sans">No folder selected</span>
+                  )}
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleBrowse}
+                  disabled={submitting}
+                  className="gap-1.5"
+                >
+                  <FolderOpen size={14} />
+                  {folder ? 'Change' : 'Browse'}
+                </Button>
+              </div>
             </div>
-          )}
-        </div>
+
+            {error && (
+              <div className="text-sm text-red-600 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md px-3 py-2 dark:text-red-400 dark:bg-red-500/15">
+                {error}
+              </div>
+            )}
+          </div>
+        )}
 
         <footer className="flex justify-end gap-2 px-5 py-3 border-t border-gray-200 dark:border-border bg-gray-50 dark:bg-muted">
-          <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
-            {submitting ? 'Starting…' : 'Import'}
-          </Button>
+          {waitingForFirstBatch ? (
+            <Button size="sm" onClick={onClose}>
+              Continue in background
+            </Button>
+          ) : (
+            <>
+              <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
+                {submitting ? 'Starting…' : 'Import'}
+              </Button>
+            </>
+          )}
         </footer>
       </div>
     </div>

--- a/src/renderer/src/AddSourceModal.jsx
+++ b/src/renderer/src/AddSourceModal.jsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
-import { Lock, FolderOpen, X, Loader2 } from 'lucide-react'
+import { Lock, FolderOpen, X } from 'lucide-react'
 import { useImportStatus } from './hooks/import'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select'
 import { Button } from './ui/button.jsx'
 import { modelZoo } from '../../shared/mlmodels.js'
 import { countries } from '../../shared/countries.js'
+import StartingImportModal from './StartingImportModal.jsx'
 
 /**
  * One modal for adding a folder to an existing study.
@@ -199,6 +200,17 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
 
   if (!isOpen) return null
 
+  if (waitingForFirstBatch) {
+    return (
+      <StartingImportModal
+        isOpen
+        folderPath={folder}
+        importStatus={importStatus}
+        onDismiss={onClose}
+      />
+    )
+  }
+
   return (
     <div
       className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
@@ -209,9 +221,7 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-5 py-4 border-b border-border">
-          <h3 className="text-base font-medium text-foreground">
-            {waitingForFirstBatch ? 'Starting import…' : 'Add images directory'}
-          </h3>
+          <h3 className="text-base font-medium text-foreground">Add images directory</h3>
           <button
             onClick={onClose}
             disabled={submitting}
@@ -221,44 +231,84 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
           </button>
         </header>
 
-        {waitingForFirstBatch ? (
-          <div className="px-5 py-6 space-y-4">
-            <div className="flex items-start gap-3">
-              <Loader2
-                size={20}
-                className="animate-spin text-blue-600 dark:text-blue-400 mt-0.5 shrink-0"
-              />
-              <div className="min-w-0">
-                <p className="text-sm text-foreground font-medium">Queueing images for analysis</p>
-                <p
-                  className="text-xs font-mono text-muted-foreground truncate mt-0.5"
-                  style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
-                  title={folder || ''}
-                >
-                  {folder ? `‎${folder}` : ''}
-                </p>
-              </div>
+        <div className="px-5 py-4 space-y-4">
+          {/* No-models-installed CTA: dead-end for users with a fresh install */}
+          {!modelLocked && !hasAnyInstalledModel && (
+            <div className="border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 rounded-md p-3 text-sm text-amber-900 dark:text-amber-200">
+              <p className="font-medium mb-1">No models installed</p>
+              <p className="text-amber-800 dark:text-amber-300 mb-2 text-xs">
+                Install at least one model before adding images for analysis.
+              </p>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  onClose()
+                  navigate('/settings/ml_zoo')
+                }}
+              >
+                Open Models settings
+              </Button>
             </div>
+          )}
 
-            <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3">
-              <p className="text-xs font-medium text-foreground mb-2">What happens next</p>
-              <ul className="text-xs text-muted-foreground space-y-1.5 leading-relaxed list-disc list-inside">
-                <li>
-                  A progress bar appears in the top-right header — pause or resume from there.
-                </li>
-                <li>Images appear in the Media tab as they get classified. No need to refresh.</li>
-                <li>You can keep using the app while this runs in the background.</li>
-              </ul>
-            </div>
-          </div>
-        ) : (
-          <div className="px-5 py-4 space-y-4">
-            {/* No-models-installed CTA: dead-end for users with a fresh install */}
-            {!modelLocked && !hasAnyInstalledModel && (
-              <div className="border border-amber-200 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-500/10 rounded-md p-3 text-sm text-amber-900 dark:text-amber-200">
-                <p className="font-medium mb-1">No models installed</p>
-                <p className="text-amber-800 dark:text-amber-300 mb-2 text-xs">
-                  Install at least one model before adding images for analysis.
+          {/* Model */}
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Model</label>
+            {modelLocked ? (
+              <div className="flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-sm text-gray-700 dark:text-foreground">
+                <Lock size={12} className="text-muted-foreground" />
+                <span>
+                  {pickedModel
+                    ? `${pickedModel.name} v${pickedModel.reference.version}`
+                    : `${latestModel.id} v${latestModel.version}`}
+                </span>
+              </div>
+            ) : (
+              <Select
+                value={pickedModelKey}
+                onValueChange={(value) => {
+                  const [id, ...rest] = value.split('-')
+                  const version = rest.join('-')
+                  const model = modelZoo.find(
+                    (m) => m.reference.id === id && m.reference.version === version
+                  )
+                  if (model && isModelCompletelyInstalled(model)) {
+                    setPickedModelKey(value)
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full bg-card border-border">
+                  <SelectValue placeholder="Select a model" />
+                </SelectTrigger>
+                <SelectContent>
+                  {modelZoo.map((m) => {
+                    const installed = isModelCompletelyInstalled(m)
+                    const modelOk = installedModels.some(
+                      (im) => im.id === m.reference.id && im.version === m.reference.version
+                    )
+                    let suffix = ''
+                    if (!modelOk) suffix = ' (not installed)'
+                    else if (!installed) suffix = ' (environment missing)'
+                    return (
+                      <SelectItem
+                        key={`${m.reference.id}-${m.reference.version}`}
+                        value={`${m.reference.id}-${m.reference.version}`}
+                        disabled={!installed}
+                        className={!installed ? 'opacity-50 cursor-not-allowed' : ''}
+                      >
+                        {m.name} v{m.reference.version}
+                        {suffix}
+                      </SelectItem>
+                    )
+                  })}
+                </SelectContent>
+              </Select>
+            )}
+            {modelLocked && pickedModel && !isModelCompletelyInstalled(pickedModel) && (
+              <div className="mt-1.5 flex items-center gap-2">
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  This model is no longer installed. Reinstall it to add a new directory.
                 </p>
                 <Button
                   variant="outline"
@@ -268,169 +318,85 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
                     navigate('/settings/ml_zoo')
                   }}
                 >
-                  Open Models settings
+                  Open Models
                 </Button>
               </div>
             )}
+            {modelLocked && (!pickedModel || isModelCompletelyInstalled(pickedModel)) && (
+              <p className="text-xs text-muted-foreground mt-1.5">
+                Same model as the previous run for this study.
+              </p>
+            )}
+          </div>
 
-            {/* Model */}
+          {/* Country (only when model uses geofencing) */}
+          {needsCountry && (
             <div>
               <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                Model
+                Country <span className="text-muted-foreground font-normal">(geofencing)</span>
               </label>
-              {modelLocked ? (
-                <div className="flex items-center gap-2 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-sm text-gray-700 dark:text-foreground">
-                  <Lock size={12} className="text-muted-foreground" />
-                  <span>
-                    {pickedModel
-                      ? `${pickedModel.name} v${pickedModel.reference.version}`
-                      : `${latestModel.id} v${latestModel.version}`}
-                  </span>
-                </div>
-              ) : (
-                <Select
-                  value={pickedModelKey}
-                  onValueChange={(value) => {
-                    const [id, ...rest] = value.split('-')
-                    const version = rest.join('-')
-                    const model = modelZoo.find(
-                      (m) => m.reference.id === id && m.reference.version === version
-                    )
-                    if (model && isModelCompletelyInstalled(model)) {
-                      setPickedModelKey(value)
-                    }
-                  }}
-                >
-                  <SelectTrigger className="w-full bg-card border-border">
-                    <SelectValue placeholder="Select a model" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {modelZoo.map((m) => {
-                      const installed = isModelCompletelyInstalled(m)
-                      const modelOk = installedModels.some(
-                        (im) => im.id === m.reference.id && im.version === m.reference.version
-                      )
-                      let suffix = ''
-                      if (!modelOk) suffix = ' (not installed)'
-                      else if (!installed) suffix = ' (environment missing)'
-                      return (
-                        <SelectItem
-                          key={`${m.reference.id}-${m.reference.version}`}
-                          value={`${m.reference.id}-${m.reference.version}`}
-                          disabled={!installed}
-                          className={!installed ? 'opacity-50 cursor-not-allowed' : ''}
-                        >
-                          {m.name} v{m.reference.version}
-                          {suffix}
-                        </SelectItem>
-                      )
-                    })}
-                  </SelectContent>
-                </Select>
-              )}
-              {modelLocked && pickedModel && !isModelCompletelyInstalled(pickedModel) && (
-                <div className="mt-1.5 flex items-center gap-2">
-                  <p className="text-xs text-amber-700 dark:text-amber-300">
-                    This model is no longer installed. Reinstall it to add a new directory.
-                  </p>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      onClose()
-                      navigate('/settings/ml_zoo')
-                    }}
-                  >
-                    Open Models
-                  </Button>
-                </div>
-              )}
-              {modelLocked && (!pickedModel || isModelCompletelyInstalled(pickedModel)) && (
+              <Select value={pickedCountry} onValueChange={setPickedCountry}>
+                <SelectTrigger className="w-full bg-card border-border">
+                  <SelectValue placeholder="Select a country" />
+                </SelectTrigger>
+                <SelectContent className="max-h-72">
+                  {countries.map((c) => (
+                    <SelectItem key={c.code} value={c.code}>
+                      {c.name} ({c.code})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {latestCountry && (
                 <p className="text-xs text-muted-foreground mt-1.5">
-                  Same model as the previous run for this study.
+                  Pre-filled from the previous run; change it for this folder if needed.
                 </p>
               )}
             </div>
+          )}
 
-            {/* Country (only when model uses geofencing) */}
-            {needsCountry && (
-              <div>
-                <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                  Country <span className="text-muted-foreground font-normal">(geofencing)</span>
-                </label>
-                <Select value={pickedCountry} onValueChange={setPickedCountry}>
-                  <SelectTrigger className="w-full bg-card border-border">
-                    <SelectValue placeholder="Select a country" />
-                  </SelectTrigger>
-                  <SelectContent className="max-h-72">
-                    {countries.map((c) => (
-                      <SelectItem key={c.code} value={c.code}>
-                        {c.name} ({c.code})
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {latestCountry && (
-                  <p className="text-xs text-muted-foreground mt-1.5">
-                    Pre-filled from the previous run; change it for this folder if needed.
-                  </p>
+          {/* Folder */}
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1.5">Folder</label>
+            <div className="flex gap-2">
+              <div
+                className="flex-1 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-xs font-mono text-gray-600 dark:text-muted-foreground truncate"
+                style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
+                title={folder || ''}
+              >
+                {folder ? (
+                  `‎${folder}`
+                ) : (
+                  <span className="text-muted-foreground font-sans">No folder selected</span>
                 )}
               </div>
-            )}
-
-            {/* Folder */}
-            <div>
-              <label className="block text-xs font-medium text-muted-foreground mb-1.5">
-                Folder
-              </label>
-              <div className="flex gap-2">
-                <div
-                  className="flex-1 px-3 py-2 border border-gray-200 dark:border-border rounded-md bg-gray-50 dark:bg-muted text-xs font-mono text-gray-600 dark:text-muted-foreground truncate"
-                  style={folder ? { direction: 'rtl', textAlign: 'left' } : undefined}
-                  title={folder || ''}
-                >
-                  {folder ? (
-                    `‎${folder}`
-                  ) : (
-                    <span className="text-muted-foreground font-sans">No folder selected</span>
-                  )}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleBrowse}
-                  disabled={submitting}
-                  className="gap-1.5"
-                >
-                  <FolderOpen size={14} />
-                  {folder ? 'Change' : 'Browse'}
-                </Button>
-              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleBrowse}
+                disabled={submitting}
+                className="gap-1.5"
+              >
+                <FolderOpen size={14} />
+                {folder ? 'Change' : 'Browse'}
+              </Button>
             </div>
-
-            {error && (
-              <div className="text-sm text-red-600 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md px-3 py-2 dark:text-red-400 dark:bg-red-500/15">
-                {error}
-              </div>
-            )}
           </div>
-        )}
+
+          {error && (
+            <div className="text-sm text-red-600 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md px-3 py-2 dark:text-red-400 dark:bg-red-500/15">
+              {error}
+            </div>
+          )}
+        </div>
 
         <footer className="flex justify-end gap-2 px-5 py-3 border-t border-gray-200 dark:border-border bg-gray-50 dark:bg-muted">
-          {waitingForFirstBatch ? (
-            <Button size="sm" onClick={onClose}>
-              Continue in background
-            </Button>
-          ) : (
-            <>
-              <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
-                Cancel
-              </Button>
-              <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
-                {submitting ? 'Starting…' : 'Import'}
-              </Button>
-            </>
-          )}
+          <Button variant="outline" size="sm" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleImport} disabled={!canImport || submitting}>
+            {submitting ? 'Starting…' : 'Import'}
+          </Button>
         </footer>
       </div>
     </div>

--- a/src/renderer/src/AddSourceModal.jsx
+++ b/src/renderer/src/AddSourceModal.jsx
@@ -185,7 +185,10 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
           isRunning: true
         }))
         queryClient.invalidateQueries({ queryKey: ['importStatus', studyId] })
-        doneAtStartRef.current = importStatus?.done ?? 0
+        // Read from the cache, not the closure: `importStatus` here is
+        // captured from the render before this handler was invoked, so it
+        // misses any polls that landed during `await addFolder(...)`.
+        doneAtStartRef.current = queryClient.getQueryData(['importStatus', studyId])?.done ?? 0
         setWaitingForFirstBatch(true)
         setSubmitting(false)
       } else {

--- a/src/renderer/src/AddSourceModal.jsx
+++ b/src/renderer/src/AddSourceModal.jsx
@@ -30,6 +30,7 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
   const [folder, setFolder] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [waitingForFirstBatch, setWaitingForFirstBatch] = useState(false)
+  const [minDisplayElapsed, setMinDisplayElapsed] = useState(false)
   const doneAtStartRef = useRef(0)
   const [error, setError] = useState(null)
   const [installedModels, setInstalledModels] = useState([])
@@ -102,16 +103,30 @@ export default function AddSourceModal({ isOpen, studyId, onClose, onImported })
     return () => window.removeEventListener('keydown', onKey)
   }, [isOpen, submitting, onClose])
 
+  // Minimum display time. Guarantees the user sees the transitional view
+  // long enough to read the "what happens next" copy before any auto-close
+  // can fire. Explicit dismiss (Continue in background / ESC / ✕ /
+  // backdrop) still works immediately.
+  useEffect(() => {
+    if (!waitingForFirstBatch) {
+      setMinDisplayElapsed(false)
+      return
+    }
+    const id = setTimeout(() => setMinDisplayElapsed(true), 3000)
+    return () => clearTimeout(id)
+  }, [waitingForFirstBatch])
+
   // Auto-close once a new job completes. importStatus.done is study-wide
   // and may already be non-zero from prior runs, so we compare against
-  // the snapshot captured when we entered the transitional state.
+  // the snapshot captured when we entered the transitional state. Gated
+  // on minDisplayElapsed so the modal is visible long enough to register.
   useEffect(() => {
-    if (!waitingForFirstBatch) return
+    if (!waitingForFirstBatch || !minDisplayElapsed) return
     if ((importStatus?.done ?? 0) > doneAtStartRef.current) {
       onImported?.()
       onClose()
     }
-  }, [waitingForFirstBatch, importStatus?.done, onImported, onClose])
+  }, [waitingForFirstBatch, minDisplayElapsed, importStatus?.done, onImported, onClose])
 
   // Failsafe: if no job completes within 15s, dismiss the modal anyway.
   // The import is genuinely running by this point (addFolder resolved),

--- a/src/renderer/src/StartingImportModal.jsx
+++ b/src/renderer/src/StartingImportModal.jsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { Loader2, X } from 'lucide-react'
+import { Button } from './ui/button.jsx'
+
+/**
+ * Transitional "Starting import…" modal shown right after the user kicks
+ * off an import. Tells them what is happening now and where to look for
+ * ongoing progress, so by the time it closes they know to expect the
+ * (subtle) header progress UI and media appearing on the page.
+ *
+ * The parent is responsible for deciding when the modal opens / closes;
+ * this component just renders the shell and forwards dismiss events.
+ */
+export default function StartingImportModal({
+  isOpen,
+  folderPath,
+  onDismiss,
+  dismissLabel = 'Continue in background',
+  dismissEnabled = true
+}) {
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e) => {
+      if (e.key === 'Escape' && dismissEnabled) onDismiss()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isOpen, dismissEnabled, onDismiss])
+
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50"
+      onClick={() => dismissEnabled && onDismiss()}
+    >
+      <div
+        className="bg-card rounded-lg shadow-xl w-[480px] max-w-[92vw] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-4 border-b border-border">
+          <h3 className="text-base font-medium text-foreground">Starting import…</h3>
+          <button
+            onClick={onDismiss}
+            disabled={!dismissEnabled}
+            className="text-muted-foreground hover:text-muted-foreground disabled:opacity-50"
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="px-5 py-6 space-y-4">
+          <div className="flex items-start gap-3">
+            <Loader2
+              size={20}
+              className="animate-spin text-blue-600 dark:text-blue-400 mt-0.5 shrink-0"
+            />
+            <div className="min-w-0">
+              <p className="text-sm text-foreground font-medium">Queueing images for analysis</p>
+              <p
+                className="text-xs font-mono text-muted-foreground truncate mt-0.5"
+                style={folderPath ? { direction: 'rtl', textAlign: 'left' } : undefined}
+                title={folderPath || ''}
+              >
+                {folderPath ? `‎${folderPath}` : ''}
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3">
+            <p className="text-xs font-medium text-foreground mb-2">What happens next</p>
+            <ul className="text-xs text-muted-foreground space-y-1.5 leading-relaxed list-disc list-inside">
+              <li>A progress bar appears in the top-right header — pause or resume from there.</li>
+              <li>Images appear in the Media tab as they get classified. No need to refresh.</li>
+              <li>You can keep using the app while this runs in the background.</li>
+            </ul>
+          </div>
+        </div>
+
+        <footer className="flex justify-end gap-2 px-5 py-3 border-t border-gray-200 dark:border-border bg-gray-50 dark:bg-muted">
+          <Button size="sm" onClick={onDismiss} disabled={!dismissEnabled}>
+            {dismissLabel}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/StartingImportModal.jsx
+++ b/src/renderer/src/StartingImportModal.jsx
@@ -4,9 +4,9 @@ import { Button } from './ui/button.jsx'
 
 /**
  * Transitional "Starting import…" modal shown right after the user kicks
- * off an import. Tells them what is happening now and where to look for
- * ongoing progress, so by the time it closes they know to expect the
- * (subtle) header progress UI and media appearing on the page.
+ * off an import. Surfaces live progress (bar + counts + speed + ETA) so
+ * the user has concrete evidence work is happening before the modal
+ * closes.
  *
  * The parent is responsible for deciding when the modal opens / closes;
  * this component just renders the shell and forwards dismiss events.
@@ -14,6 +14,7 @@ import { Button } from './ui/button.jsx'
 export default function StartingImportModal({
   isOpen,
   folderPath,
+  importStatus,
   onDismiss,
   dismissLabel = 'Continue in background',
   dismissEnabled = true
@@ -28,6 +29,28 @@ export default function StartingImportModal({
   }, [isOpen, dismissEnabled, onDismiss])
 
   if (!isOpen) return null
+
+  const total = importStatus?.total ?? 0
+  const done = importStatus?.done ?? 0
+  const speed = importStatus?.speed ?? 0
+  const etaMinutes = importStatus?.estimatedMinutesRemaining
+  const hasData = total > 0
+  const progress = hasData ? (done / total) * 100 : 0
+
+  const finishTime =
+    hasData && etaMinutes != null && etaMinutes > 0
+      ? new Date(
+          // eslint-disable-next-line react-hooks/purity -- intentional: import polls re-render every second, refreshing the wall-clock finish time
+          Date.now() + etaMinutes * 60_000
+        ).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit'
+        })
+      : null
+
+  const infoLineParts = []
+  if (hasData && speed > 0) infoLineParts.push(`${speed} media/min`)
+  if (finishTime) infoLineParts.push(`finishes ≈ ${finishTime}`)
 
   return (
     <div
@@ -67,13 +90,29 @@ export default function StartingImportModal({
             </div>
           </div>
 
-          <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3">
-            <p className="text-xs font-medium text-foreground mb-2">What happens next</p>
-            <ul className="text-xs text-muted-foreground space-y-1.5 leading-relaxed list-disc list-inside">
-              <li>A progress bar appears in the top-right header — pause or resume from there.</li>
-              <li>Images appear in the Media tab as they get classified. No need to refresh.</li>
-              <li>You can keep using the app while this runs in the background.</li>
-            </ul>
+          <div className="rounded-md border border-border bg-muted/50 dark:bg-muted px-3 py-3 space-y-2">
+            <div className="flex items-baseline justify-between">
+              <p className="text-xs font-medium text-foreground">Progress</p>
+              <p className="text-xs text-muted-foreground tabular-nums">
+                {hasData ? `${Math.round(progress)}%` : ''}
+              </p>
+            </div>
+            <div className="w-full bg-background dark:bg-muted-foreground/10 rounded-full h-2 overflow-hidden">
+              <div
+                className="h-full bg-blue-600 dark:bg-blue-500 transition-all duration-500 ease-in-out rounded-full"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground tabular-nums">
+              {hasData
+                ? `${done.toLocaleString()} of ${total.toLocaleString()} media`
+                : 'Queueing…'}
+            </p>
+            {infoLineParts.length > 0 && (
+              <p className="text-xs text-muted-foreground tabular-nums">
+                {infoLineParts.join(' · ')}
+              </p>
+            )}
           </div>
         </div>
 

--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -1,10 +1,12 @@
 import 'leaflet/dist/leaflet.css'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router'
 import { modelZoo } from '../../shared/mlmodels.js'
 import { getGbifTitle, isGbifAvailable } from '../../shared/gbifTitles.js'
 import { useQueryClient } from '@tanstack/react-query'
 import CountryPickerModal from './CountryPickerModal.jsx'
+import StartingImportModal from './StartingImportModal.jsx'
+import { useImportStatus } from './hooks/import'
 import GbifImportProgress from './GbifImportProgress.jsx'
 import DemoImportProgress from './DemoImportProgress.jsx'
 import LilaImportProgress from './LilaImportProgress.jsx'
@@ -55,6 +57,67 @@ export default function Import({ studiesCount = 0 }) {
   const [pendingDirectoryPath, setPendingDirectoryPath] = useState(null)
   const [showMoreFormats, setShowMoreFormats] = useState(false)
   const queryClient = useQueryClient()
+
+  // Local-folder import: transitional modal shown from the moment the user
+  // commits a folder until the new study is ready and the first job has
+  // landed (or a few safety nets fire). Without this, the renderer
+  // navigates straight to the empty study page and the customer reports
+  // it feels stuck.
+  const [startingFolder, setStartingFolder] = useState(null) // string | null
+  const [pendingStudyId, setPendingStudyId] = useState(null) // string | null
+  const [minDisplayElapsed, setMinDisplayElapsed] = useState(false)
+  const navigateTargetRef = useRef(null)
+
+  const { importStatus: pendingStudyStatus } = useImportStatus(pendingStudyId)
+
+  // Single place that closes the modal and (if we have a study ID) navigates.
+  const finishStartingImport = useCallback(() => {
+    const target = navigateTargetRef.current
+    setStartingFolder(null)
+    setPendingStudyId(null)
+    setMinDisplayElapsed(false)
+    navigateTargetRef.current = null
+    if (target) {
+      queryClient.invalidateQueries({ queryKey: ['studies'] })
+      navigate(`/study/${target}`)
+    }
+  }, [navigate, queryClient])
+
+  // 3s minimum display before any auto-close fires. User-initiated dismiss
+  // (X / backdrop / footer button / ESC) still works immediately.
+  useEffect(() => {
+    if (!startingFolder) {
+      setMinDisplayElapsed(false)
+      return
+    }
+    const id = setTimeout(() => setMinDisplayElapsed(true), 3000)
+    return () => clearTimeout(id)
+  }, [startingFolder])
+
+  // Auto-close once the first job for the new study lands. New studies
+  // start at done=0, so no snapshot is needed.
+  useEffect(() => {
+    if (!startingFolder || !minDisplayElapsed) return
+    if (!pendingStudyId) return
+    if ((pendingStudyStatus?.done ?? 0) > 0) {
+      finishStartingImport()
+    }
+  }, [
+    startingFolder,
+    minDisplayElapsed,
+    pendingStudyId,
+    pendingStudyStatus?.done,
+    finishStartingImport
+  ])
+
+  // Failsafe: if 15s pass after the study ID is known with no first
+  // completion, dismiss anyway. The import is queued — trapping the user
+  // here would be worse than continuing.
+  useEffect(() => {
+    if (!startingFolder || !pendingStudyId) return
+    const id = setTimeout(() => finishStartingImport(), 15000)
+    return () => clearTimeout(id)
+  }, [startingFolder, pendingStudyId, finishStartingImport])
 
   // GBIF import progress state
   const [gbifImportProgress, setGbifImportProgress] = useState(null)
@@ -352,36 +415,42 @@ export default function Import({ studiesCount = 0 }) {
       setShowCountryPicker(true)
     } else {
       // For DeepFaune and other models, import directly with model (no country needed)
-      const { id } = await window.api.selectImagesDirectoryWithModel(
+      setStartingFolder(result.directoryPath)
+      const res = await window.api.selectImagesDirectoryWithModel(
         result.directoryPath,
         selectedModel,
         null // no country needed
       )
       // Errors (e.g., ML server failed to start) are handled via IPC event in base.jsx
-      if (!id) return
-      await queryClient.invalidateQueries({ queryKey: ['studies'] })
-      navigate(`/study/${id}`)
+      if (!res?.id) {
+        setStartingFolder(null)
+        return
+      }
+      navigateTargetRef.current = res.id
+      setPendingStudyId(res.id)
     }
   }
 
   const handleCountrySelected = async (countryCode) => {
     if (!pendingDirectoryPath) return
 
-    // Close modal immediately - don't wait for server startup
     const directoryPath = pendingDirectoryPath
     setShowCountryPicker(false)
     setPendingDirectoryPath(null)
+    setStartingFolder(directoryPath)
 
-    const { id } = await window.api.selectImagesDirectoryWithModel(
+    const res = await window.api.selectImagesDirectoryWithModel(
       directoryPath,
       selectedModel,
       countryCode
     )
     // Errors (e.g., ML server failed to start) are handled via IPC event in base.jsx
-    if (!id) return
-
-    await queryClient.invalidateQueries({ queryKey: ['studies'] })
-    navigate(`/study/${id}`)
+    if (!res?.id) {
+      setStartingFolder(null)
+      return
+    }
+    navigateTargetRef.current = res.id
+    setPendingStudyId(res.id)
   }
 
   const handleCountryPickerCancel = () => {
@@ -849,6 +918,14 @@ export default function Import({ studiesCount = 0 }) {
         isOpen={showCountryPicker}
         onConfirm={handleCountrySelected}
         onCancel={handleCountryPickerCancel}
+      />
+
+      <StartingImportModal
+        isOpen={!!startingFolder}
+        folderPath={startingFolder}
+        dismissEnabled={!!pendingStudyId}
+        dismissLabel="Open study"
+        onDismiss={finishStartingImport}
       />
 
       <GbifImportProgress

--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -83,16 +83,20 @@ export default function Import({ studiesCount = 0 }) {
     }
   }, [navigate, queryClient])
 
-  // 3s minimum display before any auto-close fires. User-initiated dismiss
-  // (X / backdrop / footer button / ESC) still works immediately.
+  // 3s minimum display before any auto-close fires. The timer starts once
+  // the study ID is known (i.e. once the progress panel has real data to
+  // show), not when the modal first appears — otherwise a slow
+  // selectImagesDirectoryWithModel call eats the whole window and the user
+  // never sees the live counts. User-initiated dismiss (X / backdrop /
+  // footer button / ESC) still works immediately.
   useEffect(() => {
-    if (!startingFolder) {
+    if (!startingFolder || !pendingStudyId) {
       setMinDisplayElapsed(false)
       return
     }
     const id = setTimeout(() => setMinDisplayElapsed(true), 3000)
     return () => clearTimeout(id)
-  }, [startingFolder])
+  }, [startingFolder, pendingStudyId])
 
   // Auto-close once the first job for the new study lands. New studies
   // start at done=0, so no snapshot is needed.

--- a/src/renderer/src/import.jsx
+++ b/src/renderer/src/import.jsx
@@ -923,6 +923,7 @@ export default function Import({ studiesCount = 0 }) {
       <StartingImportModal
         isOpen={!!startingFolder}
         folderPath={startingFolder}
+        importStatus={pendingStudyStatus}
         dismissEnabled={!!pendingStudyId}
         dismissLabel="Open study"
         onDismiss={finishStartingImport}


### PR DESCRIPTION
## Summary

Address customer feedback that the moment after picking a folder is unclear — the header progress UI is too subtle, and on the new-study path there was no transitional UI at all. Add a modal that pops up the instant a folder is committed and shows the import making real progress before it dismisses.

The modal is shared across both entry points:

- **New-study flow** (`import.jsx`): folder → optional country picker → `StartingImportModal` is up during `selectImagesDirectoryWithModel` and the first batch, then auto-navigates to the new study.
- **Add-to-existing-study flow** (`AddSourceModal.jsx`): the existing form modal switches into the same `StartingImportModal` after the user clicks Import.

The modal itself shows:

- Spinner + "Queueing images for analysis" + folder path
- A live progress panel: bar + percentage + "X of Y media" + "N media/min · finishes ≈ HH:MM" (placeholder \`Queueing…\` until \`total > 0\`)
- Footer button: \"Open study\" (new-study) or \"Continue in background\" (add-source). ESC / backdrop / ✕ behave the same.

Behaviour rules:

- **3s minimum display** before any auto-close fires, so a fast first batch (or a stale closure snapshot) can't close the modal before the user registers it.
- **Auto-close on first new completion**: \`importStatus.done > snapshot\` (and elapsed >= 3s). In the new-study flow no snapshot is needed (\`done\` starts at 0). In the add-source flow we snapshot \`done\` at submit because the value is study-wide and may already be non-zero from prior runs.
- **15s failsafe** so a slow first batch never traps the user.
- Manual dismiss always fires immediately. In the new-study flow, dismiss is disabled while we don't yet have a study ID to navigate to.

Refactor: \`AddSourceModal\`'s transitional view, which originally lived inline, now delegates to the shared \`StartingImportModal\` so both flows share one piece of markup.

Spec: [docs/specs/2026-05-15-add-source-starting-state-design.md](docs/specs/2026-05-15-add-source-starting-state-design.md)
Plan: [docs/plans/2026-05-15-add-source-starting-state-plan.md](docs/plans/2026-05-15-add-source-starting-state-plan.md)

## Test plan

- [x] New-study flow with DeepFaune (non-SpeciesNet): pick folder → modal opens immediately → progress panel populates → auto-navigates to study after first batch
- [x] New-study flow with SpeciesNet: pick folder → country picker → pick country → modal opens → progress populates → auto-navigates
- [x] Add-to-existing-study: open Sources → "+ Add images directory" → fill form → Import → form switches to the transitional view → auto-closes after first new completion
- [x] Auto-close respects the 3s minimum even on tiny folders (e.g. 5 images that classify near-instantly)
- [x] 15s failsafe fires when first batch is slow (temporarily change to \`1500\` to verify, then revert)
- [x] Existing study with prior completed run: add new folder → modal does NOT close instantly (snapshot logic in \`AddSourceModal\`)
- [x] Manual dismiss: ESC / backdrop / footer button / ✕ all work; for new-study flow they only enable once the study ID is known
- [x] Dark mode visual pass