### PR TITLE
fix(delete-study): clarify that original media files are not deleted

### DIFF
--- a/src/renderer/src/DeleteStudyModal.jsx
+++ b/src/renderer/src/DeleteStudyModal.jsx
@@ -76,7 +76,7 @@ function DeleteStudyModal({ isOpen, onConfirm, onCancel, studyName }) {
             You are about to permanently delete the study{' '}
             <span className="font-semibold text-foreground">&ldquo;{studyName}&rdquo;</span> from
             Biowatch. This removes its imported metadata, deployments, observations, ML predictions,
-            and any cached files.
+            and cached files.
           </p>
 
           <p className="text-sm text-foreground mb-4">
@@ -85,7 +85,7 @@ function DeleteStudyModal({ isOpen, onConfirm, onCancel, studyName }) {
 
           <div className="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md p-3 mb-4 dark:bg-red-500/15">
             <p className="text-sm text-red-800 dark:text-red-300">
-              This action cannot be undone. Biowatch data for this study will be permanently lost.
+              Biowatch data for this study will be <strong>permanently lost</strong>.
             </p>
           </div>
 

--- a/src/renderer/src/DeleteStudyModal.jsx
+++ b/src/renderer/src/DeleteStudyModal.jsx
@@ -74,13 +74,18 @@ function DeleteStudyModal({ isOpen, onConfirm, onCancel, studyName }) {
         <div className="px-6 py-4">
           <p className="text-sm text-foreground mb-4">
             You are about to permanently delete the study{' '}
-            <span className="font-semibold text-foreground">&ldquo;{studyName}&rdquo;</span>. This
-            will remove all associated data, deployments, and media references.
+            <span className="font-semibold text-foreground">&ldquo;{studyName}&rdquo;</span> from
+            Biowatch. This removes its imported metadata, deployments, observations, ML predictions,
+            and any cached files.
+          </p>
+
+          <p className="text-sm text-foreground mb-4">
+            Your original image and video files on disk will <strong>not</strong> be deleted.
           </p>
 
           <div className="bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-md p-3 mb-4 dark:bg-red-500/15">
             <p className="text-sm text-red-800 dark:text-red-300">
-              This action is <strong>irreversible</strong>. All data will be permanently lost.
+              This action cannot be undone. Biowatch data for this study will be permanently lost.
             </p>
           </div>
 

--- a/src/renderer/src/StudySettings.jsx
+++ b/src/renderer/src/StudySettings.jsx
@@ -84,7 +84,9 @@ export default function StudySettings({ studyId, studyName }) {
             <div className="min-w-0">
               <h3 className="text-sm font-medium text-foreground">Delete this study</h3>
               <p className="text-sm text-muted-foreground mt-1">
-                Once deleted, all data associated with this study will be permanently removed.
+                Permanently removes this study from Biowatch — its imported metadata, deployments,
+                observations, ML predictions, and cached files. Your original image and video files
+                on disk are not affected.
               </p>
             </div>
             <button


### PR DESCRIPTION
## Summary

- The delete-study confirmation modal and the Study Settings → Danger Zone description previously said things like "remove all associated data... media references" and "all data will be permanently lost", which strongly implied that the source images/videos on disk would be deleted too. In reality, `study:delete-database` only removes the study folder under `userData` (Biowatch's local DB + cached files).
- Reworded both surfaces to itemize what Biowatch actually removes (imported metadata, deployments, observations, ML predictions, cached files) and to explicitly reassure the user that their original image and video files on disk are not affected.
- The right-click "Delete" action in the study list opens the same modal, so it is covered by the modal change.

## Test plan

- [x] Open the app, navigate into a study → Settings → Danger Zone, and verify the new wording reads correctly and reassures that original files are safe.
- [x] Right-click a study in the study list → Delete → verify the modal copy reads correctly and is consistent with the Danger Zone description.
- [x] Type the confirmation phrase and confirm the delete still functions end-to-end (study is removed from the list, source files on disk remain untouched).