### PR TITLE
fix(activity): polar full-day drag matches backend & x-y view

### DIFF
--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -596,28 +596,28 @@ const DailyActivityLine = ({
               style={{ left: pct(s), width: pct(e - s), backgroundColor: 'rgb(59 130 246)' }}
             />
           ))}
-          {dragEnabled && handleStartX !== null && (
-            <div
-              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
-              style={{
-                left: pct(handleStartX),
-                width: hoveredEdge === 'start' ? 12 : 9,
-                height: hoveredEdge === 'start' ? 12 : 9,
-                transform: 'translate(-50%, -50%)'
-              }}
-            />
-          )}
-          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
-            <div
-              className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
-              style={{
-                left: pct(handleEndX),
-                width: hoveredEdge === 'end' ? 12 : 9,
-                height: hoveredEdge === 'end' ? 12 : 9,
-                transform: 'translate(-50%, -50%)'
-              }}
-            />
-          )}
+          {dragEnabled &&
+            [
+              ['start', handleStartX],
+              ['end', handleEndX]
+            ]
+              // start always renders; end only when it doesn't coincide with start
+              .filter(([edge, x]) => x !== null && (edge === 'start' || x !== handleStartX))
+              .map(([edge, x]) => {
+                const size = hoveredEdge === edge ? 12 : 9
+                return (
+                  <div
+                    key={edge}
+                    className="absolute top-1/2 rounded-full bg-blue-500 border border-white"
+                    style={{
+                      left: pct(x),
+                      width: size,
+                      height: size,
+                      transform: 'translate(-50%, -50%)'
+                    }}
+                  />
+                )
+              })}
         </div>
       </div>
     </div>

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -18,8 +18,10 @@ import {
   rangesToSegments,
   rangesToBoundaries,
   bandToSegments,
+  bandWidth,
   resolveAction
 } from './clockGeometry.js'
+import { isFullDayArc } from '../utils/dayPeriods.js'
 
 // Outer radius (in px) of the activity radar and the inner reference circle.
 // The selection ring lives OUTSIDE this, so the radar is kept a little
@@ -62,12 +64,17 @@ const CircularTimeFilter = ({
   }, [startTime, endTime])
 
   const interactive = mode !== 'chips'
+  // A full-day freeform drag is "no filter" (same as the backend's
+  // isFullDayArc and the x-y view) — render no blue so it doesn't look like
+  // an active full selection. Chip-driven full day (the default) is the
+  // intended full ring and is left to the chipSectors path below.
+  const fullDayDrag = interactive && isFullDayArc({ start, end })
   // Ranges to paint as blue arcs: the live drag band, or the chip sectors.
   const ranges = interactive ? [{ start, end }] : chipSectors
-  const segments = rangesToSegments(ranges)
+  const segments = fullDayDrag ? [] : rangesToSegments(ranges)
   const isFullRing = segments.length === 1 && segments[0][0] === 0 && segments[0][1] === 24
   // Interior boundary hours, drawn as dashed radial guides into the plot.
-  const boundaries = rangesToBoundaries(ranges)
+  const boundaries = fullDayDrag ? [] : rangesToBoundaries(ranges)
 
   // Point on a circle of radius r at the given clock hour.
   const pointAt = (hour, r) => {
@@ -519,7 +526,7 @@ const DailyActivityLine = ({
     } else {
       // pan
       const { start, end } = selectedRanges[0]
-      const width = isWrapBand ? 24 - start + end : end - start
+      const width = bandWidth(selectedRanges[0])
       const panOffset = isWrapBand && cursor < end ? cursor + 24 - start : cursor - start
       setDragState({ mode: 'pan', liveStart: start, liveEnd: end, panOffset, panWidth: width })
     }

--- a/src/renderer/src/ui/clockGeometry.js
+++ b/src/renderer/src/ui/clockGeometry.js
@@ -18,6 +18,10 @@ export const isInsideBand = (cursor, band) => {
   return cursor > band.start || cursor < band.end
 }
 
+// Width in hours of a (possibly wrap-around) band.
+export const bandWidth = (band) =>
+  band.start >= band.end ? 24 - band.start + band.end : band.end - band.start
+
 // Edge grab-zone half-width (hours): at least 1h so short bands are
 // targetable, capped at 2h so it never takes over a wide band.
 export const edgeTolFor = (width) => Math.max(1, Math.min(2, width / 3))
@@ -55,8 +59,7 @@ export const resolveAction = (cursor, ranges) => {
   if (ranges.length !== 1) return 'create'
   const { start, end } = ranges[0]
   const isWrap = start >= end
-  const width = isWrap ? 24 - start + end : end - start
-  const tol = edgeTolFor(width)
+  const tol = edgeTolFor(bandWidth(ranges[0]))
   if (!isWrap && cursor >= end - tol && cursor <= end + tol) return 'edge-end'
   if (!isWrap && cursor >= start - tol && cursor <= start + tol) return 'edge-start'
   if (isInsideBand(cursor, { start, end })) return 'pan'

--- a/test/renderer/ui/clockGeometry.test.js
+++ b/test/renderer/ui/clockGeometry.test.js
@@ -6,6 +6,7 @@ import {
   isInsideBand,
   edgeTolFor,
   bandToSegments,
+  bandWidth,
   rangesToSegments,
   rangesToBoundaries,
   resolveAction
@@ -60,6 +61,18 @@ describe('bandToSegments', () => {
       [21, 24],
       [0, 5]
     ])
+  })
+})
+
+describe('bandWidth', () => {
+  test('non-wrap band: end - start', () => {
+    assert.equal(bandWidth({ start: 8, end: 18 }), 10)
+  })
+  test('wrap band: hours across midnight', () => {
+    assert.equal(bandWidth({ start: 21, end: 5 }), 8)
+  })
+  test('full-day {0,24} is 24h', () => {
+    assert.equal(bandWidth({ start: 0, end: 24 }), 24)
   })
 })
 


### PR DESCRIPTION
Follow-up to #558 (already merged). A thorough self-review surfaced one inconsistency.

## Summary
- A **full-day freeform drag** arc rendered a solid blue ring in the polar view, while the x-y track strip (and the backend filter, via `isFullDayArc`) treated the same state as **no filter** — the two views disagreed for an identical selection.
- Reuse `isFullDayArc` so a full-day drag paints no blue in the polar view too (just the track + handles). The chip-driven default full ring is unaffected.
- Also covers near-full-day drags (≥23.9h) that previously drew a near-complete ring with a hairline gap.
- Minor cleanup: extract a shared `bandWidth()` helper (was duplicated between `resolveAction` and the strip pan), with unit tests.

## Test plan
- [x] `npm test` — 1426 pass / 0 fail (incl. new `bandWidth` tests)
- [x] `npm run lint`, `prettier --check`, `electron-vite build` clean
- [x] Polar: deselect all chips → full-day drag arc shows track + handles, no full ring; matches the empty x-y strip
- [x] Default (all chips) still shows a full ring in polar and a full strip in x-y