### PR TITLE
feat(activity): move daytime filter selection into a dedicated track

### DIFF
--- a/docs/plans/2026-06-01-daytime-filter-track-plan.md
+++ b/docs/plans/2026-06-01-daytime-filter-track-plan.md
@@ -1,0 +1,793 @@
+# Daytime Filter Selection Track Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the daytime-filter selection indicator out of the plot into a dedicated track (a ring outside the polar radar, a strip below the line chart) so the activity curves are the visual priority.
+
+**Architecture:** Extract the pure geometry/range helpers from `clock.jsx` into a testable `clockGeometry.js` module, then rewrite the selection rendering in `CircularTimeFilter` (polar ring) and `DailyActivityLine` (under-axis strip) to consume them. Selection semantics stay "blue = kept"; default all-selected = a full blue track. State in `activity.jsx` is unchanged.
+
+**Tech Stack:** React, Recharts (`RadarChart`/`ComposedChart`), inline SVG, Tailwind. Tests via `node:test`.
+
+**Spec:** `docs/specs/2026-06-01-daytime-filter-track-design.md`
+
+---
+
+## File Structure
+
+- **Create** `src/renderer/src/ui/clockGeometry.js` — pure helpers: `timeToAngle`, `angleToTime`, `isInsideBand`, `edgeTolFor`, `bandToSegments`, `rangesToSegments`, `resolveAction`. No React, no DOM.
+- **Create** `test/renderer/ui/clockGeometry.test.js` — unit tests for the helpers.
+- **Modify** `src/renderer/src/ui/clock.jsx` — `CircularTimeFilter` (polar ring) and `DailyActivityLine` (under-axis strip) consume the helpers; remove the in-plot blue fills.
+- **Untouched** `src/renderer/src/activity.jsx` — same props/state; verified by manual run.
+
+Note: `dayPeriods.js` already owns the chip/arc → ranges helpers (`chipsToRanges`, `arcToRanges`, `mergeChipRanges`). `clockGeometry.js` is strictly the rendering/interaction geometry, kept separate.
+
+---
+
+## Task 1: Extract pure geometry/interaction helpers (TDD)
+
+**Files:**
+- Create: `src/renderer/src/ui/clockGeometry.js`
+- Test: `test/renderer/ui/clockGeometry.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/renderer/ui/clockGeometry.test.js`:
+
+```js
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  timeToAngle,
+  angleToTime,
+  isInsideBand,
+  edgeTolFor,
+  bandToSegments,
+  rangesToSegments,
+  resolveAction
+} from '../../../src/renderer/src/ui/clockGeometry.js'
+
+describe('timeToAngle / angleToTime', () => {
+  test('0h is 0deg, 6h is 90deg, 18h is 270deg', () => {
+    assert.equal(timeToAngle(0), 0)
+    assert.equal(timeToAngle(6), 90)
+    assert.equal(timeToAngle(18), 270)
+  })
+  test('24h wraps to 0deg', () => {
+    assert.equal(timeToAngle(24), 0)
+  })
+  test('angleToTime inverts within [0,360)', () => {
+    assert.equal(angleToTime(0), 0)
+    assert.equal(angleToTime(90), 6)
+    assert.equal(angleToTime(270), 18)
+  })
+})
+
+describe('isInsideBand', () => {
+  test('non-wrap band: strictly between start and end', () => {
+    assert.equal(isInsideBand(10, { start: 8, end: 18 }), true)
+    assert.equal(isInsideBand(8, { start: 8, end: 18 }), false)
+    assert.equal(isInsideBand(20, { start: 8, end: 18 }), false)
+  })
+  test('wrap band (start > end): outside the gap', () => {
+    assert.equal(isInsideBand(23, { start: 21, end: 5 }), true)
+    assert.equal(isInsideBand(3, { start: 21, end: 5 }), true)
+    assert.equal(isInsideBand(12, { start: 21, end: 5 }), false)
+  })
+})
+
+describe('edgeTolFor', () => {
+  test('clamps to [1, 2]', () => {
+    assert.equal(edgeTolFor(1.5), 1) // 0.5 -> floored at 1
+    assert.equal(edgeTolFor(6), 2) // 2 -> capped at 2
+    assert.equal(edgeTolFor(4.5), 1.5) // 1.5 in range
+  })
+})
+
+describe('bandToSegments', () => {
+  test('empty band (start === end) yields nothing', () => {
+    assert.deepEqual(bandToSegments({ start: 7, end: 7 }), [])
+  })
+  test('non-wrap band yields one segment', () => {
+    assert.deepEqual(bandToSegments({ start: 7, end: 18 }), [[7, 18]])
+  })
+  test('wrap band splits at midnight', () => {
+    assert.deepEqual(bandToSegments({ start: 21, end: 5 }), [
+      [21, 24],
+      [0, 5]
+    ])
+  })
+})
+
+describe('rangesToSegments', () => {
+  test('flattens multiple ranges, splitting wrap-arounds', () => {
+    assert.deepEqual(
+      rangesToSegments([
+        { start: 5, end: 8 },
+        { start: 21, end: 5 }
+      ]),
+      [
+        [5, 8],
+        [21, 24],
+        [0, 5]
+      ]
+    )
+  })
+  test('full-day range yields a single full segment', () => {
+    assert.deepEqual(rangesToSegments([{ start: 0, end: 24 }]), [[0, 24]])
+  })
+})
+
+describe('resolveAction', () => {
+  test('no single band -> create', () => {
+    assert.equal(resolveAction(10, []), 'create')
+    assert.equal(resolveAction(10, [{ start: 5, end: 8 }, { start: 18, end: 21 }]), 'create')
+  })
+  test('near end edge -> edge-end', () => {
+    assert.equal(resolveAction(17.5, [{ start: 8, end: 18 }]), 'edge-end')
+  })
+  test('near start edge -> edge-start', () => {
+    assert.equal(resolveAction(8.5, [{ start: 8, end: 18 }]), 'edge-start')
+  })
+  test('inside band, away from edges -> pan', () => {
+    assert.equal(resolveAction(13, [{ start: 8, end: 18 }]), 'pan')
+  })
+  test('outside band -> create', () => {
+    assert.equal(resolveAction(2, [{ start: 8, end: 18 }]), 'create')
+  })
+  test('wrap band is panned, not edge-slid', () => {
+    assert.equal(resolveAction(23, [{ start: 21, end: 5 }]), 'pan')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/renderer/ui/clockGeometry.test.js`
+Expected: FAIL — `Cannot find module .../clockGeometry.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/renderer/src/ui/clockGeometry.js`:
+
+```js
+/**
+ * Pure geometry + interaction helpers for the daytime-filter charts.
+ * No React, no DOM — unit-tested in test/renderer/ui/clockGeometry.test.js.
+ *
+ * Hours are 24h clock values; bands are {start, end} half-open ranges where
+ * start > end means the band wraps midnight (e.g. night 21 -> 5).
+ */
+
+// Clock angle in degrees, measured clockwise from 0h at the top.
+export const timeToAngle = (time) => (time * 15) % 360
+
+// Inverse of timeToAngle for an angle already normalized to [0, 360).
+export const angleToTime = (angle) => (angle / 15) % 24
+
+// Whether `cursor` (hours) falls strictly inside a possibly-wrapping band.
+export const isInsideBand = (cursor, band) => {
+  if (band.start < band.end) return cursor > band.start && cursor < band.end
+  return cursor > band.start || cursor < band.end
+}
+
+// Edge grab-zone half-width (hours): at least 1h so short bands are
+// targetable, capped at 2h so it never takes over a wide band.
+export const edgeTolFor = (width) => Math.max(1, Math.min(2, width / 3))
+
+// Split one band into renderable [start, end] segments, breaking a
+// wrap-around band into two pieces at midnight.
+export const bandToSegments = (band) => {
+  if (band.start === band.end) return []
+  if (band.start < band.end) return [[band.start, band.end]]
+  return [
+    [band.start, 24],
+    [0, band.end]
+  ]
+}
+
+// Flatten an array of bands into renderable segments.
+export const rangesToSegments = (ranges) => ranges.flatMap(bandToSegments)
+
+// Decide what a click/drag at `cursor` (hours) should do, given the current
+// selection. Only a single non-wrap band supports edge-resize; everything
+// else is pan (inside) or create (outside / multi-band / empty).
+export const resolveAction = (cursor, ranges) => {
+  if (ranges.length !== 1) return 'create'
+  const { start, end } = ranges[0]
+  const isWrap = start >= end
+  const width = isWrap ? 24 - start + end : end - start
+  const tol = edgeTolFor(width)
+  if (!isWrap && cursor >= end - tol && cursor <= end + tol) return 'edge-end'
+  if (!isWrap && cursor >= start - tol && cursor <= start + tol) return 'edge-start'
+  if (isInsideBand(cursor, { start, end })) return 'pan'
+  return 'create'
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/renderer/ui/clockGeometry.test.js`
+Expected: PASS — all assertions green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/ui/clockGeometry.js test/renderer/ui/clockGeometry.test.js
+git commit -m "feat(activity): extract pure clock geometry/interaction helpers"
+```
+
+---
+
+## Task 2: Polar mode — selection ring outside the radar
+
+**Files:**
+- Modify: `src/renderer/src/ui/clock.jsx` (the `CircularTimeFilter` component, lines ~22–337)
+
+Replace the in-radar blue pie/disk fill with a ring rendered *outside* the radar circle. Selected ranges are blue stroked arcs on the ring; handles and drag move to the ring; the `isFullDayRange` arc-suppression is removed (a full blue ring is the correct "all selected" state).
+
+- [ ] **Step 1: Add ring constants and an arc-path helper**
+
+At the top of `clock.jsx`, just below the existing `CLOCK_OUTER_RADIUS_PX` constant, add:
+
+```js
+// Selection ring sits just OUTSIDE the radar circle so it never covers the
+// activity blob. Radii are in the same px space as CLOCK_OUTER_RADIUS_PX.
+const RING_GAP = 4 // gap between radar edge and ring
+const RING_WIDTH = 7 // stroke thickness of the ring
+const RING_MID = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH / 2
+const RING_OUTER = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH
+```
+
+Update the import at the top of the file to pull in the helpers:
+
+```js
+import { timeToAngle, angleToTime, rangesToSegments } from './clockGeometry.js'
+```
+
+- [ ] **Step 2: Rewrite `CircularTimeFilter` to draw the ring**
+
+Replace the whole `CircularTimeFilter` component (from `const CircularTimeFilter = ({` through its closing `}` before `// New component for species daily activity visualization`) with:
+
+```jsx
+const CircularTimeFilter = ({
+  onChange,
+  startTime = 6,
+  endTime = 18,
+  mode = 'drag',
+  chipSectors = []
+}) => {
+  const [isDraggingStart, setIsDraggingStart] = useState(false)
+  const [isDraggingEnd, setIsDraggingEnd] = useState(false)
+  const [isDraggingArc, setIsDraggingArc] = useState(false)
+  const [start, setStart] = useState(startTime)
+  const [end, setEnd] = useState(endTime)
+  const [lastDragPosition, setLastDragPosition] = useState(null)
+  const svgRef = useRef(null)
+
+  const padding = 16 // room for hour labels outside the ring
+  const svgSize = RING_OUTER * 2 + padding * 2
+  const center = { x: RING_OUTER + padding, y: RING_OUTER + padding }
+  const labelOffset = RING_OUTER + 9
+
+  // Sync local state when parent updates bounds externally. Does NOT fire
+  // onChange continuously — that happens only on pointer release.
+  useEffect(() => {
+    setStart(startTime)
+    setEnd(endTime)
+  }, [startTime, endTime])
+
+  const interactive = mode !== 'chips'
+  // Ranges to paint as blue arcs: the live drag band, or the chip sectors.
+  const ranges = interactive ? [{ start, end }] : chipSectors
+  const segments = rangesToSegments(ranges)
+  const isFullRing = segments.length === 1 && segments[0][0] === 0 && segments[0][1] === 24
+
+  // Point on a circle of radius r at the given clock hour.
+  const pointAt = (hour, r) => {
+    const rad = (timeToAngle(hour) - 90) * (Math.PI / 180)
+    return { x: center.x + r * Math.cos(rad), y: center.y + r * Math.sin(rad) }
+  }
+
+  // Open arc (stroked, not filled) along RING_MID from startHour to endHour,
+  // drawn clockwise. Used for partial selections.
+  const ringArcPath = (startHour, endHour) => {
+    const a = pointAt(startHour, RING_MID)
+    const b = pointAt(endHour, RING_MID)
+    let sweep = (((endHour - startHour) % 24) + 24) % 24
+    const largeArc = sweep > 12 ? 1 : 0
+    return `M ${a.x} ${a.y} A ${RING_MID} ${RING_MID} 0 ${largeArc} 1 ${b.x} ${b.y}`
+  }
+
+  const handleMouseDown = (handle) => (e) => {
+    if (handle === 'start') {
+      setIsDraggingStart(true)
+    } else if (handle === 'end') {
+      setIsDraggingEnd(true)
+    } else if (handle === 'arc') {
+      setIsDraggingArc(true)
+      const svgRect = svgRef.current.getBoundingClientRect()
+      const x = e.clientX - svgRect.left - center.x
+      const y = e.clientY - svgRect.top - center.y
+      let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
+      if (angle < 0) angle += 360
+      setLastDragPosition(angle)
+    }
+  }
+
+  const handleMouseMove = (e) => {
+    if (!isDraggingStart && !isDraggingEnd && !isDraggingArc) return
+    const svgRect = svgRef.current.getBoundingClientRect()
+    const x = e.clientX - svgRect.left - center.x
+    const y = e.clientY - svgRect.top - center.y
+    let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
+    if (angle < 0) angle += 360
+
+    if (isDraggingStart) {
+      setStart(angleToTime(angle))
+    } else if (isDraggingEnd) {
+      setEnd(angleToTime(angle))
+    } else if (isDraggingArc) {
+      if (lastDragPosition !== null) {
+        let angleDiff = angle - lastDragPosition
+        if (angleDiff > 180) angleDiff -= 360
+        if (angleDiff < -180) angleDiff += 360
+        const timeDiff = angleDiff / 15
+        let newStart = (start + timeDiff) % 24
+        let newEnd = (end + timeDiff) % 24
+        if (newStart < 0) newStart += 24
+        if (newEnd < 0) newEnd += 24
+        setStart(newStart)
+        setEnd(newEnd)
+      }
+      setLastDragPosition(angle)
+    }
+  }
+
+  const handleMouseUp = () => {
+    const wasDragging = isDraggingStart || isDraggingEnd || isDraggingArc
+    setIsDraggingStart(false)
+    setIsDraggingEnd(false)
+    setIsDraggingArc(false)
+    setLastDragPosition(null)
+    // Commit-on-release: fire onChange once with the final value.
+    if (wasDragging) onChange({ start, end })
+  }
+
+  useEffect(() => {
+    if (isDraggingStart || isDraggingEnd || isDraggingArc) {
+      window.addEventListener('mouseup', handleMouseUp)
+      window.addEventListener('mousemove', handleMouseMove)
+    }
+    return () => {
+      window.removeEventListener('mouseup', handleMouseUp)
+      window.removeEventListener('mousemove', handleMouseMove)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDraggingStart, isDraggingEnd, isDraggingArc, lastDragPosition])
+
+  const startCoord = pointAt(start, RING_MID)
+  const endCoord = pointAt(end, RING_MID)
+
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full">
+      <svg
+        className="select-none"
+        width={svgSize}
+        height={svgSize}
+        onMouseMove={handleMouseMove}
+        ref={svgRef}
+      >
+        {/* Inner reference circle aligned to the radar's outer edge. */}
+        <circle
+          cx={center.x}
+          cy={center.y}
+          r={CLOCK_OUTER_RADIUS_PX}
+          fill="none"
+          stroke="var(--color-border)"
+          strokeWidth="1"
+        />
+
+        {/* Hour labels just outside the ring. */}
+        <text x={center.x} y={center.y - labelOffset} textAnchor="middle" dominantBaseline="middle" fontSize="9" fill="var(--color-muted-foreground)">0h</text>
+        <text x={center.x + labelOffset} y={center.y} textAnchor="middle" dominantBaseline="middle" fontSize="9" fill="var(--color-muted-foreground)">6h</text>
+        <text x={center.x} y={center.y + labelOffset} textAnchor="middle" dominantBaseline="middle" fontSize="9" fill="var(--color-muted-foreground)">12h</text>
+        <text x={center.x - labelOffset} y={center.y} textAnchor="middle" dominantBaseline="middle" fontSize="9" fill="var(--color-muted-foreground)">18h</text>
+
+        {/* Gray track ring. */}
+        <circle
+          cx={center.x}
+          cy={center.y}
+          r={RING_MID}
+          fill="none"
+          stroke="var(--color-muted)"
+          strokeWidth={RING_WIDTH}
+        />
+
+        {/* Blue selection on the ring. Full-day -> full ring; else arcs.
+            The arc is the drag target for panning in interactive mode. */}
+        {isFullRing ? (
+          <circle
+            cx={center.x}
+            cy={center.y}
+            r={RING_MID}
+            fill="none"
+            stroke="rgb(59 130 246)"
+            strokeWidth={RING_WIDTH}
+            cursor={interactive ? 'pointer' : 'default'}
+            onMouseDown={interactive ? handleMouseDown('arc') : undefined}
+          />
+        ) : (
+          segments.map(([s, e], i) => (
+            <path
+              key={i}
+              d={ringArcPath(s, e)}
+              fill="none"
+              stroke="rgb(59 130 246)"
+              strokeWidth={RING_WIDTH}
+              strokeLinecap="butt"
+              cursor={interactive ? 'pointer' : 'default'}
+              onMouseDown={interactive ? handleMouseDown('arc') : undefined}
+            />
+          ))
+        )}
+
+        {/* Draggable handles (interactive mode only). */}
+        {interactive && (
+          <>
+            <circle cx={startCoord.x} cy={startCoord.y} r="5" fill="rgb(59 130 246)" stroke="white" strokeWidth="1.5" cursor="pointer" onMouseDown={handleMouseDown('start')} />
+            <circle cx={endCoord.x} cy={endCoord.y} r="5" fill="rgb(59 130 246)" stroke="white" strokeWidth="1.5" cursor="pointer" onMouseDown={handleMouseDown('end')} />
+          </>
+        )}
+      </svg>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2b: Remove now-dead code**
+
+The old component used `radius`, `angleToCoordinates`, `timeToAngle`/`angleToTime` (local), `isFullDayRange`, `createArc`, and the 24 tick-mark `<line>`s. These are all gone in the rewrite above (the local `timeToAngle`/`angleToTime` are replaced by the imported ones, ticks are dropped in favour of the ring). Confirm none of these identifiers remain in `CircularTimeFilter` after the replace.
+
+- [ ] **Step 3: Lint and build**
+
+Run: `npm run lint`
+Expected: no errors in `clock.jsx`.
+
+Run: `npx electron-vite build` (or `npm run build` if defined)
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual verification**
+
+Run the app (`npm run dev`), open a study with temporal data, show the activity filter charts in **polar** mode:
+- Default (all chips selected): radar blob is fully visible; a **full blue ring** sits outside it; no blue wash over the data.
+- Deselect chips so the mode becomes interactive; a blue **arc** marks the selected window, with two draggable handles on the ring.
+- Drag a handle → the arc resizes; drag the arc → the window pans (including across 0h); release → downstream species/timeline data updates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/src/ui/clock.jsx
+git commit -m "feat(activity): polar selection ring outside the activity radar"
+```
+
+---
+
+## Task 3: Line mode — selection track strip below the x-axis
+
+**Files:**
+- Modify: `src/renderer/src/ui/clock.jsx` (the `DailyActivityLine` component, lines ~406–763)
+
+Remove the full-height `ReferenceArea` bands and in-chart `ReferenceLine` handles. Add a track strip beneath the axis that shows blue selected segments and hosts the handles + drag.
+
+- [ ] **Step 1: Import helpers and drop the inline duplicates**
+
+Ensure the top-of-file import (added in Task 2) also covers the line helpers:
+
+```js
+import {
+  timeToAngle,
+  angleToTime,
+  rangesToSegments,
+  bandToSegments,
+  isInsideBand,
+  edgeTolFor,
+  resolveAction
+} from './clockGeometry.js'
+```
+
+Inside `DailyActivityLine`, delete the inline `isInsideBand`, `edgeTolFor`, `actionAt`, `bandToSegments`, and the `selectedBands` builder loop — they are replaced by the imported helpers (`resolveAction` subsumes `actionAt`; `rangesToSegments` subsumes the `selectedBands` loop).
+
+- [ ] **Step 2: Rewrite `DailyActivityLine`**
+
+Replace the whole `DailyActivityLine` component (from `const DailyActivityLine = ({` through its closing `}` before `// Export all components`) with:
+
+```jsx
+const DailyActivityLine = ({
+  activityData,
+  selectedSpecies,
+  palette,
+  selectedRanges = [],
+  onArcChange
+}) => {
+  const hasSingleBand = selectedRanges.length === 1
+  const isWrapBand = hasSingleBand && selectedRanges[0].start >= selectedRanges[0].end
+  const dragEnabled =
+    typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
+
+  const stripRef = useRef(null)
+  const [dragState, setDragState] = useState(null)
+  // dragState: { mode: 'create'|'start'|'end'|'pan', liveStart, liveEnd, panOffset?, panWidth? }
+  const isDragging = dragState !== null
+  const [hoverAction, setHoverAction] = useState(null)
+
+  // Pointer x over the strip -> hour [0,24]. The strip's inner box already
+  // excludes the 8px insets, so no margin math is needed. When clamp01 is
+  // false the value can exceed [0,24] (used during pan so the band wraps).
+  const eventToHour = (e, { clamp01 = true } = {}) => {
+    if (!stripRef.current) return null
+    const rect = stripRef.current.getBoundingClientRect()
+    if (rect.width <= 0) return null
+    const raw = (e.clientX - rect.left) / rect.width
+    const ratio = clamp01 ? Math.max(0, Math.min(1, raw)) : raw
+    return ratio * 24
+  }
+
+  const handleMouseUp = () => {
+    setDragState((prev) => {
+      if (prev) {
+        const { mode, liveStart, liveEnd } = prev
+        if (mode === 'pan') {
+          onArcChange({ start: liveStart, end: liveEnd })
+        } else if (liveStart !== liveEnd) {
+          onArcChange({ start: Math.min(liveStart, liveEnd), end: Math.max(liveStart, liveEnd) })
+        }
+      }
+      return null
+    })
+  }
+
+  const formatData = (data) => {
+    if (!data || !data.length) {
+      return Array(24)
+        .fill()
+        .map((_, i) => ({ hour: i }))
+    }
+    return data.map((d) => ({ ...d, hour: d.hour }))
+  }
+  const formattedData = formatData(activityData)
+
+  // Live band while dragging — for pan it can wrap around midnight.
+  const liveBand = (() => {
+    if (!isDragging) return null
+    const { mode, liveStart, liveEnd } = dragState
+    if (mode === 'pan') return { start: liveStart, end: liveEnd }
+    return { start: Math.min(liveStart, liveEnd), end: Math.max(liveStart, liveEnd) }
+  })()
+
+  // Segments + handle positions: live band while dragging, else the committed selection.
+  const segments = liveBand ? bandToSegments(liveBand) : rangesToSegments(selectedRanges)
+  const handleStartX = (() => {
+    if (isDragging) {
+      const { mode, liveStart, liveEnd } = dragState
+      return mode === 'pan' ? liveStart : Math.min(liveStart, liveEnd)
+    }
+    if (hasSingleBand && !isWrapBand) return selectedRanges[0].start
+    return null
+  })()
+  const handleEndX = (() => {
+    if (isDragging) {
+      const { mode, liveStart, liveEnd } = dragState
+      return mode === 'pan' ? liveEnd : Math.max(liveStart, liveEnd)
+    }
+    if (hasSingleBand && !isWrapBand) return selectedRanges[0].end
+    return null
+  })()
+
+  const cursorStyle = (() => {
+    if (!dragEnabled) return undefined
+    const action = isDragging ? dragState.mode : hoverAction
+    if (action === 'pan') return 'move'
+    if (action === 'end' || action === 'start' || action === 'edge-start' || action === 'edge-end')
+      return 'ew-resize'
+    if (action === 'create') return 'crosshair'
+    return 'default'
+  })()
+  const hoveredEdge =
+    hoverAction === 'edge-start' || (isDragging && dragState.mode === 'start')
+      ? 'start'
+      : hoverAction === 'edge-end' || (isDragging && dragState.mode === 'end')
+        ? 'end'
+        : null
+
+  // While dragging, listen on the document so the cursor can leave the strip.
+  useEffect(() => {
+    if (!isDragging) return
+    const onDocMove = (e) => {
+      setDragState((prev) => {
+        if (!prev) return prev
+        const cursor = eventToHour(e, { clamp01: prev.mode !== 'pan' })
+        if (cursor === null) return prev
+        if (prev.mode === 'pan') {
+          const newStart = (((cursor - prev.panOffset) % 24) + 24) % 24
+          const newEnd = (newStart + prev.panWidth) % 24
+          return { ...prev, liveStart: newStart, liveEnd: newEnd }
+        }
+        if (prev.mode === 'start') return { ...prev, liveStart: cursor }
+        return { ...prev, liveEnd: cursor }
+      })
+    }
+    const onDocUp = () => handleMouseUp()
+    document.addEventListener('mousemove', onDocMove)
+    document.addEventListener('mouseup', onDocUp)
+    return () => {
+      document.removeEventListener('mousemove', onDocMove)
+      document.removeEventListener('mouseup', onDocUp)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDragging])
+
+  const handleStripMove = (e) => {
+    if (isDragging || !dragEnabled) return
+    const cursor = eventToHour(e)
+    if (cursor === null) return
+    setHoverAction(resolveAction(cursor, selectedRanges))
+  }
+  const handleStripDown = (e) => {
+    if (!dragEnabled) return
+    e.preventDefault()
+    const cursor = eventToHour(e)
+    if (cursor === null) return
+    const action = resolveAction(cursor, selectedRanges)
+    if (action === 'create') {
+      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
+    } else if (action === 'edge-end') {
+      setDragState({ mode: 'end', liveStart: selectedRanges[0].start, liveEnd: cursor })
+    } else if (action === 'edge-start') {
+      setDragState({ mode: 'start', liveStart: cursor, liveEnd: selectedRanges[0].end })
+    } else {
+      // pan
+      const { start, end } = selectedRanges[0]
+      const width = isWrapBand ? 24 - start + end : end - start
+      const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
+      setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
+    }
+  }
+  const handleStripLeave = () => {
+    if (!isDragging) setHoverAction(null)
+  }
+
+  const pct = (hour) => `${(hour / 24) * 100}%`
+
+  return (
+    <div className="relative w-full h-full flex flex-col select-none">
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
+            <CartesianGrid strokeOpacity={0} />
+            <XAxis
+              dataKey="hour"
+              type="number"
+              domain={[0, 24]}
+              ticks={[0, 6, 12, 18, 24]}
+              tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis hide domain={[0, 'auto']} />
+            {selectedSpecies.map((species, index) => (
+              <Line
+                key={species.scientificName}
+                type="monotone"
+                dataKey={species.scientificName}
+                stroke={palette[index % palette.length]}
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Selection track strip below the axis. 8px insets match the chart's
+          left/right margin so hour 0..24 line up with the plot. */}
+      <div className="px-2 pb-1" style={cursorStyle ? { cursor: cursorStyle } : undefined}>
+        <div
+          ref={stripRef}
+          className="relative h-2.5 rounded-full bg-muted"
+          onMouseDown={handleStripDown}
+          onMouseMove={handleStripMove}
+          onMouseLeave={handleStripLeave}
+        >
+          {segments.map(([s, e], i) => (
+            <div
+              key={i}
+              className="absolute top-0 h-full rounded-full"
+              style={{ left: pct(s), width: pct(e - s), backgroundColor: 'rgb(59 130 246)' }}
+            />
+          ))}
+          {dragEnabled && handleStartX !== null && (
+            <div
+              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
+              style={{
+                left: pct(handleStartX),
+                width: hoveredEdge === 'start' ? 12 : 9,
+                height: hoveredEdge === 'start' ? 12 : 9,
+                transform: 'translate(-50%, -50%)'
+              }}
+            />
+          )}
+          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
+            <div
+              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
+              style={{
+                left: pct(handleEndX),
+                width: hoveredEdge === 'end' ? 12 : 9,
+                height: hoveredEdge === 'end' ? 12 : 9,
+                transform: 'translate(-50%, -50%)'
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Remove now-unused imports**
+
+`ReferenceArea` and `ReferenceLine` are no longer used. Remove them from the `recharts` import at the top of `clock.jsx`. Run `npm run lint` to confirm no unused-import warnings remain.
+
+- [ ] **Step 4: Lint and build**
+
+Run: `npm run lint`
+Expected: no errors/unused warnings in `clock.jsx`.
+
+Run: `npx electron-vite build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Manual verification**
+
+Run the app, switch the activity filter to **line** mode:
+- Default (all selected): only the species lines + axis in the plot — no blue wash; the strip below is a **full blue bar**.
+- Deselect chips → interactive: drag on the strip to create a window; drag a handle to resize; drag the middle to pan (wraps past midnight); cursor changes (crosshair/ew-resize/move); release commits and updates downstream data.
+- Selecting chips again paints the correct blue segment(s) on the strip and disables strip dragging.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/src/ui/clock.jsx
+git commit -m "feat(activity): line-mode selection track strip below the axis"
+```
+
+---
+
+## Task 4: Full regression + cross-mode verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: PASS — baseline 1400 + the new `clockGeometry` tests, 0 failures.
+
+- [ ] **Step 2: Cross-mode manual check**
+
+Run the app and confirm parity between modes:
+- Toggle polar ↔ line with a partial selection active → the same window is shown as a ring arc and as a strip segment.
+- A wrap-around night selection (e.g. 21→5) renders correctly in both (ring arc crossing 0h; two strip segments).
+- Switching studies / tabs resets to all-selected (full blue track) in both modes.
+
+- [ ] **Step 3: Final lint/format**
+
+Run: `npm run lint && npm run format:check`
+Expected: clean. If `format:check` flags `clock.jsx`/`clockGeometry.js`, run `npm run format` and amend the relevant commit.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** ring outside radar (Task 2), strip below axis (Task 3), selection semantics / full blue track (Tasks 2–3 default state), track-as-drag-surface (Tasks 2–3 handlers on ring/strip), helper extraction + unit tests (Task 1), regression (Task 4). All spec sections map to a task.
+- **No activity.jsx change:** props/state contract is unchanged; the rewritten components keep the same prop names (`onChange`/`onArcChange`, `startTime`/`endTime`, `selectedRanges`, `mode`, `chipSectors`) and the same commit-on-release `{start, end}` shape. Verified by manual run in Task 4.
+- **Type/name consistency:** helper names (`timeToAngle`, `angleToTime`, `isInsideBand`, `edgeTolFor`, `bandToSegments`, `rangesToSegments`, `resolveAction`) are identical across the test, the module, and both component rewrites.

--- a/docs/specs/2026-06-01-daytime-filter-track-design.md
+++ b/docs/specs/2026-06-01-daytime-filter-track-design.md
@@ -1,0 +1,99 @@
+# Daytime filter: move selection into a dedicated track
+
+**Date:** 2026-06-01
+**Status:** Design — pending review
+**Branch:** `worktree-arthur+feat-daytime-filter-track`
+
+## Problem
+
+The daytime filter widget paints the *selected* time range as a blue fill **inside** the plot. Because the default state is "everything selected," the whole chart starts fully blue:
+
+- **Polar mode:** `CircularTimeFilter` overlays a blue pie-sector/disk on top of the activity radar. All chips selected → full blue circle covering the radar.
+- **Line mode:** `DailyActivityLine` draws full-height blue `ReferenceArea` bands across the plot.
+
+The blue wash competes with the per-species activity curves — the actual data the user is there to read.
+
+## Goal
+
+Make the activity curves the visual priority. Move the time-window selection indicator **out of the plot area** into a dedicated **track**, and keep that treatment consistent across both chart modes.
+
+## Decisions (settled during brainstorming)
+
+1. **Indicator leaves the plot.** Selection renders in a thin track *outside* the data area:
+   - Line mode: a horizontal strip beneath the x-axis.
+   - Polar mode: a ring just outside the radar circle.
+2. **Selection semantics, not deselection.** Blue marks the **kept** hours. Default (all 24h) = a full blue track. Because the track is outside the plot, a full blue track no longer obscures anything.
+3. **The track is the drag surface.** Resize handles and drag-to-move live on the track itself. The plot/circle interior is no longer an interaction target.
+4. **Everything else is unchanged.** State model, chips behaviour, commit-on-release, and wrap-around handling all stay. When chips drive the selection the track is a read-only blue readout (drag disabled), exactly as today.
+
+## Current architecture (for reference)
+
+All three components live in `src/renderer/src/ui/clock.jsx`, composed in `src/renderer/src/activity.jsx` (~lines 970–1013):
+
+- `DailyActivityRadar` — polar data viz; `outerRadius = CLOCK_OUTER_RADIUS_PX = 47`.
+- `CircularTimeFilter` (default export) — the interactive clock overlaid centered on the radar. Draws the blue arc/sector (`rgb(59 130 246 / 0.15)` fill, `/0.8` stroke) over the selected range, plus start/end handle dots. Suppresses the arc when `isFullDayRange()` so "no filter" ≠ "all selected".
+- `DailyActivityLine` — line-mode data viz **and** selection UI in one `ComposedChart`: `ReferenceArea` bands for the selected ranges + draggable `ReferenceLine` handles, with hover-preview cursors and `create`/`pan`/`edge` drag modes.
+
+State in `activity.jsx`:
+
+- `arc: {start, end}` — freeform drag range (default `{0, 24}`).
+- `chipSelection: Set` — selected day-period chips (default all).
+- `chartShape: 'polar' | 'xy'`.
+- `visualRanges` — ranges to display (chip union when chips active, else `arc`).
+- `timeRange.ranges` — the actual query filter (empty when all chips selected = no filter).
+
+Drag is disabled when chips drive selection: `onArcChange` is `undefined` and polar `mode='chips'`.
+
+## Proposed changes
+
+### Polar mode — `CircularTimeFilter`
+
+- **Remove** the blue pie-sector and the full-circle fill that overlay the radar (both the `drag` arc and the `chips` sectors).
+- **Add a selection ring** as a concentric band *outside* the radar circle. The radar's outer edge stays at radius 47; the ring occupies roughly radius 50–57.
+  - Render selected hour ranges as blue arc segments on the ring (light track-gray background ring underneath).
+  - Full-day selection → a complete blue ring. No arc-suppression hack — the full ring is the correct, readable "all selected" state, so `isFullDayRange()` suppression is dropped.
+  - Multiple disjoint ranges (from chips) → multiple blue arc segments.
+- **Grow the SVG** padding/size so the ring and hour labels fit outside the radar without clipping.
+- **Move handles and drag onto the ring.** Start/end handle dots sit on the ring; resize/pan/wrap behaviour carries over from the existing angle math (`angleToTime`, the arc-drag delta logic). Commit-on-release unchanged.
+- Hour labels (0/6/12/18) and tick marks remain.
+
+### Line mode — `DailyActivityLine`
+
+- **Remove** the full-height `ReferenceArea` selection bands (live and committed) from the plot. The plot keeps only the data `Line`s, grid, and x-axis.
+- **Add a track strip** below the x-axis: a light-gray rounded background spanning 0–24, with blue rectangles over the selected ranges. Wrap-around ranges split into two segments (existing `bandToSegments` logic).
+- **Move handles and drag onto the strip.** Handle dots sit on the strip; `create` / `pan` / `edge-start` / `edge-end` modes and hover-preview cursors carry over, but hit-testing maps to the strip's geometry instead of the full plot width.
+- The `ReferenceLine` handles inside the chart are replaced by handles drawn on the strip.
+
+### Shared / extraction
+
+To keep rendering thin and make the logic testable, extract the pure helpers into a small module (e.g. `src/renderer/src/ui/clockGeometry.js`):
+
+- hour ↔ angle (`angleToTime`, `timeToAngle`) and hour ↔ x-ratio conversions,
+- range → renderable segments (wrap-around split),
+- drag-action resolution (`actionAt`, `edgeTolFor`, `isInsideBand`).
+
+Rendering components consume these helpers. This is the only structural refactor; no unrelated cleanup.
+
+## Data flow / state
+
+Unchanged. `activity.jsx` still owns `arc`, `chipSelection`, `chartShape`, `visualRanges`, `timeRange`. The components receive the same props (`onChange`/`onArcChange`, `startTime`/`endTime`/`selectedRanges`, `mode`/`chipSectors`) and emit the same commit-on-release `{start, end}`. Downstream queries are untouched.
+
+## Out of scope
+
+- Changing what the filter computes or how queries consume `timeRange.ranges`.
+- Restyling the day-period chips, the chart-shape toggle, or the timeline chart.
+- Touching `dayPeriods.js` preset ranges.
+
+## Testing & verification
+
+- **Unit:** test the extracted pure helpers in `clockGeometry.js` (angle/x conversions, wrap-around segment splitting, drag-action resolution at boundaries) via `node --test`.
+- **Manual:** run the app and verify in both modes:
+  - default (all selected) → full blue track, plot/radar fully readable (no blue wash);
+  - drag on the track to resize and to pan across midnight;
+  - selecting chips paints the correct blue segments and disables track dragging;
+  - committing a selection updates the downstream filter exactly as before.
+- **Regression:** `npm test` stays green (baseline: 1400 pass, 0 fail).
+
+## Docs to update (per CLAUDE.md)
+
+No IPC/schema/format changes, so the backend docs are unaffected. This is a renderer-only UI change; no `docs/*.md` updates are required beyond this spec.

--- a/src/renderer/src/ui/chartShapeToggle.jsx
+++ b/src/renderer/src/ui/chartShapeToggle.jsx
@@ -10,8 +10,20 @@ import * as Tooltip from '@radix-ui/react-tooltip'
  *   onChange: (next) => void
  */
 const SHAPES = [
-  { key: 'polar', label: 'Polar', Icon: ChartPie },
-  { key: 'xy', label: 'X–Y line', Icon: ChartLine }
+  {
+    key: 'polar',
+    label: 'Polar',
+    Icon: ChartPie,
+    blurb:
+      'A 24-hour clock face. Best for reading the daily rhythm at a glance — dawn and dusk peaks, day vs. night activity, and patterns that wrap around midnight.'
+  },
+  {
+    key: 'xy',
+    label: 'X–Y line',
+    Icon: ChartLine,
+    blurb:
+      'A straight 0–24h axis. Best for reading exact hourly values and comparing several species’ curves side by side.'
+  }
 ]
 
 export default function ChartShapeToggle({ value, onChange }) {
@@ -21,7 +33,7 @@ export default function ChartShapeToggle({ value, onChange }) {
       role="radiogroup"
       aria-label="Chart shape"
     >
-      {SHAPES.map(({ key, label, Icon }, idx) => {
+      {SHAPES.map(({ key, label, Icon, blurb }, idx) => {
         const active = value === key
         const isFirst = idx === 0
         return (
@@ -48,9 +60,10 @@ export default function ChartShapeToggle({ value, onChange }) {
               <Tooltip.Content
                 side="top"
                 sideOffset={6}
-                className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+                className="z-[10000] max-w-[220px] px-2.5 py-1.5 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
               >
-                {label}
+                <p className="font-medium">{label}</p>
+                <p className="mt-0.5 text-muted-foreground leading-snug">{blurb}</p>
               </Tooltip.Content>
             </Tooltip.Portal>
           </Tooltip.Root>

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -28,7 +28,7 @@ const CLOCK_OUTER_RADIUS_PX = 42
 // Selection ring sits just OUTSIDE the radar circle so it never covers the
 // activity blob. Radii are in the same px space as CLOCK_OUTER_RADIUS_PX.
 const RING_GAP = 2 // gap between radar edge and ring
-const RING_WIDTH = 6 // stroke thickness of the ring
+const RING_WIDTH = 4 // stroke thickness of the ring
 const RING_MID = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH / 2
 const RING_OUTER = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH
 
@@ -541,7 +541,7 @@ const DailyActivityLine = ({
       <div className="px-2 pb-1" style={cursorStyle ? { cursor: cursorStyle } : undefined}>
         <div
           ref={stripRef}
-          className="relative h-2.5 rounded-full bg-muted"
+          className="relative h-1.5 rounded-full bg-muted"
           onMouseDown={handleStripDown}
           onMouseMove={handleStripMove}
           onMouseLeave={handleStripLeave}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -13,11 +13,19 @@ import {
   XAxis,
   YAxis
 } from 'recharts'
+import { timeToAngle, angleToTime, rangesToSegments } from './clockGeometry.js'
 
 // Outer-ring radius (in px) shared by the visible 24-hour circle and the
 // radar chart underneath it. Keeping them equal makes the busiest species'
 // peaks land exactly on the ring instead of overflowing it.
 const CLOCK_OUTER_RADIUS_PX = 47
+
+// Selection ring sits just OUTSIDE the radar circle so it never covers the
+// activity blob. Radii are in the same px space as CLOCK_OUTER_RADIUS_PX.
+const RING_GAP = 4 // gap between radar edge and ring
+const RING_WIDTH = 7 // stroke thickness of the ring
+const RING_MID = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH / 2
+const RING_OUTER = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH
 
 const CircularTimeFilter = ({
   onChange,
@@ -33,39 +41,39 @@ const CircularTimeFilter = ({
   const [end, setEnd] = useState(endTime)
   const [lastDragPosition, setLastDragPosition] = useState(null)
   const svgRef = useRef(null)
-  const radius = CLOCK_OUTER_RADIUS_PX
-  const padding = 16 // Padding leaves room for hour labels outside the circle
-  const svgSize = radius * 2 + padding * 2 // Increase SVG size to accommodate padding
-  const center = { x: radius + padding, y: radius + padding } // Adjust center coordinates
-  const labelOffset = 9 // Distance from circle edge to label center
 
-  // Sync local state when parent updates the bounds externally (e.g. tab
-  // switch). Does NOT fire onChange continuously — that happens only on
-  // pointer release so downstream queries don't refetch per-mousemove.
+  const padding = 16 // room for hour labels outside the ring
+  const svgSize = RING_OUTER * 2 + padding * 2
+  const center = { x: RING_OUTER + padding, y: RING_OUTER + padding }
+  const labelOffset = RING_OUTER + 9
+
+  // Sync local state when parent updates bounds externally. Does NOT fire
+  // onChange continuously — that happens only on pointer release.
   useEffect(() => {
     setStart(startTime)
     setEnd(endTime)
   }, [startTime, endTime])
 
-  const isFullDayRange = () => {
-    return Math.abs(end - start) >= 23.9 || start === end
+  const interactive = mode !== 'chips'
+  // Ranges to paint as blue arcs: the live drag band, or the chip sectors.
+  const ranges = interactive ? [{ start, end }] : chipSectors
+  const segments = rangesToSegments(ranges)
+  const isFullRing = segments.length === 1 && segments[0][0] === 0 && segments[0][1] === 24
+
+  // Point on a circle of radius r at the given clock hour.
+  const pointAt = (hour, r) => {
+    const rad = (timeToAngle(hour) - 90) * (Math.PI / 180)
+    return { x: center.x + r * Math.cos(rad), y: center.y + r * Math.sin(rad) }
   }
 
-  const angleToTime = (angle) => {
-    let time = (angle / 15) % 24
-    return time
-  }
-
-  const timeToAngle = (time) => {
-    return (time * 15) % 360
-  }
-
-  const angleToCoordinates = (angle) => {
-    const radians = (angle - 90) * (Math.PI / 180)
-    return {
-      x: center.x + radius * Math.cos(radians),
-      y: center.y + radius * Math.sin(radians)
-    }
+  // Open arc (stroked, not filled) along RING_MID from startHour to endHour,
+  // drawn clockwise. Used for partial selections.
+  const ringArcPath = (startHour, endHour) => {
+    const a = pointAt(startHour, RING_MID)
+    const b = pointAt(endHour, RING_MID)
+    const sweep = (((endHour - startHour) % 24) + 24) % 24
+    const largeArc = sweep > 12 ? 1 : 0
+    return `M ${a.x} ${a.y} A ${RING_MID} ${RING_MID} 0 ${largeArc} 1 ${b.x} ${b.y}`
   }
 
   const handleMouseDown = (handle) => (e) => {
@@ -75,25 +83,20 @@ const CircularTimeFilter = ({
       setIsDraggingEnd(true)
     } else if (handle === 'arc') {
       setIsDraggingArc(true)
-
       const svgRect = svgRef.current.getBoundingClientRect()
       const x = e.clientX - svgRect.left - center.x
       const y = e.clientY - svgRect.top - center.y
-
       let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
       if (angle < 0) angle += 360
-
       setLastDragPosition(angle)
     }
   }
 
   const handleMouseMove = (e) => {
     if (!isDraggingStart && !isDraggingEnd && !isDraggingArc) return
-
     const svgRect = svgRef.current.getBoundingClientRect()
     const x = e.clientX - svgRect.left - center.x
     const y = e.clientY - svgRect.top - center.y
-
     let angle = Math.atan2(y, x) * (180 / Math.PI) + 90
     if (angle < 0) angle += 360
 
@@ -104,22 +107,16 @@ const CircularTimeFilter = ({
     } else if (isDraggingArc) {
       if (lastDragPosition !== null) {
         let angleDiff = angle - lastDragPosition
-
         if (angleDiff > 180) angleDiff -= 360
         if (angleDiff < -180) angleDiff += 360
-
         const timeDiff = angleDiff / 15
-
         let newStart = (start + timeDiff) % 24
         let newEnd = (end + timeDiff) % 24
-
         if (newStart < 0) newStart += 24
         if (newEnd < 0) newEnd += 24
-
         setStart(newStart)
         setEnd(newEnd)
       }
-
       setLastDragPosition(angle)
     }
   }
@@ -130,8 +127,7 @@ const CircularTimeFilter = ({
     setIsDraggingEnd(false)
     setIsDraggingArc(false)
     setLastDragPosition(null)
-    // Commit-on-release: fire onChange once with the final value, rather
-    // than per-mousemove during the drag.
+    // Commit-on-release: fire onChange once with the final value.
     if (wasDragging) onChange({ start, end })
   }
 
@@ -140,7 +136,6 @@ const CircularTimeFilter = ({
       window.addEventListener('mouseup', handleMouseUp)
       window.addEventListener('mousemove', handleMouseMove)
     }
-
     return () => {
       window.removeEventListener('mouseup', handleMouseUp)
       window.removeEventListener('mousemove', handleMouseMove)
@@ -148,42 +143,8 @@ const CircularTimeFilter = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDraggingStart, isDraggingEnd, isDraggingArc, lastDragPosition])
 
-  const startCoord = angleToCoordinates(timeToAngle(start))
-  const endCoord = angleToCoordinates(timeToAngle(end))
-
-  const createArc = (startAngle, endAngle) => {
-    // Full-day check based on the PASSED angles (not closure state) so this
-    // helper works correctly for both the drag arc and chip-driven sectors.
-    const sweep = (((endAngle - startAngle) % 360) + 360) % 360
-    if (startAngle === endAngle || sweep >= 358.5) {
-      return `M ${center.x} ${center.y}
-              L ${center.x} ${center.y - radius}
-              A ${radius} ${radius} 0 1 1 ${center.x - 0.1} ${center.y - radius}
-              Z`
-    }
-
-    const startRad = (startAngle - 90) * (Math.PI / 180)
-    const endRad = (endAngle - 90) * (Math.PI / 180)
-
-    let largeArcFlag
-    if (startAngle <= endAngle) {
-      largeArcFlag = endAngle - startAngle <= 180 ? 0 : 1
-    } else {
-      largeArcFlag = 360 - startAngle + endAngle <= 180 ? 0 : 1
-    }
-
-    const startX = center.x + radius * Math.cos(startRad)
-    const startY = center.y + radius * Math.sin(startRad)
-    const endX = center.x + radius * Math.cos(endRad)
-    const endY = center.y + radius * Math.sin(endRad)
-
-    // Create a pie section by starting at center, moving to arc start,
-    // drawing the arc, then closing back to center
-    return `M ${center.x} ${center.y}
-            L ${startX} ${startY}
-            A ${radius} ${radius} 0 ${largeArcFlag} 1 ${endX} ${endY}
-            Z`
-  }
+  const startCoord = pointAt(start, RING_MID)
+  const endCoord = pointAt(end, RING_MID)
 
   return (
     <div className="flex flex-col items-center justify-center w-full h-full">
@@ -194,19 +155,20 @@ const CircularTimeFilter = ({
         onMouseMove={handleMouseMove}
         ref={svgRef}
       >
+        {/* Inner reference circle aligned to the radar's outer edge. */}
         <circle
           cx={center.x}
           cy={center.y}
-          r={radius}
+          r={CLOCK_OUTER_RADIUS_PX}
           fill="none"
           stroke="var(--color-border)"
-          strokeWidth="2"
+          strokeWidth="1"
         />
 
-        {/* Hour labels at the four cardinal points, just outside the circle */}
+        {/* Hour labels just outside the ring. */}
         <text
           x={center.x}
-          y={center.y - radius - labelOffset}
+          y={center.y - labelOffset}
           textAnchor="middle"
           dominantBaseline="middle"
           fontSize="9"
@@ -215,7 +177,7 @@ const CircularTimeFilter = ({
           0h
         </text>
         <text
-          x={center.x + radius + labelOffset}
+          x={center.x + labelOffset}
           y={center.y}
           textAnchor="middle"
           dominantBaseline="middle"
@@ -226,7 +188,7 @@ const CircularTimeFilter = ({
         </text>
         <text
           x={center.x}
-          y={center.y + radius + labelOffset}
+          y={center.y + labelOffset}
           textAnchor="middle"
           dominantBaseline="middle"
           fontSize="9"
@@ -235,7 +197,7 @@ const CircularTimeFilter = ({
           12h
         </text>
         <text
-          x={center.x - radius - labelOffset}
+          x={center.x - labelOffset}
           y={center.y}
           textAnchor="middle"
           dominantBaseline="middle"
@@ -245,87 +207,64 @@ const CircularTimeFilter = ({
           18h
         </text>
 
-        {Array.from({ length: 24 }).map((_, i) => {
-          const angle = timeToAngle(i)
-          const coord = angleToCoordinates(angle)
-          const isMajor = i % 6 === 0
+        {/* Gray track ring. */}
+        <circle
+          cx={center.x}
+          cy={center.y}
+          r={RING_MID}
+          fill="none"
+          stroke="var(--color-muted)"
+          strokeWidth={RING_WIDTH}
+        />
 
-          return (
-            <g key={i}>
-              <line
-                x1={
-                  isMajor
-                    ? center.x + (radius - 5) * Math.cos((angle - 90) * (Math.PI / 180))
-                    : coord.x
-                }
-                y1={
-                  isMajor
-                    ? center.y + (radius - 5) * Math.sin((angle - 90) * (Math.PI / 180))
-                    : coord.y
-                }
-                x2={coord.x}
-                y2={coord.y}
-                stroke="var(--color-muted-foreground)"
-                strokeWidth={isMajor ? 2 : 1}
-              />
-            </g>
-          )
-        })}
-
-        {mode === 'chips' ? (
-          chipSectors.map((sector, i) =>
-            sector.start === 0 && sector.end === 24 ? (
-              <circle
-                key={i}
-                cx={center.x}
-                cy={center.y}
-                r={radius}
-                fill="rgb(59 130 246 / 0.15)"
-                stroke="rgb(59 130 246 / 0.8)"
-                strokeWidth="2"
-                pointerEvents="none"
-              />
-            ) : (
-              <path
-                key={i}
-                d={createArc(timeToAngle(sector.start), timeToAngle(sector.end))}
-                fill="rgb(59 130 246 / 0.15)"
-                stroke="rgb(59 130 246 / 0.8)"
-                strokeWidth="2"
-                pointerEvents="none"
-              />
-            )
-          )
+        {/* Blue selection on the ring. Full-day -> full ring; else arcs.
+            The arc is the drag target for panning in interactive mode. */}
+        {isFullRing ? (
+          <circle
+            cx={center.x}
+            cy={center.y}
+            r={RING_MID}
+            fill="none"
+            stroke="rgb(59 130 246)"
+            strokeWidth={RING_WIDTH}
+            cursor={interactive ? 'pointer' : 'default'}
+            onMouseDown={interactive ? handleMouseDown('arc') : undefined}
+          />
         ) : (
-          <>
-            {/* Suppress the highlight arc when the drag selection is full-day —
-                otherwise "no filter" looks identical to "everything selected".
-                Handles stay visible (overlap at top) so the user can still drag. */}
-            {!isFullDayRange() && (
-              <path
-                d={createArc(timeToAngle(start), timeToAngle(end))}
-                fill="rgb(59 130 246 / 0.15)"
-                stroke="rgb(59 130 246 / 0.8)"
-                strokeWidth="2"
-                cursor="pointer"
-                onMouseDown={handleMouseDown('arc')}
-              />
-            )}
+          segments.map(([s, e], i) => (
+            <path
+              key={i}
+              d={ringArcPath(s, e)}
+              fill="none"
+              stroke="rgb(59 130 246)"
+              strokeWidth={RING_WIDTH}
+              strokeLinecap="butt"
+              cursor={interactive ? 'pointer' : 'default'}
+              onMouseDown={interactive ? handleMouseDown('arc') : undefined}
+            />
+          ))
+        )}
 
+        {/* Draggable handles (interactive mode only). */}
+        {interactive && (
+          <>
             <circle
               cx={startCoord.x}
               cy={startCoord.y}
-              r="4"
+              r="5"
               fill="rgb(59 130 246)"
+              stroke="white"
+              strokeWidth="1.5"
               cursor="pointer"
               onMouseDown={handleMouseDown('start')}
             />
-
             <circle
               cx={endCoord.x}
               cy={endCoord.y}
-              r="4"
+              r="5"
               fill="rgb(59 130 246)"
+              stroke="white"
+              strokeWidth="1.5"
               cursor="pointer"
               onMouseDown={handleMouseDown('end')}
             />

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -144,8 +144,11 @@ const CircularTimeFilter = ({
       window.removeEventListener('mouseup', handleMouseUp)
       window.removeEventListener('mousemove', handleMouseMove)
     }
+    // start/end are in the deps so the window listeners always close over the
+    // current range — otherwise dragging a start/end handle commits the stale
+    // pre-drag value on release (lastDragPosition only changes during arc pans).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDraggingStart, isDraggingEnd, isDraggingArc, lastDragPosition])
+  }, [isDraggingStart, isDraggingEnd, isDraggingArc, lastDragPosition, start, end])
 
   const startCoord = pointAt(start, RING_MID)
   const endCoord = pointAt(end, RING_MID)

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -7,13 +7,17 @@ import {
   PolarGrid,
   Radar,
   RadarChart,
-  ReferenceArea,
-  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis
 } from 'recharts'
-import { timeToAngle, angleToTime, rangesToSegments } from './clockGeometry.js'
+import {
+  timeToAngle,
+  angleToTime,
+  rangesToSegments,
+  bandToSegments,
+  resolveAction
+} from './clockGeometry.js'
 
 // Outer-ring radius (in px) shared by the visible 24-hour circle and the
 // radar chart underneath it. Keeping them equal makes the busiest species'
@@ -330,17 +334,16 @@ const DailyActivityRadar = ({ activityData, selectedSpecies, palette }) => {
 
 /**
  * X–Y twin of DailyActivityRadar. Renders the same hourly-bin data as a
- * line per species across a 24-hour x-axis. Selected ranges are shaded
- * with the same blue used by the polar arc.
+ * line per species across a 24-hour x-axis. The selected ranges are shown
+ * in a dedicated track strip BELOW the axis (not over the plot), so the
+ * activity curves stay unobstructed.
  *
  * Props mirror DailyActivityRadar plus:
  *   selectedRanges: Array<{start, end}> — hour ranges currently in the
- *     filter. Rendered as shaded bands.
+ *     filter. Rendered as blue segments on the track strip.
  *   onArcChange: optional ({start, end}) => void — when provided AND there
- *     is exactly one (non-wrap-around) selected range, the chart shows a
- *     draggable end-line that the user can slide to extend/contract the
- *     range. Pass undefined (e.g. while chips are driving selection) to
- *     disable.
+ *     is at most one selected range, the strip is draggable (create / resize
+ *     / pan). Pass undefined (e.g. while chips drive selection) to disable.
  */
 const DailyActivityLine = ({
   activityData,
@@ -349,87 +352,43 @@ const DailyActivityLine = ({
   selectedRanges = [],
   onArcChange
 }) => {
-  // Drag interactions on the x-y chart:
-  //   - click NEAR the end edge of an existing band  → slide the end edge
-  //   - click INSIDE the band (not near edge)         → pan the whole band
-  //                                                     (wraps at midnight)
-  //   - click OUTSIDE any band, or no band at all     → drag-to-create
-  // Wrap-around selections are panned but not edge-slid.
   const hasSingleBand = selectedRanges.length === 1
   const isWrapBand = hasSingleBand && selectedRanges[0].start >= selectedRanges[0].end
   const dragEnabled =
     typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
 
-  const containerRef = useRef(null)
+  const stripRef = useRef(null)
   const [dragState, setDragState] = useState(null)
-  // dragState shape:
-  //   { mode: 'end',    liveStart, liveEnd }
-  //   { mode: 'start',  liveStart, liveEnd }
-  //   { mode: 'pan',    liveStart, liveEnd, panOffset, panWidth }
-  //   { mode: 'create', liveStart, liveEnd }
+  // dragState: { mode: 'create'|'start'|'end'|'pan', liveStart, liveEnd, panOffset?, panWidth? }
   const isDragging = dragState !== null
-  // Tracks what the cursor is hovering OVER (when not dragging) so we can
-  // preview the action that a click would trigger.
   const [hoverAction, setHoverAction] = useState(null)
 
-  // Convert a native pointer event to a chart-x hour value, accounting for
-  // the ComposedChart's left/right margin so the hover preview matches what
-  // a click would actually hit. When `clamp01` is false the result can fall
-  // outside [0, 24] — used during pan so the band keeps wrapping past the
-  // chart's edge.
+  // Pointer x over the strip -> hour [0,24]. The strip's inner box already
+  // excludes the 8px insets, so no margin math is needed. When clamp01 is
+  // false the value can exceed [0,24] (used during pan so the band wraps).
   const eventToHour = (e, { clamp01 = true } = {}) => {
-    if (!containerRef.current) return null
-    const rect = containerRef.current.getBoundingClientRect()
-    const marginLeft = 8
-    const marginRight = 8
-    const innerWidth = rect.width - marginLeft - marginRight
-    if (innerWidth <= 0) return null
-    const xPx = e.clientX - rect.left - marginLeft
-    const rawRatio = xPx / innerWidth
-    const ratio = clamp01 ? Math.max(0, Math.min(1, rawRatio)) : rawRatio
+    if (!stripRef.current) return null
+    const rect = stripRef.current.getBoundingClientRect()
+    if (rect.width <= 0) return null
+    const raw = (e.clientX - rect.left) / rect.width
+    const ratio = clamp01 ? Math.max(0, Math.min(1, raw)) : raw
     return ratio * 24
   }
 
-  // Whether `cursor` is inside the (possibly wrap-around) band.
-  const isInsideBand = (cursor, band) => {
-    if (band.start < band.end) return cursor > band.start && cursor < band.end
-    return cursor > band.start || cursor < band.end
-  }
-
-  // Compute what action a click at `cursor` would trigger (used for both
-  // hover-cursor previewing and the actual mousedown branch). Edge zones
-  // are at least 1h wide so they're easy to target on short bands;
-  // capped at 2h so they don't take over wide bands.
-  const edgeTolFor = (width) => Math.max(1, Math.min(2, width / 3))
-  const actionAt = (cursor) => {
-    if (!hasSingleBand) return 'create'
-    const { start, end } = selectedRanges[0]
-    const width = isWrapBand ? 24 - start + end : end - start
-    const edgeTol = edgeTolFor(width)
-    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) return 'edge-end'
-    if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) return 'edge-start'
-    if (isInsideBand(cursor, { start, end })) return 'pan'
-    return 'create'
-  }
-
   const handleMouseUp = () => {
-    // Use functional setState so we read the LATEST drag state (the
-    // document-level listener was registered with a stale closure
-    // otherwise — committed band would lag the cursor).
     setDragState((prev) => {
       if (prev) {
         const { mode, liveStart, liveEnd } = prev
         if (mode === 'pan') {
           onArcChange({ start: liveStart, end: liveEnd })
         } else if (liveStart !== liveEnd) {
-          const start = Math.min(liveStart, liveEnd)
-          const end = Math.max(liveStart, liveEnd)
-          onArcChange({ start, end })
+          onArcChange({ start: Math.min(liveStart, liveEnd), end: Math.max(liveStart, liveEnd) })
         }
       }
       return null
     })
   }
+
   const formatData = (data) => {
     if (!data || !data.length) {
       return Array(24)
@@ -440,29 +399,6 @@ const DailyActivityLine = ({
   }
   const formattedData = formatData(activityData)
 
-  // Highlight the SELECTED ranges (consistent with the polar's blue arc).
-  // Wrap-around ranges (start > end) split into two pieces.
-  const selectedBands = []
-  for (const r of selectedRanges) {
-    if (r.start === r.end) continue
-    if (r.start < r.end) {
-      selectedBands.push([r.start, r.end])
-    } else {
-      selectedBands.push([r.start, 24])
-      selectedBands.push([0, r.end])
-    }
-  }
-
-  // Convert a (possibly wrap-around) {start, end} band into one or two
-  // ReferenceArea-friendly [s, e] segments.
-  const bandToSegments = (band) => {
-    if (band.start === band.end) return []
-    if (band.start < band.end) return [[band.start, band.end]]
-    return [
-      [band.start, 24],
-      [0, band.end]
-    ]
-  }
   // Live band while dragging — for pan it can wrap around midnight.
   const liveBand = (() => {
     if (!isDragging) return null
@@ -470,15 +406,13 @@ const DailyActivityLine = ({
     if (mode === 'pan') return { start: liveStart, end: liveEnd }
     return { start: Math.min(liveStart, liveEnd), end: Math.max(liveStart, liveEnd) }
   })()
-  const liveSegments = liveBand ? bandToSegments(liveBand) : []
 
-  // Edge-line positions for the visible handles.
+  // Segments + handle positions: live band while dragging, else the committed selection.
+  const segments = liveBand ? bandToSegments(liveBand) : rangesToSegments(selectedRanges)
   const handleStartX = (() => {
     if (isDragging) {
       const { mode, liveStart, liveEnd } = dragState
-      if (mode === 'pan') return liveStart
-      if (mode === 'create') return Math.min(liveStart, liveEnd)
-      return Math.min(liveStart, liveEnd)
+      return mode === 'pan' ? liveStart : Math.min(liveStart, liveEnd)
     }
     if (hasSingleBand && !isWrapBand) return selectedRanges[0].start
     return null
@@ -486,17 +420,12 @@ const DailyActivityLine = ({
   const handleEndX = (() => {
     if (isDragging) {
       const { mode, liveStart, liveEnd } = dragState
-      if (mode === 'pan') return liveEnd
-      if (mode === 'create') return Math.max(liveStart, liveEnd)
-      return Math.max(liveStart, liveEnd)
+      return mode === 'pan' ? liveEnd : Math.max(liveStart, liveEnd)
     }
     if (hasSingleBand && !isWrapBand) return selectedRanges[0].end
     return null
   })()
 
-  // Dynamic cursor: previews the action when idle, reflects it during drag.
-  // Use an inline style + child selector so Recharts' SVG elements don't
-  // override the cursor with their own defaults.
   const cursorStyle = (() => {
     if (!dragEnabled) return undefined
     const action = isDragging ? dragState.mode : hoverAction
@@ -506,8 +435,6 @@ const DailyActivityLine = ({
     if (action === 'create') return 'crosshair'
     return 'default'
   })()
-  // Which edge (if any) is currently being hovered — used to make the
-  // corresponding handle dot pop visually.
   const hoveredEdge =
     hoverAction === 'edge-start' || (isDragging && dragState.mode === 'start')
       ? 'start'
@@ -515,10 +442,7 @@ const DailyActivityLine = ({
         ? 'end'
         : null
 
-  // While a drag is in progress, listen on the document so the user can
-  // move the cursor outside the chart and the drag keeps tracking. For
-  // pan mode the cursor is intentionally NOT clamped so the band keeps
-  // wrapping past midnight as the user drags further left/right.
+  // While dragging, listen on the document so the cursor can leave the strip.
   useEffect(() => {
     if (!isDragging) return
     const onDocMove = (e) => {
@@ -545,158 +469,110 @@ const DailyActivityLine = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDragging])
 
-  // Native mouse handlers on the wrapping div for hover-preview only;
-  // mousedown still starts the drag but mousemove/mouseup are taken over
-  // by the document-level listeners above.
-  const handleNativeMove = (e) => {
+  const handleStripMove = (e) => {
     if (isDragging || !dragEnabled) return
     const cursor = eventToHour(e)
     if (cursor === null) return
-    setHoverAction(actionAt(cursor))
+    setHoverAction(resolveAction(cursor, selectedRanges))
   }
-  const handleNativeDown = (e) => {
+  const handleStripDown = (e) => {
     if (!dragEnabled) return
-    // Stop the native drag-selects-text behavior the moment we start handling.
     e.preventDefault()
     const cursor = eventToHour(e)
     if (cursor === null) return
-    if (!hasSingleBand) {
+    const action = resolveAction(cursor, selectedRanges)
+    if (action === 'create') {
       setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
-      return
-    }
-    const { start, end } = selectedRanges[0]
-    const width = isWrapBand ? 24 - start + end : end - start
-    const edgeTol = edgeTolFor(width)
-    if (!isWrapBand && cursor >= end - edgeTol && cursor <= end + edgeTol) {
-      setDragState({ mode: 'end', liveStart: start, liveEnd: cursor })
-    } else if (!isWrapBand && cursor >= start - edgeTol && cursor <= start + edgeTol) {
-      setDragState({ mode: 'start', liveStart: cursor, liveEnd: end })
-    } else if (isInsideBand(cursor, { start, end })) {
+    } else if (action === 'edge-end') {
+      setDragState({ mode: 'end', liveStart: selectedRanges[0].start, liveEnd: cursor })
+    } else if (action === 'edge-start') {
+      setDragState({ mode: 'start', liveStart: cursor, liveEnd: selectedRanges[0].end })
+    } else {
+      // pan
+      const { start, end } = selectedRanges[0]
+      const width = isWrapBand ? 24 - start + end : end - start
       const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
       setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
-    } else {
-      setDragState({ mode: 'create', liveStart: cursor, liveEnd: cursor })
     }
   }
-  // Only clear hover preview on leave; never cancel an in-progress drag
-  // (the document-level listeners handle move/up while dragging).
-  const handleNativeLeave = () => {
+  const handleStripLeave = () => {
     if (!isDragging) setHoverAction(null)
   }
 
+  const pct = (hour) => `${(hour / 24) * 100}%`
+
   return (
-    <div
-      ref={containerRef}
-      className="relative w-full h-full select-none [&_*]:!cursor-[inherit]"
-      style={cursorStyle ? { cursor: cursorStyle } : undefined}
-      onMouseDown={handleNativeDown}
-      onMouseMove={handleNativeMove}
-      onMouseLeave={handleNativeLeave}
-    >
-      <ResponsiveContainer width="100%" height="100%">
-        <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
-          <CartesianGrid strokeOpacity={0} />
-          <XAxis
-            dataKey="hour"
-            type="number"
-            domain={[0, 24]}
-            ticks={[0, 6, 12, 18, 24]}
-            tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
-            axisLine={false}
-            tickLine={false}
-          />
-          <YAxis hide domain={[0, 'auto']} />
-          {/* While dragging, show only the live band; otherwise the committed bands. */}
-          {isDragging
-            ? liveSegments.map(([s, e], i) => (
-                <ReferenceArea
-                  key={i}
-                  x1={s}
-                  x2={e}
-                  fill="rgb(59 130 246)"
-                  fillOpacity={0.2}
-                  stroke="rgb(59 130 246)"
-                  strokeOpacity={0.7}
-                  strokeWidth={1}
-                />
-              ))
-            : selectedBands.map(([s, e], i) => (
-                <ReferenceArea
-                  key={i}
-                  x1={s}
-                  x2={e}
-                  fill="rgb(59 130 246)"
-                  fillOpacity={0.15}
-                  stroke="rgb(59 130 246)"
-                  strokeOpacity={0.5}
-                  strokeWidth={1}
-                />
-              ))}
-          {/* Draggable start-line handle (dot centered vertically on the line). */}
-          {dragEnabled && handleStartX !== null && (
-            <ReferenceLine
-              x={handleStartX}
-              stroke="rgb(59 130 246)"
-              strokeWidth={hoveredEdge === 'start' ? 3 : 2}
-              isFront
-              label={{
-                position: 'center',
-                content: ({ viewBox }) => {
-                  if (!viewBox || viewBox.x === undefined) return null
-                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
-                  return (
-                    <circle
-                      cx={viewBox.x}
-                      cy={cy}
-                      r={hoveredEdge === 'start' ? 6 : 4}
-                      fill="rgb(59 130 246)"
-                      stroke="white"
-                      strokeWidth={1}
-                    />
-                  )
-                }
-              }}
+    <div className="relative w-full h-full flex flex-col select-none">
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={formattedData} margin={{ top: 4, right: 8, bottom: 0, left: 8 }}>
+            <CartesianGrid strokeOpacity={0} />
+            <XAxis
+              dataKey="hour"
+              type="number"
+              domain={[0, 24]}
+              ticks={[0, 6, 12, 18, 24]}
+              tick={{ fontSize: 9, fill: 'var(--color-muted-foreground)' }}
+              axisLine={false}
+              tickLine={false}
             />
-          )}
-          {/* Draggable end-line handle. */}
-          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
-            <ReferenceLine
-              x={handleEndX}
-              stroke="rgb(59 130 246)"
-              strokeWidth={hoveredEdge === 'end' ? 3 : 2}
-              isFront
-              label={{
-                position: 'center',
-                content: ({ viewBox }) => {
-                  if (!viewBox || viewBox.x === undefined) return null
-                  const cy = viewBox.y + (viewBox.height ?? 0) / 2
-                  return (
-                    <circle
-                      cx={viewBox.x}
-                      cy={cy}
-                      r={hoveredEdge === 'end' ? 6 : 4}
-                      fill="rgb(59 130 246)"
-                      stroke="white"
-                      strokeWidth={1}
-                    />
-                  )
-                }
-              }}
-            />
-          )}
-          {selectedSpecies.map((species, index) => (
-            <Line
-              key={species.scientificName}
-              type="monotone"
-              dataKey={species.scientificName}
-              stroke={palette[index % palette.length]}
-              strokeWidth={1.5}
-              dot={false}
-              isAnimationActive={false}
+            <YAxis hide domain={[0, 'auto']} />
+            {selectedSpecies.map((species, index) => (
+              <Line
+                key={species.scientificName}
+                type="monotone"
+                dataKey={species.scientificName}
+                stroke={palette[index % palette.length]}
+                strokeWidth={1.5}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* Selection track strip below the axis. 8px insets match the chart's
+          left/right margin so hour 0..24 line up with the plot. */}
+      <div className="px-2 pb-1" style={cursorStyle ? { cursor: cursorStyle } : undefined}>
+        <div
+          ref={stripRef}
+          className="relative h-2.5 rounded-full bg-muted"
+          onMouseDown={handleStripDown}
+          onMouseMove={handleStripMove}
+          onMouseLeave={handleStripLeave}
+        >
+          {segments.map(([s, e], i) => (
+            <div
+              key={i}
+              className="absolute top-0 h-full rounded-full"
+              style={{ left: pct(s), width: pct(e - s), backgroundColor: 'rgb(59 130 246)' }}
             />
           ))}
-        </ComposedChart>
-      </ResponsiveContainer>
+          {dragEnabled && handleStartX !== null && (
+            <div
+              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
+              style={{
+                left: pct(handleStartX),
+                width: hoveredEdge === 'start' ? 12 : 9,
+                height: hoveredEdge === 'start' ? 12 : 9,
+                transform: 'translate(-50%, -50%)'
+              }}
+            />
+          )}
+          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
+            <div
+              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
+              style={{
+                left: pct(handleEndX),
+                width: hoveredEdge === 'end' ? 12 : 9,
+                height: hoveredEdge === 'end' ? 12 : 9,
+                transform: 'translate(-50%, -50%)'
+              }}
+            />
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -7,6 +7,7 @@ import {
   PolarGrid,
   Radar,
   RadarChart,
+  ReferenceLine,
   ResponsiveContainer,
   XAxis,
   YAxis
@@ -15,6 +16,7 @@ import {
   timeToAngle,
   angleToTime,
   rangesToSegments,
+  rangesToBoundaries,
   bandToSegments,
   resolveAction
 } from './clockGeometry.js'
@@ -64,6 +66,8 @@ const CircularTimeFilter = ({
   const ranges = interactive ? [{ start, end }] : chipSectors
   const segments = rangesToSegments(ranges)
   const isFullRing = segments.length === 1 && segments[0][0] === 0 && segments[0][1] === 24
+  // Interior boundary hours, drawn as dashed radial guides into the plot.
+  const boundaries = rangesToBoundaries(ranges)
 
   // Point on a circle of radius r at the given clock hour.
   const pointAt = (hour, r) => {
@@ -214,6 +218,25 @@ const CircularTimeFilter = ({
         >
           18h
         </text>
+
+        {/* Dashed radial guides at the selection boundaries (center -> radar
+            edge), so it's visible where the window sits over the activity. */}
+        {boundaries.map((hour) => {
+          const p = pointAt(hour, CLOCK_OUTER_RADIUS_PX)
+          return (
+            <line
+              key={`bound-${hour}`}
+              x1={center.x}
+              y1={center.y}
+              x2={p.x}
+              y2={p.y}
+              stroke="var(--color-muted-foreground)"
+              strokeWidth="1"
+              strokeDasharray="3 3"
+              strokeOpacity="0.5"
+            />
+          )
+        })}
 
         {/* Gray track ring. */}
         <circle
@@ -413,6 +436,8 @@ const DailyActivityLine = ({
 
   // Segments + handle positions: live band while dragging, else the committed selection.
   const segments = liveBand ? bandToSegments(liveBand) : rangesToSegments(selectedRanges)
+  // Interior boundary hours, drawn as dashed vertical guides in the plot.
+  const boundaries = rangesToBoundaries(liveBand ? [liveBand] : selectedRanges)
   const handleStartX = (() => {
     if (isDragging) {
       const { mode, liveStart, liveEnd } = dragState
@@ -521,6 +546,17 @@ const DailyActivityLine = ({
               tickLine={false}
             />
             <YAxis hide domain={[0, 'auto']} />
+            {/* Dashed vertical guides at the selection boundaries. */}
+            {boundaries.map((hour) => (
+              <ReferenceLine
+                key={`bound-${hour}`}
+                x={hour}
+                stroke="var(--color-muted-foreground)"
+                strokeWidth={1}
+                strokeDasharray="3 3"
+                strokeOpacity={0.5}
+              />
+            ))}
             {selectedSpecies.map((species, index) => (
               <Line
                 key={species.scientificName}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -19,15 +19,16 @@ import {
   resolveAction
 } from './clockGeometry.js'
 
-// Outer-ring radius (in px) shared by the visible 24-hour circle and the
-// radar chart underneath it. Keeping them equal makes the busiest species'
-// peaks land exactly on the ring instead of overflowing it.
-const CLOCK_OUTER_RADIUS_PX = 47
+// Outer radius (in px) of the activity radar and the inner reference circle.
+// The selection ring lives OUTSIDE this, so the radar is kept a little
+// smaller than the old full-size circle to leave room for the ring without
+// growing the widget's footprint (which would collide with the mode toggle).
+const CLOCK_OUTER_RADIUS_PX = 42
 
 // Selection ring sits just OUTSIDE the radar circle so it never covers the
 // activity blob. Radii are in the same px space as CLOCK_OUTER_RADIUS_PX.
-const RING_GAP = 4 // gap between radar edge and ring
-const RING_WIDTH = 7 // stroke thickness of the ring
+const RING_GAP = 2 // gap between radar edge and ring
+const RING_WIDTH = 6 // stroke thickness of the ring
 const RING_MID = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH / 2
 const RING_OUTER = CLOCK_OUTER_RADIUS_PX + RING_GAP + RING_WIDTH
 
@@ -46,10 +47,10 @@ const CircularTimeFilter = ({
   const [lastDragPosition, setLastDragPosition] = useState(null)
   const svgRef = useRef(null)
 
-  const padding = 16 // room for hour labels outside the ring
+  const padding = 14 // room for hour labels outside the ring
   const svgSize = RING_OUTER * 2 + padding * 2
   const center = { x: RING_OUTER + padding, y: RING_OUTER + padding }
-  const labelOffset = RING_OUTER + 9
+  const labelOffset = RING_OUTER + 8
 
   // Sync local state when parent updates bounds externally. Does NOT fire
   // onChange continuously — that happens only on pointer release.

--- a/src/renderer/src/ui/clockGeometry.js
+++ b/src/renderer/src/ui/clockGeometry.js
@@ -36,6 +36,18 @@ export const bandToSegments = (band) => {
 // Flatten an array of bands into renderable segments.
 export const rangesToSegments = (ranges) => ranges.flatMap(bandToSegments)
 
+// Distinct interior boundary hours of a selection, used to draw the dashed
+// guide lines in the plots. Endpoints at the 0/24 seam are dropped (they
+// coincide with the plot/circle edge), so a full-day selection yields none.
+export const rangesToBoundaries = (ranges) => {
+  const hours = new Set()
+  for (const [s, e] of rangesToSegments(ranges)) {
+    if (s !== 0 && s !== 24) hours.add(s)
+    if (e !== 0 && e !== 24) hours.add(e)
+  }
+  return [...hours].sort((a, b) => a - b)
+}
+
 // Decide what a click/drag at `cursor` (hours) should do, given the current
 // selection. Only a single non-wrap band supports edge-resize; everything
 // else is pan (inside) or create (outside / multi-band / empty).

--- a/src/renderer/src/ui/clockGeometry.js
+++ b/src/renderer/src/ui/clockGeometry.js
@@ -1,0 +1,52 @@
+/**
+ * Pure geometry + interaction helpers for the daytime-filter charts.
+ * No React, no DOM — unit-tested in test/renderer/ui/clockGeometry.test.js.
+ *
+ * Hours are 24h clock values; bands are {start, end} half-open ranges where
+ * start > end means the band wraps midnight (e.g. night 21 -> 5).
+ */
+
+// Clock angle in degrees, measured clockwise from 0h at the top.
+export const timeToAngle = (time) => (time * 15) % 360
+
+// Inverse of timeToAngle for an angle already normalized to [0, 360).
+export const angleToTime = (angle) => (angle / 15) % 24
+
+// Whether `cursor` (hours) falls strictly inside a possibly-wrapping band.
+export const isInsideBand = (cursor, band) => {
+  if (band.start < band.end) return cursor > band.start && cursor < band.end
+  return cursor > band.start || cursor < band.end
+}
+
+// Edge grab-zone half-width (hours): at least 1h so short bands are
+// targetable, capped at 2h so it never takes over a wide band.
+export const edgeTolFor = (width) => Math.max(1, Math.min(2, width / 3))
+
+// Split one band into renderable [start, end] segments, breaking a
+// wrap-around band into two pieces at midnight.
+export const bandToSegments = (band) => {
+  if (band.start === band.end) return []
+  if (band.start < band.end) return [[band.start, band.end]]
+  return [
+    [band.start, 24],
+    [0, band.end]
+  ]
+}
+
+// Flatten an array of bands into renderable segments.
+export const rangesToSegments = (ranges) => ranges.flatMap(bandToSegments)
+
+// Decide what a click/drag at `cursor` (hours) should do, given the current
+// selection. Only a single non-wrap band supports edge-resize; everything
+// else is pan (inside) or create (outside / multi-band / empty).
+export const resolveAction = (cursor, ranges) => {
+  if (ranges.length !== 1) return 'create'
+  const { start, end } = ranges[0]
+  const isWrap = start >= end
+  const width = isWrap ? 24 - start + end : end - start
+  const tol = edgeTolFor(width)
+  if (!isWrap && cursor >= end - tol && cursor <= end + tol) return 'edge-end'
+  if (!isWrap && cursor >= start - tol && cursor <= start + tol) return 'edge-start'
+  if (isInsideBand(cursor, { start, end })) return 'pan'
+  return 'create'
+}

--- a/test/renderer/ui/clockGeometry.test.js
+++ b/test/renderer/ui/clockGeometry.test.js
@@ -84,7 +84,13 @@ describe('rangesToSegments', () => {
 describe('resolveAction', () => {
   test('no single band -> create', () => {
     assert.equal(resolveAction(10, []), 'create')
-    assert.equal(resolveAction(10, [{ start: 5, end: 8 }, { start: 18, end: 21 }]), 'create')
+    assert.equal(
+      resolveAction(10, [
+        { start: 5, end: 8 },
+        { start: 18, end: 21 }
+      ]),
+      'create'
+    )
   })
   test('near end edge -> edge-end', () => {
     assert.equal(resolveAction(17.5, [{ start: 8, end: 18 }]), 'edge-end')

--- a/test/renderer/ui/clockGeometry.test.js
+++ b/test/renderer/ui/clockGeometry.test.js
@@ -1,0 +1,104 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  timeToAngle,
+  angleToTime,
+  isInsideBand,
+  edgeTolFor,
+  bandToSegments,
+  rangesToSegments,
+  resolveAction
+} from '../../../src/renderer/src/ui/clockGeometry.js'
+
+describe('timeToAngle / angleToTime', () => {
+  test('0h is 0deg, 6h is 90deg, 18h is 270deg', () => {
+    assert.equal(timeToAngle(0), 0)
+    assert.equal(timeToAngle(6), 90)
+    assert.equal(timeToAngle(18), 270)
+  })
+  test('24h wraps to 0deg', () => {
+    assert.equal(timeToAngle(24), 0)
+  })
+  test('angleToTime inverts within [0,360)', () => {
+    assert.equal(angleToTime(0), 0)
+    assert.equal(angleToTime(90), 6)
+    assert.equal(angleToTime(270), 18)
+  })
+})
+
+describe('isInsideBand', () => {
+  test('non-wrap band: strictly between start and end', () => {
+    assert.equal(isInsideBand(10, { start: 8, end: 18 }), true)
+    assert.equal(isInsideBand(8, { start: 8, end: 18 }), false)
+    assert.equal(isInsideBand(20, { start: 8, end: 18 }), false)
+  })
+  test('wrap band (start > end): outside the gap', () => {
+    assert.equal(isInsideBand(23, { start: 21, end: 5 }), true)
+    assert.equal(isInsideBand(3, { start: 21, end: 5 }), true)
+    assert.equal(isInsideBand(12, { start: 21, end: 5 }), false)
+  })
+})
+
+describe('edgeTolFor', () => {
+  test('clamps to [1, 2]', () => {
+    assert.equal(edgeTolFor(1.5), 1) // 0.5 -> floored at 1
+    assert.equal(edgeTolFor(6), 2) // 2 -> capped at 2
+    assert.equal(edgeTolFor(4.5), 1.5) // 1.5 in range
+  })
+})
+
+describe('bandToSegments', () => {
+  test('empty band (start === end) yields nothing', () => {
+    assert.deepEqual(bandToSegments({ start: 7, end: 7 }), [])
+  })
+  test('non-wrap band yields one segment', () => {
+    assert.deepEqual(bandToSegments({ start: 7, end: 18 }), [[7, 18]])
+  })
+  test('wrap band splits at midnight', () => {
+    assert.deepEqual(bandToSegments({ start: 21, end: 5 }), [
+      [21, 24],
+      [0, 5]
+    ])
+  })
+})
+
+describe('rangesToSegments', () => {
+  test('flattens multiple ranges, splitting wrap-arounds', () => {
+    assert.deepEqual(
+      rangesToSegments([
+        { start: 5, end: 8 },
+        { start: 21, end: 5 }
+      ]),
+      [
+        [5, 8],
+        [21, 24],
+        [0, 5]
+      ]
+    )
+  })
+  test('full-day range yields a single full segment', () => {
+    assert.deepEqual(rangesToSegments([{ start: 0, end: 24 }]), [[0, 24]])
+  })
+})
+
+describe('resolveAction', () => {
+  test('no single band -> create', () => {
+    assert.equal(resolveAction(10, []), 'create')
+    assert.equal(resolveAction(10, [{ start: 5, end: 8 }, { start: 18, end: 21 }]), 'create')
+  })
+  test('near end edge -> edge-end', () => {
+    assert.equal(resolveAction(17.5, [{ start: 8, end: 18 }]), 'edge-end')
+  })
+  test('near start edge -> edge-start', () => {
+    assert.equal(resolveAction(8.5, [{ start: 8, end: 18 }]), 'edge-start')
+  })
+  test('inside band, away from edges -> pan', () => {
+    assert.equal(resolveAction(13, [{ start: 8, end: 18 }]), 'pan')
+  })
+  test('outside band -> create', () => {
+    assert.equal(resolveAction(2, [{ start: 8, end: 18 }]), 'create')
+  })
+  test('wrap band is panned, not edge-slid', () => {
+    assert.equal(resolveAction(23, [{ start: 21, end: 5 }]), 'pan')
+  })
+})

--- a/test/renderer/ui/clockGeometry.test.js
+++ b/test/renderer/ui/clockGeometry.test.js
@@ -7,6 +7,7 @@ import {
   edgeTolFor,
   bandToSegments,
   rangesToSegments,
+  rangesToBoundaries,
   resolveAction
 } from '../../../src/renderer/src/ui/clockGeometry.js'
 
@@ -78,6 +79,33 @@ describe('rangesToSegments', () => {
   })
   test('full-day range yields a single full segment', () => {
     assert.deepEqual(rangesToSegments([{ start: 0, end: 24 }]), [[0, 24]])
+  })
+})
+
+describe('rangesToBoundaries', () => {
+  test('partial single band -> its two interior edges', () => {
+    assert.deepEqual(rangesToBoundaries([{ start: 7, end: 18 }]), [7, 18])
+  })
+  test('full-day range -> no boundaries (0/24 dropped)', () => {
+    assert.deepEqual(rangesToBoundaries([{ start: 0, end: 24 }]), [])
+  })
+  test('band touching the seam drops the 0 edge', () => {
+    assert.deepEqual(rangesToBoundaries([{ start: 0, end: 18 }]), [18])
+  })
+  test('wrap-around night -> its two real edges, sorted', () => {
+    assert.deepEqual(rangesToBoundaries([{ start: 21, end: 5 }]), [5, 21])
+  })
+  test('multiple chips -> all interior edges, deduped and sorted', () => {
+    assert.deepEqual(
+      rangesToBoundaries([
+        { start: 5, end: 8 },
+        { start: 18, end: 21 }
+      ]),
+      [5, 8, 18, 21]
+    )
+  })
+  test('empty selection -> no boundaries', () => {
+    assert.deepEqual(rangesToBoundaries([]), [])
   })
 })
 


### PR DESCRIPTION
## Summary
- Move the daytime-filter selection indicator **out of the plot** into a dedicated track: a ring just outside the polar activity radar, and a strip beneath the line chart's x-axis. The activity curves are no longer washed over by the selection fill.
- Use **selection semantics** (blue = kept hours); the track is the drag surface (create / resize / pan, including wrap-around past midnight). Default all-selected = a full blue track, plot stays clean.
- Add **dashed boundary guides** for partial selections — vertical in the line chart, radial in the polar clock — so a window's position is visible against the curves; hidden at full selection.
- Extract pure geometry/interaction helpers into `clockGeometry.js`, covered by unit tests.

## Details
- Polar handle release previously committed the stale pre-drag range (window mouseup closed over old state) — fixed by re-binding listeners to the live range.
- Polar ring footprint tuned so it clears the chart-shape toggle; ring stroke and line-track thinned.

## Test plan
- [x] `npm test` — 1423 pass / 0 fail (incl. 23 `clockGeometry` unit tests)
- [x] `npm run lint`, `prettier --check`, `electron-vite build` all clean
- [x] Polar: drag start/end handles + arc pan; selection sticks on release; ring clears the toggle; wrap-around night renders correctly
- [x] Line: drag/create/resize/pan on the strip; curves unobstructed; boundary guides track the window
- [x] Toggle polar ↔ line with a partial selection — same window shown both ways