### PR TITLE
fix(overview): truncate species name row with ellipsis

### DIFF
--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -55,7 +55,7 @@ function SpeciesRow({
       >
         <HoverCard.Trigger asChild>
           <div className="flex items-center gap-3 flex-shrink-0">
-            <div className="w-80 flex-shrink-0">
+            <div className="w-80 flex-shrink-0 truncate">
               <span
                 className={`text-sm text-foreground font-medium ${showScientific ? 'capitalize' : ''}`}
               >


### PR DESCRIPTION
## Summary
- Long common + scientific name strings in the Overview tab's species list wrapped to a second line, breaking row alignment.
- Added Tailwind's `truncate` utility on the 320px name wrapper so both names stay on one line and overflow is clipped with an ellipsis.

## Test plan
- [x] Open a study whose species list contains long names (e.g. "Western European Hedgehog / Erinaceus europaeus")
- [x] Confirm rows render on a single line with `…` at the right edge instead of wrapping
- [x] Hover the row — HoverCard still appears with the full info
- [x] Shorter rows (e.g. "European Hare") render unchanged