### PR TITLE
feat(activity): filter widgets by map viewport area

### DIFF
--- a/docs/specs/2026-05-29-activity-map-viewport-filter-design.md
+++ b/docs/specs/2026-05-29-activity-map-viewport-filter-design.md
@@ -1,0 +1,170 @@
+# Activity tab: map viewport as a spatial filter
+
+**Date:** 2026-05-29
+**Status:** Approved design, ready for implementation plan
+**Area:** Renderer (`src/renderer/src/activity.jsx`) + Main (`src/main/ipc/`, `src/main/database/queries/`)
+
+## Summary
+
+Add an on-demand geographic (bounding-box) filter to the Activity tab, driven by the
+map viewport. The user pans/zooms the Leaflet map, clicks a floating **"Filter to this
+area"** button, and the current viewport bounds are snapshotted as a filter. That
+bounding box is applied to the **species distribution list**, the **day activity chart**,
+and the **time activity chart**.
+
+The map itself keeps showing all markers (it remains a full overview / navigation
+surface) with a rectangle overlay marking the snapshotted area. An active-filter chip —
+mirroring the existing date-range chip — shows the filter is on and lets the user clear
+it.
+
+## Goals
+
+- Let users restrict the three side widgets to a chosen geographic region of the study.
+- Keep the interaction cheap: heavy sequence-aware queries (seconds on large studies)
+  recompute only when the user explicitly applies/clears the filter — never on every
+  pan/zoom frame.
+- Reuse existing filter conventions (the `null` sentinel, per-study persistence, the
+  active-filter chip, the Reset filters button) so the feature feels native.
+
+## Non-goals
+
+- No polygon / freehand region selection — bounding box only.
+- No GIS / R-tree / SpatiaLite extension.
+- No new database index (see Performance).
+- No filtering of the map's own pie-chart markers — the map stays a full overview.
+- Antimeridian-crossing viewports (west > east) are out of scope for v1.
+
+## Behaviour decisions (from brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| When does the filter apply? | **On demand** — only when the user clicks the button. |
+| Filter model | **Snapshot** — bounds frozen on apply; user can pan elsewhere while widgets stay filtered. |
+| Trigger UX | **Floating map button + active chip** (consistent with the date-range filter). |
+| Map markers under an active filter | **Always show all markers**; draw a rectangle overlay for the snapshotted area. |
+| Species distribution list | **Filtered too** (not just the activity charts). |
+| Geometry | **Bounding box** (NE/SW corners). |
+| Window/map resize | **Filter stays pinned** (snapshot); widgets do not recompute on resize. |
+
+## Architecture
+
+### State & data flow (`activity.jsx`)
+
+A new filter state lives alongside the existing `dateRange`, `chipSelection`/`arc`, and
+`selectedSpecies`:
+
+- `areaFilter: { north, south, east, west } | null`
+  - `null` is the "no filter" sentinel, matching the `[null, null]` convention used by
+    `dateRange`. When `null`, all queries behave exactly as today (zero regression).
+- Set by reading Leaflet's `map.getBounds()` when the floating button is clicked.
+- Cleared by the chip's ✕ or by the existing **Reset filters** button
+  (`handleResetFilters` is extended to also clear `areaFilter`).
+- Persisted per-study via a small `useAreaFilter(studyId)` hook (localStorage key
+  `areaFilter:${studyId}`), consistent with `useDateRange` / `useSequenceGap`.
+
+`areaFilter` becomes a new input to the relevant query keys and is passed to the queries
+below. Because `null` = "include everything", no new `enabled` gating is required — the
+queries gate the same way they do today.
+
+### Backend — optional bounding box on the sequence-aware queries
+
+All affected queries gain an **optional trailing `bbox` param** (`{ north, south, east,
+west }` or `null`). When `null`, behaviour is identical to today.
+
+| Query | Change |
+| --- | --- |
+| `getSequenceAwareSpeciesDistribution` | add `bbox` (needed for "filter species list too") |
+| `getSequenceAwareTimeseries` | add `bbox` |
+| `getSequenceAwareDailyActivity` | add `bbox` |
+| `getSequenceAwareHeatmap` | **unchanged** — map shows all markers |
+
+The SQL change is uniform. These queries already `INNER JOIN deployments d`, so the
+filter is a conditional clause appended only when `bbox` is provided:
+
+```sql
+AND d.latitude  BETWEEN :south AND :north
+AND d.longitude BETWEEN :west  AND :east
+```
+
+Threading follows the project's IPC pattern: query function → IPC handler
+(`src/main/ipc/...`) → preload (`window.api.*`) → React `useQuery`. `getSequenceAware*`
+distribution/timeseries/daily-activity handlers and their preload signatures each gain
+the optional `bbox` argument.
+
+> Note: `getSequenceAwareSpeciesDistribution` currently takes no spatial filter. The
+> species distribution **list** the widget renders is driven by this query (via
+> `speciesDistributionData` in `activity.jsx`), so the `bbox` must be threaded here for
+> the species list to reflect the filtered area. `getBestImagePerSpecies` (hover
+> thumbnails only) is **not** changed.
+
+### Frontend — map control, overlay, chip
+
+- **Floating button** overlaid on the map corner (Leaflet control or absolutely
+  positioned div over `MapContainer`), styled like the existing layer toggle. Label:
+  "Filter to this area." Enabled only when the current viewport differs from the applied
+  `areaFilter` by more than a tolerance (see Resize).
+- **Rectangle overlay**: when `areaFilter` is set, draw a Leaflet `Rectangle` at those
+  bounds so the snapshotted area is visible even after panning away. Drawn in geographic
+  coordinates, so Leaflet re-projects it automatically on pan/zoom/resize.
+- **Active chip**: reuse the date-filter chip pattern (`areaFilterLabel` like the
+  existing `dateFilterLabel`), e.g. "Area filter" with a ✕, wired into the same
+  filter-summary row.
+- **Reset filters**: `handleResetFilters` extended to clear `areaFilter`.
+
+### Resize behaviour
+
+`areaFilter` is stored as **geographic bounds**, frozen on apply. The visible geographic
+extent of the map depends on the container's pixel size at a given zoom, so resizing the
+window/map changes what's on screen but must **not** change the filter:
+
+- Widgets do **not** recompute on resize (avoids triggering multi-second heavy queries).
+- The rectangle overlay stays glued to the same lat/lng (Leaflet re-projects it),
+  rendered larger/smaller as appropriate.
+- The floating button's enabled/disabled state uses a **tolerance-based** comparison of
+  the current viewport vs. the applied bounds (mirroring the `isFullRange` 1-day
+  tolerance for dates), so trivial jitter/sub-pixel reprojection doesn't leave the button
+  perpetually enabled with a meaningless diff. After a resize that meaningfully changes
+  the visible extent, the button re-enables, inviting an optional re-snapshot — but
+  nothing happens unless the user clicks it.
+
+## Performance
+
+The largest real study (gmu8_leuven) has **2,704 deployments** vs **2.7M observations** —
+~1,000 observations per deployment. The deployment count is tiny; the observations join
+is the cost center.
+
+- **No GIS / R-tree** — built for 100k+ points where spatial pruning is the bottleneck.
+  Here a bbox scan over 2,704 deployment rows is sub-5ms regardless, and `loadExtension`
+  would complicate the Electron / Linux `afterPack` build for zero payoff.
+- **No new index** — ship without a migration. The bbox is one more `AND` inside queries
+  that already scan 2.7M observations and join deployments; the deployment-side filter is
+  rounding error against that join. Revisit only if profiling on a large study shows the
+  deployment scan actually matters. (Defensive option, deferred:
+  `CREATE INDEX idx_deployments_lat_lng ON deployments(latitude, longitude)`.)
+- **Query-plan verification**: the cheap win is to constrain the observations scan to the
+  matching deployments rather than scanning all observations and filtering deployments at
+  the end. In practice this is still just the conditional `AND` on the existing
+  `INNER JOIN deployments d`; SQLite's planner typically pushes it down. The implementer
+  should sanity-check the query plan on gmu8_leuven (e.g. `EXPLAIN QUERY PLAN`) to confirm
+  the bbox prunes before the heavy join. No structural rewrite required.
+
+## Testing
+
+- **Unit/integration** (`node --test`): for each of the three newly filtered query
+  functions (`getSequenceAwareSpeciesDistribution`, `getSequenceAwareTimeseries`,
+  `getSequenceAwareDailyActivity`), assert that:
+  1. a `bbox` excludes observations belonging to out-of-bounds deployments, and
+  2. a `null` bbox returns the full result (regression guard).
+  Use a temp SQLite fixture with deployments at known coordinates.
+- **E2E** (Playwright) — stretch / follow-up: apply the area filter, assert the species
+  count in the sidebar changes and the chip appears. Scoped as a stretch since map
+  interaction in Playwright is fiddly.
+
+## Affected files (anticipated)
+
+- `src/renderer/src/activity.jsx` — `areaFilter` state, query-key wiring, button/overlay/chip, `handleResetFilters`.
+- `src/renderer/src/hooks/useAreaFilter.js` — new per-study persistence hook (mirrors `useDateRange`).
+- `src/renderer/src/ui/speciesDistribution.jsx` — list reflects the filtered distribution data (data already passed down).
+- `src/preload/index.js` — optional `bbox` arg on three `getSequenceAware*` methods.
+- `src/main/ipc/sequences.js`, `src/main/ipc/species.js` — pass `bbox` through.
+- `src/main/database/queries/species.js` — conditional bbox clause in the three SQL builders.

