### PR TITLE
feat(deployments): add explanatory tooltips to CSV actions and sparkline toggle

### DIFF
--- a/src/renderer/src/deployments/DeploymentsCsvActions.jsx
+++ b/src/renderer/src/deployments/DeploymentsCsvActions.jsx
@@ -137,10 +137,14 @@ export default function DeploymentsCsvActions({ studyId, onApplied }) {
           <Tooltip.Portal>
             <Tooltip.Content
               side="bottom"
-              sideOffset={6}
-              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              sideOffset={8}
+              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
             >
-              Download deployments — locations, dates, cameras — as a CSV file
+              <div className="font-medium mb-1">Export CSV</div>
+              <p className="text-muted-foreground leading-snug">
+                Download every deployment — locations, dates, and cameras — as a spreadsheet you can
+                edit or share.
+              </p>
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>
@@ -159,10 +163,14 @@ export default function DeploymentsCsvActions({ studyId, onApplied }) {
           <Tooltip.Portal>
             <Tooltip.Content
               side="bottom"
-              sideOffset={6}
-              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              sideOffset={8}
+              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
             >
-              Update deployments in bulk from an edited CSV file
+              <div className="font-medium mb-1">Import CSV</div>
+              <p className="text-muted-foreground leading-snug">
+                Bulk-update deployments from an edited CSV. You&apos;ll preview every change before
+                it&apos;s applied.
+              </p>
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>

--- a/src/renderer/src/deployments/DeploymentsCsvActions.jsx
+++ b/src/renderer/src/deployments/DeploymentsCsvActions.jsx
@@ -1,5 +1,6 @@
 import { Download, Upload } from 'lucide-react'
 import { useCallback, useState } from 'react'
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { toast } from 'sonner'
 import DeploymentsImportPreviewModal from './DeploymentsImportPreviewModal'
 import DeploymentsExportPreviewModal from './DeploymentsExportPreviewModal'
@@ -121,26 +122,50 @@ export default function DeploymentsCsvActions({ studyId, onApplied }) {
   return (
     <>
       <div className="inline-flex items-center rounded border border-border overflow-hidden bg-card">
-        <button
-          onClick={handleExportClick}
-          title="Export deployments CSV"
-          className={btnClass}
-          aria-label="Export deployments CSV"
-          disabled={isLoadingExport}
-        >
-          <Download size={12} />
-          Export CSV
-        </button>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={handleExportClick}
+              className={btnClass}
+              aria-label="Export deployments CSV"
+              disabled={isLoadingExport}
+            >
+              <Download size={12} />
+              Export CSV
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="bottom"
+              sideOffset={6}
+              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+            >
+              Download deployments — locations, dates, cameras — as a CSV file
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
         <div className="w-px self-stretch bg-border" aria-hidden="true" />
-        <button
-          onClick={handleImportClick}
-          title="Import deployments CSV"
-          className={btnClass}
-          aria-label="Import deployments CSV"
-        >
-          <Upload size={12} />
-          Import CSV
-        </button>
+        <Tooltip.Root>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={handleImportClick}
+              className={btnClass}
+              aria-label="Import deployments CSV"
+            >
+              <Upload size={12} />
+              Import CSV
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="bottom"
+              sideOffset={6}
+              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+            >
+              Update deployments in bulk from an edited CSV file
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
       </div>
 
       {(isParsing || isLoadingExport) && (

--- a/src/renderer/src/deployments/SparklineToggle.jsx
+++ b/src/renderer/src/deployments/SparklineToggle.jsx
@@ -2,9 +2,27 @@ import { BarChart3, LineChart, Grid3x3 } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
 
 const MODES = [
-  { id: 'bars', label: 'Bars', Icon: BarChart3, hint: 'Show activity over time as bars' },
-  { id: 'line', label: 'Line', Icon: LineChart, hint: 'Show activity over time as a line' },
-  { id: 'heatmap', label: 'Heatmap', Icon: Grid3x3, hint: 'Show activity over time as a heatmap' }
+  {
+    id: 'bars',
+    label: 'Bars',
+    Icon: BarChart3,
+    description:
+      "Each deployment's activity over time as a bar chart — taller bars mean more captures."
+  },
+  {
+    id: 'line',
+    label: 'Line',
+    Icon: LineChart,
+    description:
+      "Each deployment's activity over time as a smooth area line — good for spotting trends."
+  },
+  {
+    id: 'heatmap',
+    label: 'Heatmap',
+    Icon: Grid3x3,
+    description:
+      "Each deployment's activity over time as colored cells — darker means more captures."
+  }
 ]
 
 /**
@@ -14,7 +32,7 @@ const MODES = [
 export default function SparklineToggle({ mode, onChange }) {
   return (
     <div className="flex items-center gap-px rounded border border-border bg-card p-px">
-      {MODES.map(({ id, label, Icon, hint }) => (
+      {MODES.map(({ id, label, Icon, description }) => (
         <Tooltip.Root key={id}>
           <Tooltip.Trigger asChild>
             <button
@@ -33,10 +51,11 @@ export default function SparklineToggle({ mode, onChange }) {
           <Tooltip.Portal>
             <Tooltip.Content
               side="top"
-              sideOffset={6}
-              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+              sideOffset={8}
+              className="z-[10000] max-w-[16rem] px-3 py-2 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
             >
-              {hint}
+              <div className="font-medium mb-1">{label}</div>
+              <p className="text-muted-foreground leading-snug">{description}</p>
             </Tooltip.Content>
           </Tooltip.Portal>
         </Tooltip.Root>

--- a/src/renderer/src/deployments/SparklineToggle.jsx
+++ b/src/renderer/src/deployments/SparklineToggle.jsx
@@ -1,9 +1,10 @@
 import { BarChart3, LineChart, Grid3x3 } from 'lucide-react'
+import * as Tooltip from '@radix-ui/react-tooltip'
 
 const MODES = [
-  { id: 'bars', label: 'Bars', Icon: BarChart3 },
-  { id: 'line', label: 'Line', Icon: LineChart },
-  { id: 'heatmap', label: 'Heatmap', Icon: Grid3x3 }
+  { id: 'bars', label: 'Bars', Icon: BarChart3, hint: 'Show activity over time as bars' },
+  { id: 'line', label: 'Line', Icon: LineChart, hint: 'Show activity over time as a line' },
+  { id: 'heatmap', label: 'Heatmap', Icon: Grid3x3, hint: 'Show activity over time as a heatmap' }
 ]
 
 /**
@@ -13,21 +14,32 @@ const MODES = [
 export default function SparklineToggle({ mode, onChange }) {
   return (
     <div className="flex items-center gap-px rounded border border-border bg-card p-px">
-      {MODES.map(({ id, label, Icon }) => (
-        <button
-          key={id}
-          onClick={() => onChange(id)}
-          title={label}
-          aria-label={`Sparkline: ${label}`}
-          aria-pressed={mode === id}
-          className={`p-1 rounded ${
-            mode === id
-              ? 'bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300'
-              : 'text-muted-foreground hover:bg-accent hover:text-foreground'
-          }`}
-        >
-          <Icon size={14} />
-        </button>
+      {MODES.map(({ id, label, Icon, hint }) => (
+        <Tooltip.Root key={id}>
+          <Tooltip.Trigger asChild>
+            <button
+              onClick={() => onChange(id)}
+              aria-label={`Sparkline: ${label}`}
+              aria-pressed={mode === id}
+              className={`p-1 rounded ${
+                mode === id
+                  ? 'bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-300'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+              }`}
+            >
+              <Icon size={14} />
+            </button>
+          </Tooltip.Trigger>
+          <Tooltip.Portal>
+            <Tooltip.Content
+              side="top"
+              sideOffset={6}
+              className="z-[10000] px-2 py-1 bg-popover text-popover-foreground text-xs rounded-md border border-border shadow-md"
+            >
+              {hint}
+            </Tooltip.Content>
+          </Tooltip.Portal>
+        </Tooltip.Root>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- Add Radix tooltips (matching the activity-chart shape toggle / Dawn–Dusk chips) to the deployments tab: **Export CSV**, **Import CSV**, and the **Bars / Line / Heatmap** sparkline toggle.
- Each tooltip uses the richer day-period treatment — a bold title over a short muted description explaining what the control does — and replaces the bare native `title` attributes (no more duplicate native + Radix tooltips).

## Test plan
- [ ] Open the Deployments tab; hover Export CSV / Import CSV in the header strip — tooltip shows title + description, opens below the buttons.
- [ ] Hover each of Bars / Line / Heatmap in the sparkline toggle — tooltip shows the mode title + description, opens above.
- [ ] Verify no duplicate (native browser) tooltip appears alongside the Radix one.