### PR TITLE
fix(ml-inference): handle corrupt-image partial-failure predictions

### DIFF
--- a/python-environments/common/tests/test_utils.py
+++ b/python-environments/common/tests/test_utils.py
@@ -1,0 +1,98 @@
+"""Unit tests for shared ML server utilities."""
+
+from utils import VideoCapableLitAPI
+
+
+class TestNormalizeFailedPredictions:
+    """Tests for VideoCapableLitAPI._normalize_failed_predictions.
+
+    SpeciesNet returns partial-failure predictions with a `failures` field but
+    no `prediction` field when an image cannot be loaded (e.g. corrupt JPEG).
+    Downstream JS validation requires `prediction` to be a string, so we
+    rewrite those records into a standard error prediction before yielding.
+    """
+
+    def test_normalizes_partial_failure_to_error(self):
+        """A prediction with `failures` and no `prediction` is rewritten."""
+        result = {
+            "predictions": [
+                {
+                    "filepath": "/corrupt.jpg",
+                    "failures": ["CLASSIFIER", "DETECTOR"],
+                    "model_version": "4.0.1a",
+                }
+            ]
+        }
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/corrupt.jpg")
+        assert len(normalized["predictions"]) == 1
+        pred = normalized["predictions"][0]
+        assert pred["filepath"] == "/corrupt.jpg"
+        assert pred["prediction"] == "error"
+        assert pred["prediction_score"] == 0.0
+        assert pred["classifications"] == {}
+        assert pred["detections"] == []
+        assert pred["model_version"] == "4.0.1a"
+        assert "CLASSIFIER" in pred["error"]
+        assert "DETECTOR" in pred["error"]
+
+    def test_preserves_successful_prediction(self):
+        """A normal prediction with `prediction` field is passed through unchanged."""
+        result = {
+            "predictions": [
+                {
+                    "filepath": "/animal.jpg",
+                    "prediction": "uuid;mammalia;carnivora;felidae;panthera;leo;lion",
+                    "prediction_score": 0.95,
+                    "model_version": "4.0.1a",
+                    "classifications": {"classes": ["uuid;..."], "scores": [0.95]},
+                    "detections": [{"category": "1", "label": "animal", "conf": 0.99}],
+                }
+            ]
+        }
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/animal.jpg")
+        assert normalized["predictions"][0] == result["predictions"][0]
+
+    def test_falls_back_to_provided_filepath(self):
+        """When the failed prediction lacks `filepath`, fallback is used."""
+        result = {"predictions": [{"failures": ["CLASSIFIER"]}]}
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/fallback.jpg")
+        assert normalized["predictions"][0]["filepath"] == "/fallback.jpg"
+
+    def test_handles_unknown_model_version(self):
+        """When the failed prediction lacks `model_version`, fallback is 'unknown'."""
+        result = {"predictions": [{"filepath": "/x.jpg", "failures": ["CLASSIFIER"]}]}
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/x.jpg")
+        assert normalized["predictions"][0]["model_version"] == "unknown"
+
+    def test_mixed_batch(self):
+        """A batch with both successful and failed predictions is partially rewritten."""
+        result = {
+            "predictions": [
+                {
+                    "filepath": "/ok.jpg",
+                    "prediction": "blank",
+                    "prediction_score": 0.5,
+                    "model_version": "4.0.1a",
+                },
+                {
+                    "filepath": "/bad.jpg",
+                    "failures": ["CLASSIFIER", "DETECTOR"],
+                    "model_version": "4.0.1a",
+                },
+            ]
+        }
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/fallback.jpg")
+        assert normalized["predictions"][0]["prediction"] == "blank"
+        assert normalized["predictions"][1]["prediction"] == "error"
+
+    def test_empty_predictions(self):
+        """Empty predictions list is handled."""
+        result = {"predictions": []}
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/x.jpg")
+        assert normalized == {"predictions": []}
+
+    def test_missing_predictions_key(self):
+        """Result without `predictions` key returns empty list."""
+        result = {}
+        normalized = VideoCapableLitAPI._normalize_failed_predictions(result, "/x.jpg")
+        assert normalized == {"predictions": []}