--- a/src/main/database/queries/bbox.js
+++ b/src/main/database/queries/bbox.js
@@ -1,0 +1,23 @@
+/**
+ * Build the SQL fragment + bind params for an optional bounding-box filter on
+ * a deployments table alias. Returns an empty clause (and no params) when the
+ * bbox is null/undefined or crosses the antimeridian (west > east), which v1
+ * does not support — see docs/specs/2026-05-29-activity-map-viewport-filter-design.md.
+ *
+ * Params are returned in the order the placeholders appear: south, north,
+ * west, east (latitude BETWEEN south AND north, longitude BETWEEN west AND east).
+ *
+ * @param {{north:number, south:number, east:number, west:number}|null|undefined} bbox
+ * @param {string} alias - SQL alias of the deployments table (e.g. 'd')
+ * @returns {{clause: string, params: number[]}}
+ */
+export function buildBboxClause(bbox, alias) {
+  if (!bbox) return { clause: '', params: [] }
+  const { north, south, east, west } = bbox
+  if ([north, south, east, west].some((v) => typeof v !== 'number' || Number.isNaN(v))) {
+    return { clause: '', params: [] }
+  }
+  if (west > east) return { clause: '', params: [] }
+  const clause = `AND ${alias}.latitude BETWEEN ? AND ? AND ${alias}.longitude BETWEEN ? AND ?`
+  return { clause, params: [south, north, west, east] }
+}

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -17,10 +17,12 @@ import {
   lte,
   isNull,
   or,
-  notExists
+  notExists,
+  between
 } from 'drizzle-orm'
 import log from 'electron-log'
 import { getStudyIdFromPath } from './utils.js'
+import { buildBboxClause } from './bbox.js'
 import { BLANK_SENTINEL } from '../../../shared/constants.js'
 import { normalizeTimeRange } from './sequences.js'
 
@@ -232,7 +234,7 @@ export async function getSpeciesDistributionByMedia(dbPath) {
  * @returns {Promise<Array<{scientificName: string, count: number}>|null>}
  *   Sorted by count desc, or null if the caller must use the JS fallback.
  */
-export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
+export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox = null) {
   const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
   if (isPositiveGap) return null
 
@@ -240,6 +242,9 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
   const studyId = getStudyIdFromPath(dbPath)
   const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
   const sqlite = manager.getSqlite()
+
+  const { clause: bboxClause, params: bboxParams } = buildBboxClause(bbox, 'd')
+  const bboxJoin = bbox ? 'INNER JOIN deployments d ON m.deploymentID = d.deploymentID' : ''
 
   const useEventIDPath = gapSeconds === 0
 
@@ -263,7 +268,9 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
                    COUNT(o.observationID) AS cnt
               FROM observations o
               INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
               WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+                ${bboxClause}
               GROUP BY o.scientificName, m.mediaID
           ),
           classified AS (
@@ -299,7 +306,7 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
           GROUP BY scientificName ORDER BY count DESC
         `
         )
-        .all()
+        .all(...bboxParams)
     } else {
       // Per-media path: each media is its own sequence, so MAX == count per media,
       // SUM over media reduces to COUNT(observationID) per species.
@@ -310,12 +317,14 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds) {
                  COUNT(o.observationID) AS count
             FROM observations o
             INNER JOIN media m ON o.mediaID = m.mediaID
+            ${bboxJoin}
             WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+              ${bboxClause}
             GROUP BY o.scientificName
             ORDER BY count DESC
         `
         )
-        .all()
+        .all(...bboxParams)
     }
 
     const elapsed = Date.now() - startTime

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -368,7 +368,12 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
  * @param {number|null|undefined} gapSeconds
  * @returns {Promise<Array<{scientificName: string, weekStart: string, count: number}>|null>}
  */
