### PR TITLE
fix(ui): keep daily-activity radar inside the visible clock ring

### DIFF
--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -14,6 +14,11 @@ import {
   YAxis
 } from 'recharts'
 
+// Outer-ring radius (in px) shared by the visible 24-hour circle and the
+// radar chart underneath it. Keeping them equal makes the busiest species'
+// peaks land exactly on the ring instead of overflowing it.
+const CLOCK_OUTER_RADIUS_PX = 47
+
 const CircularTimeFilter = ({
   onChange,
   startTime = 6,
@@ -28,7 +33,7 @@ const CircularTimeFilter = ({
   const [end, setEnd] = useState(endTime)
   const [lastDragPosition, setLastDragPosition] = useState(null)
   const svgRef = useRef(null)
-  const radius = 47
+  const radius = CLOCK_OUTER_RADIUS_PX
   const padding = 16 // Padding leaves room for hour labels outside the circle
   const svgSize = radius * 2 + padding * 2 // Increase SVG size to accommodate padding
   const center = { x: radius + padding, y: radius + padding } // Adjust center coordinates
@@ -358,16 +363,13 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
     <div className="relative w-full h-full flex items-center justify-center" ref={chartRef}>
       <div className="relative h-full aspect-square">
         <ResponsiveContainer width="100%" height="100%">
-          <RadarChart data={formattedData} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+          <RadarChart
+            data={formattedData}
+            margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
+            outerRadius={CLOCK_OUTER_RADIUS_PX}
+          >
             <PolarGrid radialLines={false} polarRadius={[]} strokeWidth={1} />
             <PolarAngleAxis dataKey="name" tick={false} />
-            {/* <PolarRadiusAxis
-              angle={30}
-              domain={[0, 'auto']}
-              tick={false}
-              axisLine={false}
-              tickCount={5}
-            /> */}
             {selectedSpecies.map((species, index) => (
               <Radar
                 key={species.scientificName}


### PR DESCRIPTION
## Summary
- The hour-of-day polar plot in the day filter (left of the time filter on the Activity/Media tabs) was rendering the busiest species' peaks several pixels outside the visible blue ring.
- Cause: the ring is drawn at a hardcoded 47px from center inside `CircularTimeFilter`, but the radar underneath used Recharts' default outer radius (~80% of half the chart size, ~50–55px in the 180px-wide container).
- Fix: extract `CLOCK_OUTER_RADIUS_PX = 47` as a module-level constant in `clock.jsx`, share it between `CircularTimeFilter`'s `radius` and the `<RadarChart outerRadius=…>` prop. Now the maximum data value lands exactly on the ring.
- Also drop the dead commented-out `PolarRadiusAxis` block that's no longer needed.

## Test plan
- [x] `npm test` — 1346/1346 pass
- [x] `npm run lint` — 0 errors (only pre-existing warnings)
- [x] `prettier --write` on the file — no changes (already formatted)
- [ ] Visual check: open Activity tab, select a species with strong hour-of-day bias, confirm the radar curve's peak sits on the blue ring instead of outside it
- [ ] Visual check: same on the Media tab
- [ ] Visual check: select multiple species — confirm none overflow
- [ ] Visual check: toggle to X–Y line view and back — confirm the polar view still looks right