--- a/python-environments/common/utils.py
+++ b/python-environments/common/utils.py
@@ -158,6 +158,43 @@ class VideoCapableLitAPI(ABC):
         """
         pass
 
+    @staticmethod
+    def _normalize_failed_predictions(result: dict, fallback_filepath: str) -> dict:
+        """Convert partial-failure predictions to the standard error format.
+
+        Some models (notably SpeciesNet) swallow image-loading errors internally
+        and return a prediction dict with a `failures` field but no `prediction`
+        field. Downstream JS validation expects every prediction to carry the
+        required fields, so a partial-failure record fails validation and
+        aborts the whole batch. Rewrite those records into the same shape that
+        the `except` handler emits so consumers see uniform output.
+
+        Args:
+            result: Dict returned by `_predict_single_image` (or a frame thereof).
+            fallback_filepath: Filepath to use if the prediction omits one.
+
+        Returns:
+            New dict with the same shape as `result`, with any partial-failure
+            predictions replaced by standard error predictions.
+        """
+        normalized = []
+        for pred in result.get("predictions", []):
+            if pred.get("prediction") is None:
+                normalized.append(
+                    {
+                        "filepath": pred.get("filepath", str(fallback_filepath)),
+                        "prediction": "error",
+                        "prediction_score": 0.0,
+                        "error": f"Inference failed: {pred.get('failures', ['unknown'])}",
+                        "classifications": {},
+                        "detections": [],
+                        "model_version": pred.get("model_version", "unknown"),
+                    }
+                )
+            else:
+                normalized.append(pred)
+        return {"predictions": normalized}
+
     def predict_with_video_support(self, x, **kwargs):
         """
         Main predict method with automatic video support.
@@ -185,10 +222,11 @@ class VideoCapableLitAPI(ABC):
 
             try:
                 if is_video_file(filepath):
-                    yield from self._predict_video(filepath, sample_fps, **kwargs)
+                    for frame_result in self._predict_video(filepath, sample_fps, **kwargs):
+                        yield self._normalize_failed_predictions(frame_result, filepath)
                 else:
-                    # For images, just pass through to single image prediction
-                    yield self._predict_single_image(filepath, **kwargs)
+                    result = self._predict_single_image(filepath, **kwargs)
+                    yield self._normalize_failed_predictions(result, filepath)
             except Exception as e:
                 logger.error(f"Skipping file due to error: {filepath!r} - {e}")
                 yield {
@@ -200,6 +238,7 @@ class VideoCapableLitAPI(ABC):
                             "error": str(e),
                             "classifications": {},
                             "detections": [],
+                            "model_version": "unknown",
                         }
                     ]
                 }

--- a/src/main/services/inference-consumer.js
+++ b/src/main/services/inference-consumer.js
@@ -88,6 +88,24 @@ export class InferenceConsumer extends QueueConsumer {
       const videoPredictionsMap = new Map() // filepath -> predictions[]
 
       for await (const prediction of getPredictions(filePaths, this.port, batchAbort.signal)) {
+        // Skip failed predictions (corrupt images, model-side load errors).
+        // The media row stays without an observation, so it surfaces in the
+        // blank section of the media tab via notExists(realObservations).
+        // We mark the job complete (not failed) — corrupt files aren't retriable.
+        if (prediction.prediction === 'error' || prediction.failures) {
+          log.warn(
+            `[InferenceConsumer] Failed prediction for ${prediction.filepath}: ${
+              prediction.error || JSON.stringify(prediction.failures)
+            }`
+          )
+          const job = jobByPath.get(prediction.filepath)
+          if (job) {
+            complete(this.manager, job.id)
+            completedPaths.add(prediction.filepath)
+          }
+          continue
+        }
+
         const isVideoFrame = prediction.frame_number !== undefined
 
         if (isVideoFrame) {


### PR DESCRIPTION
## Summary

- **Root cause:** SpeciesNet silently emits prediction records with a `failures` field and no `prediction` when an image can't be loaded (e.g. corrupt JPEG). The Zod validator rejected those, `insertModelOutput` threw, and the catch block cascaded the failure to every other job in the same batch — fanning a single corrupt file into up to `batchSize` permanent failures and leaving the progress bar stuck at <100% with no way to resume.
- **Python fix:** Added `VideoCapableLitAPI._normalize_failed_predictions` in `utils.py` to rewrite partial-failure records into the standard `prediction: "error"` format used by the existing exception handler. Also backfilled `model_version: "unknown"` in that handler so DeepFaune/Manas error paths (which already raised on bad images) now pass validation too.
- **JS fix:** Added an early-exit guard in `InferenceConsumer.processBatch` that detects `prediction === 'error'` or a `failures` field, marks the job complete (corrupt files aren't retriable), and skips observation creation. Media rows stay observation-less and surface naturally in the blank section via the existing `notExists(realObservations)` query.

## Test plan

- [x] New unit tests in `tests/test_utils.py` for `_normalize_failed_predictions` (7 cases: partial-failure, success passthrough, fallback filepath/model_version, mixed batch, empty, missing key)
- [x] `make lint` + `make format` clean in `python-environments/common/`
- [x] Existing JS tests pass (`queue-consumer`, `model-output` validator — 45 total)
- [x] Verified end-to-end on a fresh `md-test-images` study: 48/48 jobs completed on first attempt, both `corrupt-images/` JPEGs end up with 0 observations and surface in the blank section, no batch errors in logs.