### PR TITLE
fix(sources): drop misleading per-source deployment count

### DIFF
--- a/src/renderer/src/sources.jsx
+++ b/src/renderer/src/sources.jsx
@@ -45,7 +45,7 @@ function StatusCell({ row }) {
   return null
 }
 
-function MediaCounts({ imageCount, videoCount, deploymentCount }) {
+function MediaCounts({ imageCount, videoCount }) {
   const parts = []
   if (imageCount > 0) {
     parts.push(
@@ -58,13 +58,6 @@ function MediaCounts({ imageCount, videoCount, deploymentCount }) {
     parts.push(
       <span key="vid">
         <strong className="text-foreground">{videoCount.toLocaleString()}</strong> videos
-      </span>
-    )
-  }
-  if (deploymentCount > 0) {
-    parts.push(
-      <span key="dep">
-        {deploymentCount} deployment{deploymentCount !== 1 ? 's' : ''}
       </span>
     )
   }
@@ -199,11 +192,7 @@ function SourceRow({ source, importerName, studyName, expanded, onToggle }) {
           )}
         </div>
         <div className="flex items-center gap-4 ml-auto">
-          <MediaCounts
-            imageCount={source.imageCount}
-            videoCount={source.videoCount}
-            deploymentCount={mergedDeployments.length}
-          />
+          <MediaCounts imageCount={source.imageCount} videoCount={source.videoCount} />
           <div className="w-[200px] flex justify-end flex-shrink-0">
             <StatusCell row={source} />
           </div>
@@ -217,11 +206,7 @@ function SourceRow({ source, importerName, studyName, expanded, onToggle }) {
           >
             <div className="flex-1 min-w-[180px] text-sm text-foreground truncate">{d.label}</div>
             <div className="flex items-center gap-4 ml-auto">
-              <MediaCounts
-                imageCount={d.imageCount}
-                videoCount={d.videoCount}
-                deploymentCount={0}
-              />
+              <MediaCounts imageCount={d.imageCount} videoCount={d.videoCount} />
               <div className="w-[200px] flex justify-end flex-shrink-0">
                 <StatusCell row={d} />
               </div>


### PR DESCRIPTION
## Summary

- The Sources tab showed `X deployments` per source by grouping `media` rows by `(importFolder, deploymentID)`. Deployments declared in `deployments.csv` but with no associated media (common in CamtrapDP/LILA packages like Muntjac Antwerp and Alpine Tundra Rodents) were invisible to that count, so it disagreed with the Deployments tab.
- The Sources tab is about provenance — deployment counts already live in the Deployments tab — so the cleanest fix is to drop the per-source deployment count entirely rather than reconcile a duplicate metric.
- Each source row now shows just images / videos. Per-deployment expandable sub-rows are unchanged. Backend `getSourcesData` is untouched.

## Test plan

- [x] Open a CamtrapDP study with media-less deployments (e.g. Muntjac Antwerp) → Sources tab no longer shows a deployment count; Deployments tab is the source of truth.
- [x] Open a local-folder ("orphan") study → expanding a source still lists each deployment as a sub-row.
- [x] Mid-import in-flight bar still renders and progresses.