### PR TITLE
fix(models): snappy hover state in ModelSelect dropdown

### DIFF
--- a/src/renderer/src/models/ModelSelect.jsx
+++ b/src/renderer/src/models/ModelSelect.jsx
@@ -146,7 +146,7 @@ export default function ModelSelect({
               <SelectPrimitive.Item
                 key={`${model.reference.id}-${model.reference.version}`}
                 value={`${model.reference.id}-${model.reference.version}`}
-                className="focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-pointer items-start gap-2 rounded-sm py-2 px-2 text-sm outline-none select-none"
+                className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex w-full cursor-pointer items-start gap-2 rounded-sm py-2 px-2 text-sm outline-none select-none"
               >
                 <ModelRow model={model} status={status} />
               </SelectPrimitive.Item>
@@ -156,7 +156,7 @@ export default function ModelSelect({
         <SelectSeparator />
         <SelectPrimitive.Item
           value={FOOTER_VALUE}
-          className="focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 px-2 text-sm text-muted-foreground outline-none select-none"
+          className="data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground relative flex w-full cursor-pointer items-center gap-2 rounded-sm py-1.5 px-2 text-sm text-muted-foreground outline-none select-none"
         >
           <span className="inline-flex items-center gap-2">
             <Settings size={12} />


### PR DESCRIPTION
## Summary

Follow-up to #539. The model dropdown's hover highlight could feel laggy because shadcn's pattern uses `focus:bg-accent`, which only fires once Radix has called `.focus()` on the item — a `pointermove → focus → React render` round-trip per row. Radix also sets `data-[highlighted]` synchronously on pointer-enter, which is the more responsive hook.

Switched the model rows and the footer to `data-[highlighted]:bg-accent` so the highlight is applied the instant the pointer crosses a row.

## Test Plan

- [ ] Open the model dropdown from either the import screen or the AddSource modal.
- [ ] Move the pointer across the three rows quickly — the blue highlight should follow without any visible delay.
- [ ] Hard reload the renderer first if you don't see the change (Vite HMR is flaky with newly-introduced Tailwind utility classes).