-export async function getSequenceAwareTimeseriesSQL(dbPath, speciesNames = [], gapSeconds) {
+export async function getSequenceAwareTimeseriesSQL(
+  dbPath,
+  speciesNames = [],
+  gapSeconds,
+  bbox = null
+) {
   const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
   if (isPositiveGap) return null
 
@@ -386,6 +391,8 @@ export async function getSequenceAwareTimeseriesSQL(dbPath, speciesNames = [], g
   const speciesPlaceholders = regularSpecies.map(() => '?').join(',')
   const speciesFilter =
     regularSpecies.length > 0 ? `AND o.scientificName IN (${speciesPlaceholders})` : ''
+  const { clause: bboxClause, params: bboxParams } = buildBboxClause(bbox, 'd')
+  const bboxJoin = bbox ? 'INNER JOIN deployments d ON m.deploymentID = d.deploymentID' : ''
 
   try {
     let rows
@@ -400,9 +407,11 @@ export async function getSequenceAwareTimeseriesSQL(dbPath, speciesNames = [], g
                    COUNT(*) AS media_count
               FROM observations o
               INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
               WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
                 AND m.timestamp IS NOT NULL
                 ${speciesFilter}
+                ${bboxClause}
               GROUP BY o.scientificName, o.mediaID
           ),
           event_maxes AS (
@@ -416,7 +425,7 @@ export async function getSequenceAwareTimeseriesSQL(dbPath, speciesNames = [], g
             ORDER BY weekStart
         `
         )
-        .all(...regularSpecies)
+        .all(...regularSpecies, ...bboxParams)
     } else {
       rows = sqlite
         .prepare(
@@ -426,14 +435,16 @@ export async function getSequenceAwareTimeseriesSQL(dbPath, speciesNames = [], g
                  COUNT(o.observationID) AS count
             FROM observations o
             INNER JOIN media m ON o.mediaID = m.mediaID
+            ${bboxJoin}
             WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
               AND m.timestamp IS NOT NULL
               ${speciesFilter}
+              ${bboxClause}
             GROUP BY o.scientificName, weekStart
             ORDER BY weekStart
         `
         )
-        .all(...regularSpecies)
+        .all(...regularSpecies, ...bboxParams)
     }
 
     const elapsed = Date.now() - startTime

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -973,7 +973,8 @@ export async function getSequenceAwareDailyActivitySQL(
   speciesNames = [],
   startDate,
   endDate,
-  gapSeconds
+  gapSeconds,
+  bbox = null
 ) {
   const regularSpecies = speciesNames.filter((s) => s !== BLANK_SENTINEL)
   if (speciesNames.includes(BLANK_SENTINEL)) return null
@@ -984,6 +985,9 @@ export async function getSequenceAwareDailyActivitySQL(
   const studyId = getStudyIdFromPath(dbPath)
   const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
   const sqlite = manager.getSqlite()
+
+  const { clause: bboxClause, params: bboxParams } = buildBboxClause(bbox, 'd')
+  const bboxJoin = bbox ? 'INNER JOIN deployments d ON m.deploymentID = d.deploymentID' : ''
 
   const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
   const useEventIDPath = gapSeconds === 0
@@ -1010,9 +1014,11 @@ export async function getSequenceAwareDailyActivitySQL(
                    COUNT(*) AS media_count
               FROM observations o
               INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
               WHERE o.scientificName IN (${speciesPlaceholders})
                 AND m.timestamp IS NOT NULL
                 AND m.timestamp >= ? AND m.timestamp <= ?
+                ${bboxClause}
               GROUP BY o.scientificName, o.mediaID
           ),
           marked AS (
@@ -1047,7 +1053,7 @@ export async function getSequenceAwareDailyActivitySQL(
             ORDER BY hour
         `
         )
-        .all(...regularSpecies, startDate, endDate, gapSeconds)
+        .all(...regularSpecies, startDate, endDate, ...bboxParams, gapSeconds)
     } else if (useEventIDPath) {
       rows = sqlite
         .prepare(
@@ -1059,9 +1065,11 @@ export async function getSequenceAwareDailyActivitySQL(
                    COUNT(*) AS media_count
               FROM observations o
               INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
               WHERE o.scientificName IN (${speciesPlaceholders})
                 AND m.timestamp IS NOT NULL
                 AND m.timestamp >= ? AND m.timestamp <= ?
+                ${bboxClause}
               GROUP BY o.scientificName, o.mediaID
           ),
           event_maxes AS (
@@ -1075,7 +1083,7 @@ export async function getSequenceAwareDailyActivitySQL(
             ORDER BY hour
         `
         )
-        .all(...regularSpecies, startDate, endDate)
+        .all(...regularSpecies, startDate, endDate, ...bboxParams)
     } else {
       rows = sqlite
         .prepare(
@@ -1085,14 +1093,16 @@ export async function getSequenceAwareDailyActivitySQL(
                  COUNT(o.observationID) AS count
             FROM observations o
             INNER JOIN media m ON o.mediaID = m.mediaID
+            ${bboxJoin}
             WHERE o.scientificName IN (${speciesPlaceholders})
               AND m.timestamp IS NOT NULL
               AND m.timestamp >= ? AND m.timestamp <= ?
+              ${bboxClause}
             GROUP BY o.scientificName, hour
             ORDER BY hour
         `
         )
-        .all(...regularSpecies, startDate, endDate)
+        .all(...regularSpecies, startDate, endDate, ...bboxParams)
     }
 
     const elapsed = Date.now() - startTime

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -162,7 +162,7 @@ export async function getVehicleMediaCount(dbPath) {
  * @param {string} dbPath - Path to the SQLite database
  * @returns {Promise<Array>} - Array of { scientificName, mediaID, timestamp, deploymentID, eventID, fileMediatype, count }
  */
-export async function getSpeciesDistributionByMedia(dbPath) {
+export async function getSpeciesDistributionByMedia(dbPath, bbox = null) {
   const startTime = Date.now()
   log.info(`Querying species distribution by media from: ${dbPath}`)
 
@@ -171,7 +171,7 @@ export async function getSpeciesDistributionByMedia(dbPath) {
 
     const db = await getDrizzleDb(studyId, dbPath, { readonly: true })
 
-    const result = await db
+    let query = db
       .select({
         scientificName: observations.scientificName,
         mediaID: media.mediaID,
@@ -183,15 +183,19 @@ export async function getSpeciesDistributionByMedia(dbPath) {
       })
       .from(observations)
       .innerJoin(media, eq(observations.mediaID, media.mediaID))
-      .where(
-        and(
-          isNotNull(observations.scientificName),
-          ne(observations.scientificName, '')
-          // The scientificName filter already excludes empty-species rows
-          // (blank/unclassified/unknown/vehicle). See spec
-          // docs/specs/2026-05-04-empty-species-observations-design.md.
-        )
-      )
+
+    // The scientificName filter already excludes empty-species rows
+    // (blank/unclassified/unknown/vehicle). See spec
+    // docs/specs/2026-05-04-empty-species-observations-design.md.
+    const conditions = [isNotNull(observations.scientificName), ne(observations.scientificName, '')]
+    if (bbox && bbox.west <= bbox.east) {
+      query = query.innerJoin(deployments, eq(media.deploymentID, deployments.deploymentID))
+      conditions.push(between(deployments.latitude, bbox.south, bbox.north))
+      conditions.push(between(deployments.longitude, bbox.west, bbox.east))
+    }
+
+    const result = await query
+      .where(and(...conditions))
       .groupBy(observations.scientificName, media.mediaID)
       .orderBy(media.timestamp)
 
@@ -465,7 +469,7 @@ export async function getSequenceAwareTimeseriesSQL(
  * @param {Array<string>} speciesNames - List of scientific names to include
  * @returns {Promise<Array>} - Array of { scientificName, mediaID, timestamp, deploymentID, eventID, fileMediatype, weekStart, count }
  */
-export async function getSpeciesTimeseriesByMedia(dbPath, speciesNames = []) {
+export async function getSpeciesTimeseriesByMedia(dbPath, speciesNames = [], bbox = null) {
   const startTime = Date.now()
   log.info(`Querying species timeseries by media from: ${dbPath}`)
 
@@ -491,7 +495,7 @@ export async function getSpeciesTimeseriesByMedia(dbPath, speciesNames = []) {
       const weekStartColumn =
         sql`date(substr(${media.timestamp}, 1, 10), 'weekday 0', '-7 days')`.as('weekStart')
 
-      results = await db
+      let query = db
         .select({
           scientificName: observations.scientificName,
           mediaID: media.mediaID,
@@ -504,13 +508,20 @@ export async function getSpeciesTimeseriesByMedia(dbPath, speciesNames = []) {
         })
         .from(observations)
         .innerJoin(media, eq(observations.mediaID, media.mediaID))
-        .where(
-          and(
-            isNotNull(observations.scientificName),
-            ne(observations.scientificName, ''),
-            speciesCondition
-          )
-        )
+
+      const conditions = [
+        isNotNull(observations.scientificName),
+        ne(observations.scientificName, ''),
+        speciesCondition
+      ]
+      if (bbox && bbox.west <= bbox.east) {
+        query = query.innerJoin(deployments, eq(media.deploymentID, deployments.deploymentID))
+        conditions.push(between(deployments.latitude, bbox.south, bbox.north))
+        conditions.push(between(deployments.longitude, bbox.west, bbox.east))
+      }
+
+      results = await query
+        .where(and(...conditions))
         .groupBy(observations.scientificName, media.mediaID)
         .orderBy(media.timestamp)
     }

--- a/src/main/ipc/sequences.js
+++ b/src/main/ipc/sequences.js
@@ -47,7 +47,7 @@ export function registerSequencesIPCHandlers() {
    * @param {string} studyId - Study identifier
    * @param {number|null} [gapSeconds] - Optional gap threshold; fetched from metadata if not provided
    */
-  ipcMain.handle('sequences:get-species-distribution', async (_, studyId, gapSeconds) => {
+  ipcMain.handle('sequences:get-species-distribution', async (_, studyId, gapSeconds, bbox) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
       if (!dbPath || !existsSync(dbPath)) {
@@ -64,7 +64,8 @@ export function registerSequencesIPCHandlers() {
         type: 'species-distribution',
         dbPath,
         studyId,
-        gapSeconds
+        gapSeconds,
+        bbox
       })
       return { data }
     } catch (error) {
@@ -79,7 +80,7 @@ export function registerSequencesIPCHandlers() {
    * @param {Array<string>} speciesNames - Species to include in timeseries
    * @param {number|null} [gapSeconds] - Optional gap threshold; fetched from metadata if not provided
    */
-  ipcMain.handle('sequences:get-timeseries', async (_, studyId, speciesNames, gapSeconds) => {
+  ipcMain.handle('sequences:get-timeseries', async (_, studyId, speciesNames, gapSeconds, bbox) => {
     try {
       const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
       if (!dbPath || !existsSync(dbPath)) {
@@ -97,7 +98,8 @@ export function registerSequencesIPCHandlers() {
         dbPath,
         studyId,
         gapSeconds,
-        speciesNames: stripped
+        speciesNames: stripped,
+        bbox
       })
       return { data }
     } catch (error) {
@@ -170,7 +172,7 @@ export function registerSequencesIPCHandlers() {
    */
   ipcMain.handle(
     'sequences:get-daily-activity',
-    async (_, studyId, speciesNames, startDate, endDate, gapSeconds) => {
+    async (_, studyId, speciesNames, startDate, endDate, gapSeconds, bbox) => {
       try {
         const dbPath = getStudyDatabasePath(app.getPath('userData'), studyId)
         if (!dbPath || !existsSync(dbPath)) {
@@ -190,7 +192,8 @@ export function registerSequencesIPCHandlers() {
           gapSeconds,
           speciesNames: stripped,
           startDate,
-          endDate
+          endDate,
+          bbox
         })
         return { data }
       } catch (error) {

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -46,7 +46,8 @@ async function run() {
     startDate,
     endDate,
     timeRange,
-    includeNullTimestamps
+    includeNullTimestamps,
+    bbox
   } = workerData
 
   // Fetch gapSeconds from metadata if not provided
@@ -63,9 +64,9 @@ async function run() {
       // the final [{scientificName, count}] directly (83 rows, not 1.65M).
       // Returns null for positive gapSeconds, in which case we fall back to the
       // row-dump + JS sequence grouping below.
-      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds)
+      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds, bbox)
       if (fast !== null) return fast
-      const rawData = await getSpeciesDistributionByMedia(dbPath)
+      const rawData = await getSpeciesDistributionByMedia(dbPath, bbox)
       return calculateSequenceAwareSpeciesCounts(rawData, effectiveGapSeconds)
     }
     case 'timeseries': {
@@ -77,10 +78,11 @@ async function run() {
       const fastRows = await getSequenceAwareTimeseriesSQL(
         dbPath,
         speciesNames,
-        effectiveGapSeconds
+        effectiveGapSeconds,
+        bbox
       )
       if (fastRows !== null) return pivotPreAggregatedTimeseries(fastRows)
-      const rawData = await getSpeciesTimeseriesByMedia(dbPath, speciesNames)
+      const rawData = await getSpeciesTimeseriesByMedia(dbPath, speciesNames, bbox)
       return calculateSequenceAwareTimeseries(rawData, effectiveGapSeconds)
     }
     case 'heatmap': {
@@ -117,7 +119,8 @@ async function run() {
         speciesNames,
         startDate,
         endDate,
-        effectiveGapSeconds
+        effectiveGapSeconds,
+        bbox
       )
       return pivotPreAggregatedDailyActivity(rows || [], speciesNames)
     }

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -149,11 +149,22 @@ const api = {
   },
   // Sequence-aware species distribution APIs (pre-computed in main thread)
   // gapSeconds is fetched from study metadata in the backend
-  getSequenceAwareSpeciesDistribution: async (studyId) => {
-    return await electronAPI.ipcRenderer.invoke('sequences:get-species-distribution', studyId)
+  getSequenceAwareSpeciesDistribution: async (studyId, gapSeconds, bbox) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'sequences:get-species-distribution',
+      studyId,
+      gapSeconds,
+      bbox
+    )
   },
-  getSequenceAwareTimeseries: async (studyId, speciesNames) => {
-    return await electronAPI.ipcRenderer.invoke('sequences:get-timeseries', studyId, speciesNames)
+  getSequenceAwareTimeseries: async (studyId, speciesNames, gapSeconds, bbox) => {
+    return await electronAPI.ipcRenderer.invoke(
+      'sequences:get-timeseries',
+      studyId,
+      speciesNames,
+      gapSeconds,
+      bbox
+    )
   },
   getSequenceAwareHeatmap: async (
     studyId,
@@ -173,13 +184,22 @@ const api = {
       includeNullTimestamps
     )
   },
-  getSequenceAwareDailyActivity: async (studyId, speciesNames, startDate, endDate) => {
+  getSequenceAwareDailyActivity: async (
+    studyId,
+    speciesNames,
+    startDate,
+    endDate,
+    gapSeconds,
+    bbox
+  ) => {
     return await electronAPI.ipcRenderer.invoke(
       'sequences:get-daily-activity',
       studyId,
       speciesNames,
       startDate,
-      endDate
+      endDate,
+      gapSeconds,
+      bbox
     )
   },
   // Paginated sequences API for media gallery

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -99,21 +99,18 @@ function MapContextMenuController({ onContextMenu, mapRef }) {
   return null
 }
 
-// Floating top-center pill that toggles the map area filter, mirroring the
-// day-period chips: when no filter is active it snapshots the current
-// viewport bounds on click; when a filter IS active the pill turns blue and
-// clicking it clears the filter (always enabled so it can always be turned
-// off). The filter is a frozen snapshot — panning away after applying does
-// NOT recompute it; to filter a different area, clear then apply again.
+// Floating top-center pill for the map area filter. The pill body always
+// snapshots the current viewport bounds on click — so when a filter is
+// already active you can re-filter a freshly-panned area in one click (no
+// clear-first dance). When a filter IS active the pill turns blue and a ✕
+// appears inside it at the trailing edge; clicking the ✕ clears in one click
+// without re-applying. The filter is a frozen snapshot: panning after
+// applying does NOT recompute it until you click the pill again.
 function AreaFilterControl({ areaFilter, onApplyAreaFilter }) {
   const map = useMap()
   const active = !!areaFilter
 
-  const handleClick = () => {
-    if (active) {
-      onApplyAreaFilter(null)
-      return
-    }
+  const apply = () => {
     const b = map.getBounds()
     onApplyAreaFilter({
       north: b.getNorth(),
@@ -123,23 +120,44 @@ function AreaFilterControl({ areaFilter, onApplyAreaFilter }) {
     })
   }
 
+  const clear = (e) => {
+    e.stopPropagation()
+    onApplyAreaFilter(null)
+  }
+
   return (
     <div className="leaflet-top" style={{ left: '50%', transform: 'translateX(-50%)' }}>
       <div className="leaflet-control">
-        <button
-          type="button"
-          onClick={handleClick}
-          className={`flex items-center gap-1.5 h-7 px-3 rounded-full text-xs font-medium border shadow-sm transition-colors ${
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={apply}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') apply()
+          }}
+          className={`flex items-center gap-1.5 h-7 rounded-full text-xs font-medium border shadow-sm transition-colors cursor-pointer ${
+            active ? 'pl-3 pr-1.5' : 'px-3'
+          } ${
             active
               ? 'text-blue-600 bg-blue-50 border-blue-200 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:border-blue-500/30 dark:hover:bg-blue-500/25'
               : 'text-muted-foreground bg-card border-border hover:bg-accent'
           }`}
-          aria-label={active ? 'Clear area filter' : 'Filter to this area'}
+          aria-label="Filter to this area"
           aria-pressed={active}
         >
-          {active ? <X size={14} /> : <MapPin size={14} />}
-          {active ? 'Clear area filter' : 'Filter to this area'}
-        </button>
+          <MapPin size={14} />
+          Filter to this area
+          {active && (
+            <button
+              type="button"
+              onClick={clear}
+              className="flex items-center justify-center h-5 w-5 rounded-full hover:bg-blue-200/60 dark:hover:bg-blue-500/30 transition-colors"
+              aria-label="Clear area filter"
+            >
+              <X size={13} />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -36,6 +36,7 @@ import { getTopNonHumanSpecies } from './utils/speciesUtils'
 import { useSequenceGap } from './hooks/useSequenceGap'
 import { useShowFilterCharts } from './hooks/useShowFilterCharts'
 import { useDateRange } from './hooks/useDateRange'
+import { useAreaFilter } from './hooks/useAreaFilter'
 
 // Inject the keyframes used by the skeleton markers once per page load.
 // Guarded by an id check so HMR / multiple SpeciesMap mounts don't re-append
@@ -631,11 +632,13 @@ export default function Activity({ studyData, studyId }) {
       d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
     return `${fmt(dateRange[0])} → ${fmt(dateRange[1])}`
   }, [hasDateFilter, dateRange])
+  const { areaFilter, setAreaFilter } = useAreaFilter(actualStudyId)
   const handleResetFilters = useCallback(() => {
     setChipSelection(new Set(ALL_CHIPS_SELECTED))
     setArc({ start: 0, end: 24 })
     setDateRange([null, null])
-  }, [setDateRange])
+    setAreaFilter(null)
+  }, [setDateRange, setAreaFilter])
   const { importStatus } = useImportStatus(actualStudyId, 5000)
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
@@ -676,9 +679,13 @@ export default function Activity({ studyData, studyId }) {
   // Fetch sequence-aware species distribution data
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)
   const { data: speciesDistributionData, error: speciesDistributionError } = useQuery({
-    queryKey: ['sequenceAwareSpeciesDistribution', actualStudyId, sequenceGap],
+    queryKey: ['sequenceAwareSpeciesDistribution', actualStudyId, sequenceGap, areaFilter],
     queryFn: async () => {
-      const response = await window.api.getSequenceAwareSpeciesDistribution(actualStudyId)
+      const response = await window.api.getSequenceAwareSpeciesDistribution(
+        actualStudyId,
+        sequenceGap,
+        areaFilter
+      )
       if (response.error) throw new Error(response.error)
       return response.data
     },
@@ -716,9 +723,20 @@ export default function Activity({ studyData, studyId }) {
   // Fetch sequence-aware timeseries data
   // sequenceGap in queryKey ensures refetch when slider changes (backend fetches from metadata)
   const { data: timeseriesQueryData } = useQuery({
-    queryKey: ['sequenceAwareTimeseries', actualStudyId, [...speciesNames].sort(), sequenceGap],
+    queryKey: [
+      'sequenceAwareTimeseries',
+      actualStudyId,
+      [...speciesNames].sort(),
+      sequenceGap,
+      areaFilter
+    ],
     queryFn: async () => {
-      const response = await window.api.getSequenceAwareTimeseries(actualStudyId, speciesNames)
+      const response = await window.api.getSequenceAwareTimeseries(
+        actualStudyId,
+        speciesNames,
+        sequenceGap,
+        areaFilter
+      )
       if (response.error) throw new Error(response.error)
       return response.data
     },
@@ -829,14 +847,17 @@ export default function Activity({ studyData, studyId }) {
       [...speciesNames].sort(),
       effectiveStart?.toISOString(),
       effectiveEnd?.toISOString(),
-      sequenceGap
+      sequenceGap,
+      areaFilter
     ],
     queryFn: async () => {
       const response = await window.api.getSequenceAwareDailyActivity(
         actualStudyId,
         speciesNames,
         effectiveStart?.toISOString(),
-        effectiveEnd?.toISOString()
+        effectiveEnd?.toISOString(),
+        sequenceGap,
+        areaFilter
       )
       if (response.error) throw new Error(response.error)
       return response.data

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -4,7 +4,15 @@ import 'leaflet/dist/leaflet.css'
 import { MapPin } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { LayersControl, MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet'
+import {
+  LayersControl,
+  MapContainer,
+  Marker,
+  Rectangle,
+  TileLayer,
+  useMap,
+  useMapEvents
+} from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
@@ -91,6 +99,63 @@ function MapContextMenuController({ onContextMenu, mapRef }) {
   return null
 }
 
+// Floating map control that snapshots the current viewport bounds as the
+// area filter on demand. The button is enabled only when the live viewport
+// differs from the applied filter by more than a tolerance — so trivial
+// pan/zoom jitter and sub-pixel reprojection (e.g. on window resize) don't
+// leave it perpetually enabled with a meaningless diff. The filter itself is
+// a frozen snapshot: panning away after applying does NOT recompute it.
+function AreaFilterControl({ areaFilter, onApplyAreaFilter }) {
+  const map = useMap()
+  const [viewportDiffers, setViewportDiffers] = useState(true)
+
+  const TOL = 1e-4
+  const recompute = useCallback(() => {
+    if (!areaFilter) {
+      setViewportDiffers(true)
+      return
+    }
+    const b = map.getBounds()
+    const differs =
+      Math.abs(b.getNorth() - areaFilter.north) > TOL ||
+      Math.abs(b.getSouth() - areaFilter.south) > TOL ||
+      Math.abs(b.getEast() - areaFilter.east) > TOL ||
+      Math.abs(b.getWest() - areaFilter.west) > TOL
+    setViewportDiffers(differs)
+  }, [map, areaFilter])
+
+  useEffect(() => {
+    recompute()
+    map.on('moveend zoomend resize', recompute)
+    return () => map.off('moveend zoomend resize', recompute)
+  }, [map, recompute])
+
+  const apply = () => {
+    const b = map.getBounds()
+    onApplyAreaFilter({
+      north: b.getNorth(),
+      south: b.getSouth(),
+      east: b.getEast(),
+      west: b.getWest()
+    })
+  }
+
+  return (
+    <div className="leaflet-bottom leaflet-left">
+      <div className="leaflet-control leaflet-bar">
+        <button
+          type="button"
+          onClick={apply}
+          disabled={!viewportDiffers}
+          className="px-2 py-1 text-xs bg-card text-foreground disabled:opacity-50"
+        >
+          Filter to this area
+        </button>
+      </div>
+    </div>
+  )
+}
+
 const slugifyForFilename = (s) =>
   (s || '')
     .toLowerCase()
@@ -123,7 +188,9 @@ const SpeciesMap = ({
   geoKey,
   studyId,
   studyName,
-  scientificToCommon
+  scientificToCommon,
+  areaFilter,
+  onApplyAreaFilter
 }) => {
   // Persist map layer selection per study
   const mapLayerKey = `mapLayer:${studyId}`
@@ -436,6 +503,17 @@ const SpeciesMap = ({
       <MapContainer bounds={bounds} boundsOptions={boundsOptions} className="rounded w-full h-full">
         <HideLeafletAttribution />
         <MapContextMenuController onContextMenu={setContextMenu} mapRef={mapRef} />
+        <AreaFilterControl areaFilter={areaFilter} onApplyAreaFilter={onApplyAreaFilter} />
+        {areaFilter && (
+          <Rectangle
+            bounds={[
+              [areaFilter.south, areaFilter.west],
+              [areaFilter.north, areaFilter.east]
+            ]}
+            pathOptions={{ color: '#2563eb', weight: 1, fillOpacity: 0.05 }}
+            interactive={false}
+          />
+        )}
         <LayersControl position="topright">
           <LayersControl.BaseLayer name="Satellite" checked={selectedLayer === 'Satellite'}>
             <TileLayer
@@ -633,6 +711,8 @@ export default function Activity({ studyData, studyId }) {
     return `${fmt(dateRange[0])} → ${fmt(dateRange[1])}`
   }, [hasDateFilter, dateRange])
   const { areaFilter, setAreaFilter } = useAreaFilter(actualStudyId)
+  const areaFilterLabel = useMemo(() => (areaFilter ? 'Map area' : null), [areaFilter])
+  const isFilteringWithArea = isFiltering || !!areaFilter
   const handleResetFilters = useCallback(() => {
     setChipSelection(new Set(ALL_CHIPS_SELECTED))
     setArc({ start: 0, end: 24 })
@@ -917,6 +997,8 @@ export default function Activity({ studyData, studyId }) {
                     studyName={studyData?.name}
                     geoKey={geoKey}
                     scientificToCommon={scientificToCommon}
+                    areaFilter={areaFilter}
+                    onApplyAreaFilter={setAreaFilter}
                   />
                 )}
               {heatmapStatus === 'noData' && !isHeatmapLoading && (
@@ -945,9 +1027,10 @@ export default function Activity({ studyData, studyId }) {
                       // once we've confirmed the study has no timestamps
                       // (ENA24, Biome Health Project, etc).
                       hasTemporalData={hasTemporalData || timeseriesQueryData === undefined}
-                      isFiltering={isFiltering}
+                      isFiltering={isFilteringWithArea}
                       dayFilterLabel={dayFilterLabel}
                       dateFilterLabel={dateFilterLabel}
+                      areaFilterLabel={areaFilterLabel}
                       onResetFilters={handleResetFilters}
                     />
                   </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -169,6 +169,18 @@ const slugifyForFilename = (s) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '')
 
+// Markers whose deployment falls outside the active area filter are kept on the
+// map (so the user can still see where to widen the selection) but visually
+// de-emphasized to OUTSIDE_OPACITY. With no filter, everything is fully opaque.
+const OUTSIDE_OPACITY = 0.35
+const isInsideArea = (lat, lng, area) => {
+  if (!area) return true
+  const { north, south, east, west } = area
+  if ([north, south, east, west].some((v) => typeof v !== 'number' || Number.isNaN(v))) return true
+  if (west > east) return true // antimeridian box: don't de-emphasize (matches buildBboxClause no-op)
+  return lat >= south && lat <= north && lng >= west && lng <= east
+}
+
 // SpeciesMap component.
 //
 // Renders the leaflet map in two progressive modes so the user sees something
@@ -271,98 +283,105 @@ const SpeciesMap = ({
       })
     }
   }, [studyId, studyName])
-  // Function to create a pie chart icon
-  const createPieChartIcon = (counts) => {
-    const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
-    const size = Math.min(60, Math.max(10, Math.sqrt(total) * 3)) // Scale dot size based on count
+  // Function to create a pie chart icon. Memoized so re-renders (e.g. toggling
+  // the area filter) don't rebuild every SVG — building the SVG + serializing +
+  // base64-encoding it for ~hundreds of points on every render is what froze the
+  // UI thread. `opacity` < 1 fades the whole pie (used for de-emphasized clusters).
+  const createPieChartIcon = useCallback(
+    (counts, opacity = 1) => {
+      const total = Object.values(counts).reduce((sum, count) => sum + count, 0)
+      const size = Math.min(60, Math.max(10, Math.sqrt(total) * 3)) // Scale dot size based on count
 
-    const createSVG = () => {
-      // Create SVG for pie chart
-      const svgNS = 'http://www.w3.org/2000/svg'
-      const svg = document.createElementNS(svgNS, 'svg')
-      svg.setAttribute('width', size)
-      svg.setAttribute('height', size)
-      svg.setAttribute('viewBox', `0 0 100 100`)
+      const createSVG = () => {
+        // Create SVG for pie chart
+        const svgNS = 'http://www.w3.org/2000/svg'
+        const svg = document.createElementNS(svgNS, 'svg')
+        svg.setAttribute('width', size)
+        svg.setAttribute('height', size)
+        svg.setAttribute('viewBox', `0 0 100 100`)
+        if (opacity < 1) svg.setAttribute('opacity', String(opacity))
 
-      // Add a circle background - only needed for multiple species
-      if (Object.keys(counts).length > 1) {
-        const circle = document.createElementNS(svgNS, 'circle')
-        circle.setAttribute('cx', '50')
-        circle.setAttribute('cy', '50')
-        circle.setAttribute('r', '50')
-        circle.setAttribute('fill', 'white')
-        svg.appendChild(circle)
-      }
+        // Add a circle background - only needed for multiple species
+        if (Object.keys(counts).length > 1) {
+          const circle = document.createElementNS(svgNS, 'circle')
+          circle.setAttribute('cx', '50')
+          circle.setAttribute('cy', '50')
+          circle.setAttribute('r', '50')
+          circle.setAttribute('fill', 'white')
+          svg.appendChild(circle)
+        }
 
-      // Draw pie slices
-      let startAngle = 0
-      const colors = selectedSpecies.map((_, i) => palette[i % palette.length])
+        // Draw pie slices
+        let startAngle = 0
+        const colors = selectedSpecies.map((_, i) => palette[i % palette.length])
 
-      // Use the same radius for pie slices as for the circle
-      const radius = 50
+        // Use the same radius for pie slices as for the circle
+        const radius = 50
 
-      // Special case for single species - draw a full circle
-      if (Object.keys(counts).length === 1) {
-        const species = Object.keys(counts)[0]
-        const index = selectedSpecies.findIndex((s) => s.scientificName === species)
-        const colorIndex = index >= 0 ? index : 0
-        const color = colors[colorIndex]
-
-        const circle = document.createElementNS(svgNS, 'circle')
-        circle.setAttribute('cx', '50')
-        circle.setAttribute('cy', '50')
-        circle.setAttribute('r', '50')
-        circle.setAttribute('fill', color)
-        svg.appendChild(circle)
-      } else {
-        // Multiple species - draw pie slices
-        Object.entries(counts).forEach(([species, count]) => {
+        // Special case for single species - draw a full circle
+        if (Object.keys(counts).length === 1) {
+          const species = Object.keys(counts)[0]
           const index = selectedSpecies.findIndex((s) => s.scientificName === species)
-          if (index < 0) return // Skip if species not in selectedSpecies
+          const colorIndex = index >= 0 ? index : 0
+          const color = colors[colorIndex]
 
-          const portion = count / total
-          const endAngle = startAngle + portion * 2 * Math.PI
-          const color = colors[index]
+          const circle = document.createElementNS(svgNS, 'circle')
+          circle.setAttribute('cx', '50')
+          circle.setAttribute('cy', '50')
+          circle.setAttribute('r', '50')
+          circle.setAttribute('fill', color)
+          svg.appendChild(circle)
+        } else {
+          // Multiple species - draw pie slices
+          Object.entries(counts).forEach(([species, count]) => {
+            const index = selectedSpecies.findIndex((s) => s.scientificName === species)
+            if (index < 0) return // Skip if species not in selectedSpecies
 
-          const largeArcFlag = portion > 0.5 ? 1 : 0
+            const portion = count / total
+            const endAngle = startAngle + portion * 2 * Math.PI
+            const color = colors[index]
 
-          const x1 = 50 + radius * Math.sin(startAngle)
-          const y1 = 50 - radius * Math.cos(startAngle)
-          const x2 = 50 + radius * Math.sin(endAngle)
-          const y2 = 50 - radius * Math.cos(endAngle)
+            const largeArcFlag = portion > 0.5 ? 1 : 0
 
-          const pathData = [
-            `M 50 50`,
-            `L ${x1} ${y1}`,
-            `A ${radius} ${radius} 0 ${largeArcFlag} 1 ${x2} ${y2}`,
-            `Z`
-          ].join(' ')
+            const x1 = 50 + radius * Math.sin(startAngle)
+            const y1 = 50 - radius * Math.cos(startAngle)
+            const x2 = 50 + radius * Math.sin(endAngle)
+            const y2 = 50 - radius * Math.cos(endAngle)
 
-          const path = document.createElementNS(svgNS, 'path')
-          path.setAttribute('d', pathData)
-          path.setAttribute('fill', color)
-          path.setAttribute('stroke', color) // Match stroke color to fill color
-          path.setAttribute('stroke-width', '0.5') // Very thin stroke just to smooth edges
-          svg.appendChild(path)
+            const pathData = [
+              `M 50 50`,
+              `L ${x1} ${y1}`,
+              `A ${radius} ${radius} 0 ${largeArcFlag} 1 ${x2} ${y2}`,
+              `Z`
+            ].join(' ')
 
-          startAngle = endAngle
-        })
+            const path = document.createElementNS(svgNS, 'path')
+            path.setAttribute('d', pathData)
+            path.setAttribute('fill', color)
+            path.setAttribute('stroke', color) // Match stroke color to fill color
+            path.setAttribute('stroke-width', '0.5') // Very thin stroke just to smooth edges
+            svg.appendChild(path)
+
+            startAngle = endAngle
+          })
+        }
+
+        return svg
       }
 
-      return svg
-    }
+      const svgElement = createSVG()
+      const svgString = new XMLSerializer().serializeToString(svgElement)
+      const dataUrl = `data:image/svg+xml;base64,${btoa(svgString)}`
 
-    const svgElement = createSVG()
-    const svgString = new XMLSerializer().serializeToString(svgElement)
-    const dataUrl = `data:image/svg+xml;base64,${btoa(svgString)}`
-
-    return L.icon({
-      iconUrl: dataUrl,
-      iconSize: [size, size],
-      iconAnchor: [size / 2, size / 2],
-      popupAnchor: [0, -size / 2]
-    })
-  }
+      return L.icon({
+        iconUrl: dataUrl,
+        iconSize: [size, size],
+        iconAnchor: [size / 2, size / 2],
+        popupAnchor: [0, -size / 2]
+      })
+    },
+    [selectedSpecies, palette]
+  )
 
   // Render the React MarkerHoverCard to an HTML string. Leaflet's tooltip API
   // takes raw HTML, so we serialize the JSX once per call. Using a React
@@ -379,7 +398,9 @@ const SpeciesMap = ({
       />
     )
 
-  // PieChartMarker component with tooltip binding
+  // PieChartMarker component with tooltip binding. Out-of-area de-emphasis is
+  // applied imperatively (see the opacity effect below) rather than via an
+  // `opacity` prop, so toggling the area filter never re-renders these markers.
   function PieChartMarker({ point, icon }) {
     const markerRef = useRef(null)
 
@@ -409,8 +430,10 @@ const SpeciesMap = ({
     )
   }
 
-  // Process data points
-  const processPointData = () => {
+  // Process data points. Memoized on the underlying data/species so the point
+  // set — and the `counts` object identities the tooltip effect depends on —
+  // stay stable across re-renders (e.g. when the area filter toggles).
+  const locationPoints = useMemo(() => {
     const locations = {}
 
     // Combine data from all species
@@ -433,9 +456,42 @@ const SpeciesMap = ({
     })
 
     return Object.values(locations)
-  }
+  }, [heatmapData, selectedSpecies])
 
-  const locationPoints = processPointData()
+  // Pie icons are expensive (SVG build + serialize + base64). Memoize them on the
+  // data — crucially NOT on areaFilter — so applying/clearing the area filter
+  // never rebuilds them; only the cheap per-marker opacity changes.
+  const pieIcons = useMemo(
+    () => locationPoints.map((point) => createPieChartIcon(point.counts)),
+    [locationPoints, createPieChartIcon]
+  )
+
+  // Memoize the marker elements so they are NOT recreated/reconciled when the
+  // area filter toggles (only when the underlying data changes). Recreating
+  // ~hundreds of react-leaflet markers per render is the bulk of the freeze.
+  const markerElements = useMemo(
+    () =>
+      locationPoints.map((point, index) => (
+        <PieChartMarker key={index} point={point} icon={pieIcons[index]} />
+      )),
+    [locationPoints, pieIcons]
+  )
+
+  // De-emphasize markers outside the area filter imperatively: set each marker's
+  // opacity directly on the Leaflet layer and re-fade the cluster icons. This
+  // avoids touching the React tree, so applying/clearing the filter is cheap.
+  const pieClusterRef = useRef(null)
+  useEffect(() => {
+    const group = pieClusterRef.current
+    if (!group) return
+    group.getLayers().forEach((layer) => {
+      const ll = layer.getLatLng?.()
+      if (ll && layer.setOpacity) {
+        layer.setOpacity(isInsideArea(ll.lat, ll.lng, areaFilter) ? 1 : OUTSIDE_OPACITY)
+      }
+    })
+    group.refreshClusters?.()
+  }, [areaFilter, markerElements])
 
   // Bounds derive from deploymentLocations, not heatmapData, so the initial
   // viewport is fixed from the moment the map mounts — it doesn't shift
@@ -560,6 +616,7 @@ const SpeciesMap = ({
               </MarkerClusterGroup>
             ) : (
               <MarkerClusterGroup
+                ref={pieClusterRef}
                 key={`pies:${geoKey}`}
                 chunkedLoading
                 showCoverageOnHover={false}
@@ -569,6 +626,13 @@ const SpeciesMap = ({
                 iconCreateFunction={(cluster) => {
                   // Get all markers in this cluster
                   const markers = cluster.getAllChildMarkers()
+
+                  // A cluster is de-emphasized only when ALL its markers fall
+                  // outside the area filter; any inside marker keeps it full.
+                  const anyInside = markers.some((m) => {
+                    const ll = m.getLatLng()
+                    return isInsideArea(ll.lat, ll.lng, areaFilter)
+                  })
 
                   // Combine counts from all markers
                   const combinedCounts = {}
@@ -604,16 +668,10 @@ const SpeciesMap = ({
                     className: 'species-map-tooltip'
                   })
 
-                  return createPieChartIcon(filteredCounts)
+                  return createPieChartIcon(filteredCounts, anyInside ? 1 : OUTSIDE_OPACITY)
                 }}
               >
-                {locationPoints.map((point, index) => (
-                  <PieChartMarker
-                    key={index}
-                    point={point}
-                    icon={createPieChartIcon(point.counts)}
-                  />
-                ))}
+                {markerElements}
               </MarkerClusterGroup>
             )}
           </LayersControl.Overlay>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -1,7 +1,7 @@
 import * as htmlToImage from 'html-to-image'
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
-import { MapPin } from 'lucide-react'
+import { MapPin, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import {
@@ -99,38 +99,21 @@ function MapContextMenuController({ onContextMenu, mapRef }) {
   return null
 }
 
-// Floating map control that snapshots the current viewport bounds as the
-// area filter on demand. The button is enabled only when the live viewport
-// differs from the applied filter by more than a tolerance — so trivial
-// pan/zoom jitter and sub-pixel reprojection (e.g. on window resize) don't
-// leave it perpetually enabled with a meaningless diff. The filter itself is
-// a frozen snapshot: panning away after applying does NOT recompute it.
+// Floating top-center pill that toggles the map area filter, mirroring the
+// day-period chips: when no filter is active it snapshots the current
+// viewport bounds on click; when a filter IS active the pill turns blue and
+// clicking it clears the filter (always enabled so it can always be turned
+// off). The filter is a frozen snapshot — panning away after applying does
+// NOT recompute it; to filter a different area, clear then apply again.
 function AreaFilterControl({ areaFilter, onApplyAreaFilter }) {
   const map = useMap()
-  const [viewportDiffers, setViewportDiffers] = useState(true)
+  const active = !!areaFilter
 
-  const TOL = 1e-4
-  const recompute = useCallback(() => {
-    if (!areaFilter) {
-      setViewportDiffers(true)
+  const handleClick = () => {
+    if (active) {
+      onApplyAreaFilter(null)
       return
     }
-    const b = map.getBounds()
-    const differs =
-      Math.abs(b.getNorth() - areaFilter.north) > TOL ||
-      Math.abs(b.getSouth() - areaFilter.south) > TOL ||
-      Math.abs(b.getEast() - areaFilter.east) > TOL ||
-      Math.abs(b.getWest() - areaFilter.west) > TOL
-    setViewportDiffers(differs)
-  }, [map, areaFilter])
-
-  useEffect(() => {
-    recompute()
-    map.on('moveend zoomend resize', recompute)
-    return () => map.off('moveend zoomend resize', recompute)
-  }, [map, recompute])
-
-  const apply = () => {
     const b = map.getBounds()
     onApplyAreaFilter({
       north: b.getNorth(),
@@ -141,15 +124,21 @@ function AreaFilterControl({ areaFilter, onApplyAreaFilter }) {
   }
 
   return (
-    <div className="leaflet-bottom leaflet-left">
-      <div className="leaflet-control leaflet-bar">
+    <div className="leaflet-top" style={{ left: '50%', transform: 'translateX(-50%)' }}>
+      <div className="leaflet-control">
         <button
           type="button"
-          onClick={apply}
-          disabled={!viewportDiffers}
-          className="px-2 py-1 text-xs bg-card text-foreground disabled:opacity-50"
+          onClick={handleClick}
+          className={`flex items-center gap-1.5 h-7 px-3 rounded-full text-xs font-medium border shadow-sm transition-colors ${
+            active
+              ? 'text-blue-600 bg-blue-50 border-blue-200 hover:bg-blue-100 dark:text-blue-400 dark:bg-blue-500/15 dark:border-blue-500/30 dark:hover:bg-blue-500/25'
+              : 'text-muted-foreground bg-card border-border hover:bg-accent'
+          }`}
+          aria-label={active ? 'Clear area filter' : 'Filter to this area'}
+          aria-pressed={active}
         >
-          Filter to this area
+          {active ? <X size={14} /> : <MapPin size={14} />}
+          {active ? 'Clear area filter' : 'Filter to this area'}
         </button>
       </div>
     </div>

--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -700,7 +700,12 @@ export default function Activity({ studyData, studyId }) {
     return `${fmt(dateRange[0])} → ${fmt(dateRange[1])}`
   }, [hasDateFilter, dateRange])
   const { areaFilter, setAreaFilter } = useAreaFilter(actualStudyId)
-  const areaFilterLabel = useMemo(() => (areaFilter ? 'Map area' : null), [areaFilter])
+  const areaFilterLabel = useMemo(() => {
+    if (!areaFilter) return null
+    const lat = (v) => `${Math.abs(v).toFixed(2)}°${v >= 0 ? 'N' : 'S'}`
+    const lng = (v) => `${Math.abs(v).toFixed(2)}°${v >= 0 ? 'E' : 'W'}`
+    return `${lat(areaFilter.south)}–${lat(areaFilter.north)}, ${lng(areaFilter.west)}–${lng(areaFilter.east)}`
+  }, [areaFilter])
   const isFilteringWithArea = isFiltering || !!areaFilter
   const handleResetFilters = useCallback(() => {
     setChipSelection(new Set(ALL_CHIPS_SELECTED))

--- a/src/renderer/src/hooks/useAreaFilter.js
+++ b/src/renderer/src/hooks/useAreaFilter.js
@@ -1,0 +1,68 @@
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+
+const storageKey = (studyId) => `areaFilter:${studyId}`
+
+function readFromStorage(studyId) {
+  try {
+    const raw = localStorage.getItem(storageKey(studyId))
+    if (raw === null) return null
+    const parsed = JSON.parse(raw)
+    if (
+      !parsed ||
+      typeof parsed.north !== 'number' ||
+      typeof parsed.south !== 'number' ||
+      typeof parsed.east !== 'number' ||
+      typeof parsed.west !== 'number'
+    ) {
+      return null
+    }
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Per-study persistence for the Activity map's bounding-box area filter.
+ * Mirrors {@link useDateRange}: backed by localStorage, broadcast through
+ * the React Query cache so the value survives tab navigation.
+ *
+ * Returns `null` when no area filter is set (the "no filter" sentinel that
+ * downstream queries treat as "include everything").
+ *
+ * @param {string} studyId
+ * @returns {{ areaFilter: {north:number,south:number,east:number,west:number}|null, setAreaFilter: (next: object|null) => void }}
+ */
+export function useAreaFilter(studyId) {
+  const queryClient = useQueryClient()
+  const queryKey = useMemo(() => ['areaFilter', studyId], [studyId])
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn: () => readFromStorage(studyId),
+    enabled: !!studyId,
+    staleTime: Infinity,
+    initialData: () => readFromStorage(studyId)
+  })
+
+  const areaFilter = data ?? null
+
+  const setAreaFilter = useCallback(
+    (next) => {
+      queryClient.setQueryData(queryKey, next)
+      try {
+        if (next === null) {
+          localStorage.removeItem(storageKey(studyId))
+        } else {
+          localStorage.setItem(storageKey(studyId), JSON.stringify(next))
+        }
+      } catch {
+        // ignore quota / disabled storage
+      }
+    },
+    [queryClient, queryKey, studyId]
+  )
+
+  return { areaFilter, setAreaFilter }
+}

--- a/src/renderer/src/ui/FilterChartsToggle.jsx
+++ b/src/renderer/src/ui/FilterChartsToggle.jsx
@@ -22,6 +22,7 @@ export default function FilterChartsToggle({
   isFiltering = false,
   dayFilterLabel = null,
   dateFilterLabel = null,
+  areaFilterLabel = null,
   onResetFilters = null
 }) {
   const { showFilterCharts, setShowFilterCharts } = useShowFilterCharts(studyId)
@@ -70,7 +71,7 @@ export default function FilterChartsToggle({
           <p className="text-muted-foreground leading-relaxed">
             Daily-activity clock and timeline filters.
           </p>
-          {isFiltering && (dayFilterLabel || dateFilterLabel) && (
+          {isFiltering && (dayFilterLabel || dateFilterLabel || areaFilterLabel) && (
             <ul className="mt-3 pt-3 border-t border-border space-y-1.5 text-popover-foreground/90 leading-snug">
               {dayFilterLabel && (
                 <li className="flex gap-2">
@@ -82,6 +83,12 @@ export default function FilterChartsToggle({
                 <li className="flex gap-2">
                   <span className="text-muted-foreground shrink-0">Date range</span>
                   <span className="flex-1">{dateFilterLabel}</span>
+                </li>
+              )}
+              {areaFilterLabel && (
+                <li className="flex gap-2">
+                  <span className="text-muted-foreground shrink-0">Map area</span>
+                  <span className="flex-1">{areaFilterLabel}</span>
                 </li>
               )}
             </ul>

--- a/test/integration/queries/bbox-filter.test.js
+++ b/test/integration/queries/bbox-filter.test.js
@@ -68,3 +68,14 @@ test('species counts: bbox restricts to in-bounds deployments', async () => {
   // Only depA (Vulpes) is inside; depB (the only Capreolus) is excluded.
   assert.deepEqual(rows, [{ scientificName: 'Vulpes vulpes', count: 1 }])
 })
+
+test('timeseries: null bbox includes out-of-bounds species', async () => {
+  const rows = await getSequenceAwareTimeseriesSQL(dbPath, ['Capreolus capreolus'], null, null)
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  assert.equal(total, 1) // the single depB Capreolus observation
+})
+
+test('timeseries: bbox excludes out-of-bounds species entirely', async () => {
+  const rows = await getSequenceAwareTimeseriesSQL(dbPath, ['Capreolus capreolus'], null, BBOX_IN)
+  assert.deepEqual(rows, []) // Capreolus only exists at depB, which is outside BBOX_IN
+})

--- a/test/integration/queries/bbox-filter.test.js
+++ b/test/integration/queries/bbox-filter.test.js
@@ -79,3 +79,60 @@ test('timeseries: bbox excludes out-of-bounds species entirely', async () => {
   const rows = await getSequenceAwareTimeseriesSQL(dbPath, ['Capreolus capreolus'], null, BBOX_IN)
   assert.deepEqual(rows, []) // Capreolus only exists at depB, which is outside BBOX_IN
 })
+
+const START = '2024-01-01T00:00:00'
+const END = '2024-12-31T23:59:59'
+
+test('daily-activity: null bbox includes out-of-bounds observations', async () => {
+  const rows = await getSequenceAwareDailyActivitySQL(
+    dbPath,
+    ['Vulpes vulpes'],
+    START,
+    END,
+    null,
+    null
+  )
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  assert.equal(total, 2) // Vulpes at depA (08:00) + depB (09:00)
+})
+
+test('daily-activity: bbox restricts to in-bounds observations', async () => {
+  const rows = await getSequenceAwareDailyActivitySQL(
+    dbPath,
+    ['Vulpes vulpes'],
+    START,
+    END,
+    null,
+    BBOX_IN
+  )
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  assert.equal(total, 1) // only depA Vulpes (08:00) is inside BBOX_IN
+})
+
+// Guard the param bind-order in the eventID (gap=0) and positive-gap branches,
+// which append bbox params after a different number of leading params.
+test('daily-activity: bbox restricts in eventID branch (gap=0)', async () => {
+  const rows = await getSequenceAwareDailyActivitySQL(
+    dbPath,
+    ['Vulpes vulpes'],
+    START,
+    END,
+    0,
+    BBOX_IN
+  )
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  assert.equal(total, 1)
+})
+
+test('daily-activity: bbox restricts in positive-gap branch', async () => {
+  const rows = await getSequenceAwareDailyActivitySQL(
+    dbPath,
+    ['Vulpes vulpes'],
+    START,
+    END,
+    300,
+    BBOX_IN
+  )
+  const total = rows.reduce((s, r) => s + r.count, 0)
+  assert.equal(total, 1)
+})

--- a/test/integration/queries/bbox-filter.test.js
+++ b/test/integration/queries/bbox-filter.test.js
@@ -1,0 +1,70 @@
+import { test, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import Database from 'better-sqlite3'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getSequenceAwareSpeciesCountsSQL,
+  getSequenceAwareTimeseriesSQL,
+  getSequenceAwareDailyActivitySQL,
+  getSpeciesDistributionByMedia,
+  getSpeciesTimeseriesByMedia
+} from '../../../src/main/database/queries/species.js'
+
+// A study UUID directory so getStudyIdFromPath(dbPath) resolves a stable id.
+let dir
+let dbPath
+
+// Two deployments: depA inside the test bbox, depB outside it.
+// Fox observed at both; Deer only at depB (outside).
+const BBOX_IN = { north: 51.0, south: 50.0, east: 5.0, west: 4.0 } // contains depA only
+
+before(() => {
+  dir = mkdtempSync(join(tmpdir(), 'bbox-study-'))
+  dbPath = join(dir, 'study.db')
+  const db = new Database(dbPath)
+  db.exec(`
+    CREATE TABLE deployments (
+      deploymentID TEXT PRIMARY KEY, locationID TEXT, locationName TEXT,
+      deploymentStart TEXT, deploymentEnd TEXT, latitude REAL, longitude REAL,
+      cameraModel TEXT, cameraID TEXT, coordinateUncertainty INTEGER
+    );
+    CREATE TABLE media (
+      mediaID TEXT PRIMARY KEY, deploymentID TEXT, timestamp TEXT,
+      filePath TEXT, fileName TEXT, fileMediatype TEXT, folderName TEXT
+    );
+    CREATE TABLE observations (
+      observationID TEXT PRIMARY KEY, mediaID TEXT, deploymentID TEXT,
+      eventID TEXT, eventStart TEXT, scientificName TEXT, observationType TEXT
+    );
+    INSERT INTO deployments (deploymentID, latitude, longitude) VALUES
+      ('depA', 50.5, 4.5),   -- inside BBOX_IN
+      ('depB', 52.0, 6.0);   -- outside BBOX_IN
+    INSERT INTO media (mediaID, deploymentID, timestamp, fileMediatype) VALUES
+      ('mA1', 'depA', '2024-06-01T08:00:00', 'image/jpeg'),
+      ('mB1', 'depB', '2024-06-01T09:00:00', 'image/jpeg'),
+      ('mB2', 'depB', '2024-06-01T10:00:00', 'image/jpeg');
+    INSERT INTO observations (observationID, mediaID, deploymentID, eventID, eventStart, scientificName) VALUES
+      ('oA1', 'mA1', 'depA', 'e1', '2024-06-01T08:00:00', 'Vulpes vulpes'),
+      ('oB1', 'mB1', 'depB', 'e2', '2024-06-01T09:00:00', 'Vulpes vulpes'),
+      ('oB2', 'mB2', 'depB', 'e3', '2024-06-01T10:00:00', 'Capreolus capreolus');
+  `)
+  db.close()
+})
+
+after(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+test('species counts: null bbox returns all species (regression guard)', async () => {
+  const rows = await getSequenceAwareSpeciesCountsSQL(dbPath, null, null)
+  const names = rows.map((r) => r.scientificName).sort()
+  assert.deepEqual(names, ['Capreolus capreolus', 'Vulpes vulpes'])
+})
+
+test('species counts: bbox restricts to in-bounds deployments', async () => {
+  const rows = await getSequenceAwareSpeciesCountsSQL(dbPath, null, BBOX_IN)
+  // Only depA (Vulpes) is inside; depB (the only Capreolus) is excluded.
+  assert.deepEqual(rows, [{ scientificName: 'Vulpes vulpes', count: 1 }])
+})

--- a/test/integration/queries/bbox-filter.test.js
+++ b/test/integration/queries/bbox-filter.test.js
@@ -136,3 +136,25 @@ test('daily-activity: bbox restricts in positive-gap branch', async () => {
   const total = rows.reduce((s, r) => s + r.count, 0)
   assert.equal(total, 1)
 })
+
+test('distribution-by-media: bbox excludes out-of-bounds media rows', async () => {
+  const rows = await getSpeciesDistributionByMedia(dbPath, BBOX_IN)
+  const names = [...new Set(rows.map((r) => r.scientificName))].sort()
+  assert.deepEqual(names, ['Vulpes vulpes']) // depB (Capreolus) excluded
+})
+
+test('distribution-by-media: null bbox returns all (regression guard)', async () => {
+  const rows = await getSpeciesDistributionByMedia(dbPath, null)
+  const names = [...new Set(rows.map((r) => r.scientificName))].sort()
+  assert.deepEqual(names, ['Capreolus capreolus', 'Vulpes vulpes'])
+})
+
+test('timeseries-by-media: bbox excludes out-of-bounds media rows', async () => {
+  const rows = await getSpeciesTimeseriesByMedia(dbPath, ['Capreolus capreolus'], BBOX_IN)
+  assert.deepEqual(rows, []) // Capreolus only at depB, outside BBOX_IN
+})
+
+test('timeseries-by-media: null bbox includes out-of-bounds rows', async () => {
+  const rows = await getSpeciesTimeseriesByMedia(dbPath, ['Capreolus capreolus'], null)
+  assert.equal(rows.length, 1)
+})

--- a/test/unit/bbox.test.js
+++ b/test/unit/bbox.test.js
@@ -1,0 +1,32 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildBboxClause } from '../../src/main/database/queries/bbox.js'
+
+test('returns empty clause and no params when bbox is null', () => {
+  const { clause, params } = buildBboxClause(null, 'd')
+  assert.equal(clause, '')
+  assert.deepEqual(params, [])
+})
+
+test('returns empty clause when bbox is undefined', () => {
+  const { clause, params } = buildBboxClause(undefined, 'd')
+  assert.equal(clause, '')
+  assert.deepEqual(params, [])
+})
+
+test('builds lat/lng BETWEEN clause with south,north,west,east order', () => {
+  const bbox = { north: 51.2, south: 50.8, east: 4.6, west: 4.2 }
+  const { clause, params } = buildBboxClause(bbox, 'd')
+  assert.equal(
+    clause.replace(/\s+/g, ' ').trim(),
+    'AND d.latitude BETWEEN ? AND ? AND d.longitude BETWEEN ? AND ?'
+  )
+  assert.deepEqual(params, [50.8, 51.2, 4.2, 4.6])
+})
+
+test('ignores antimeridian-crossing bbox (west > east) — returns no clause', () => {
+  const bbox = { north: 10, south: -10, east: -170, west: 170 }
+  const { clause, params } = buildBboxClause(bbox, 'd')
+  assert.equal(clause, '')
+  assert.deepEqual(params, [])
+})


### PR DESCRIPTION
## Summary

Adds an on-demand geographic (bounding-box) filter to the Activity tab, driven by the map viewport. The user pans/zooms the map and clicks a **Filter to this area** pill; the current viewport bounds are snapshotted and applied to the **species distribution list**, the **day-activity chart**, and the **time-activity chart**. The map's own pie-chart markers stay unfiltered so it remains a full overview surface.

Design spec: `docs/specs/2026-05-29-activity-map-viewport-filter-design.md`

## How it works

- **Pill (top-center of the map):** styled like the day-period chips. Click the body to apply/re-apply the current viewport (one click, even when a filter is already active — no clear-first dance). When active it turns blue and shows an inline ✕ to clear without re-applying.
- **Rectangle overlay** marks the snapshotted area; it re-projects on pan/zoom/resize so it stays glued to the same geography.
- **Snapshot model:** the filter is frozen on apply. Panning away or resizing the window does **not** recompute the widgets — avoids triggering the multi-second sequence-aware queries on every interaction.
- **Persistence:** the filter is stored per-study (localStorage), mirroring `useDateRange`. `null` = no filter.
- The filter-charts tooltip lists the active **Map area** as a coordinate range (e.g. `24.31°S–22.10°S, 31.20°E–32.05°E`), and **Reset filters** clears it alongside the date/time filters.

## Implementation

- New optional `bbox` param threaded through preload → IPC handlers → sequences worker → SQL builders. When `null`, behavior is byte-identical to before (regression-guarded by tests).
- SQL: bbox becomes a conditional `INNER JOIN deployments` + `latitude/longitude BETWEEN` clause on the species-distribution, timeseries, and daily-activity queries (all gap paths, incl. the positive-gap JS fallback). The heatmap query is intentionally left unfiltered.
- **No GIS / R-tree and no new index** — at the largest study's scale (~2.7k deployments vs ~2.7M observations) the deployment scan is negligible against the observations join.

## Test Plan

- [x] Unit tests for the bbox SQL-fragment helper (`test/unit/bbox.test.js`)
- [x] Integration tests asserting bbox excludes out-of-bounds deployments and `null` bbox returns the full result, across all three queries and all gap paths (`test/integration/queries/bbox-filter.test.js`)
- [x] Full suite green: 1416 passing, 0 failing
- [x] Manually verified in the running app: apply turns the pill blue + draws the rectangle + filters the species list; body re-applies a panned area in one click; inline ✕ clears without re-applying