### PR TITLE
refactor(activity): centralize wrap predicate as bandWraps

### DIFF
--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -19,6 +19,7 @@ import {
   rangesToBoundaries,
   bandToSegments,
   bandWidth,
+  bandWraps,
   resolveAction
 } from './clockGeometry.js'
 import { isFullDayArc } from '../utils/dayPeriods.js'
@@ -387,7 +388,7 @@ const DailyActivityLine = ({
   onArcChange
 }) => {
   const hasSingleBand = selectedRanges.length === 1
-  const isWrapBand = hasSingleBand && selectedRanges[0].start >= selectedRanges[0].end
+  const isWrapBand = hasSingleBand && bandWraps(selectedRanges[0])
   const dragEnabled =
     typeof onArcChange === 'function' && (hasSingleBand || selectedRanges.length === 0)
 

--- a/src/renderer/src/ui/clockGeometry.js
+++ b/src/renderer/src/ui/clockGeometry.js
@@ -18,9 +18,13 @@ export const isInsideBand = (cursor, band) => {
   return cursor > band.start || cursor < band.end
 }
 
+// Whether a band wraps past midnight (start >= end). Single source of truth
+// for the wrap convention used by bandWidth, resolveAction, and the views.
+export const bandWraps = (band) => band.start >= band.end
+
 // Width in hours of a (possibly wrap-around) band.
 export const bandWidth = (band) =>
-  band.start >= band.end ? 24 - band.start + band.end : band.end - band.start
+  bandWraps(band) ? 24 - band.start + band.end : band.end - band.start
 
 // Edge grab-zone half-width (hours): at least 1h so short bands are
 // targetable, capped at 2h so it never takes over a wide band.
@@ -58,7 +62,7 @@ export const rangesToBoundaries = (ranges) => {
 export const resolveAction = (cursor, ranges) => {
   if (ranges.length !== 1) return 'create'
   const { start, end } = ranges[0]
-  const isWrap = start >= end
+  const isWrap = bandWraps(ranges[0])
   const tol = edgeTolFor(bandWidth(ranges[0]))
   if (!isWrap && cursor >= end - tol && cursor <= end + tol) return 'edge-end'
   if (!isWrap && cursor >= start - tol && cursor <= start + tol) return 'edge-start'

--- a/test/renderer/ui/clockGeometry.test.js
+++ b/test/renderer/ui/clockGeometry.test.js
@@ -7,6 +7,7 @@ import {
   edgeTolFor,
   bandToSegments,
   bandWidth,
+  bandWraps,
   rangesToSegments,
   rangesToBoundaries,
   resolveAction
@@ -61,6 +62,18 @@ describe('bandToSegments', () => {
       [21, 24],
       [0, 5]
     ])
+  })
+})
+
+describe('bandWraps', () => {
+  test('non-wrap band does not wrap', () => {
+    assert.equal(bandWraps({ start: 8, end: 18 }), false)
+  })
+  test('wrap band (start > end) wraps', () => {
+    assert.equal(bandWraps({ start: 21, end: 5 }), true)
+  })
+  test('start === end is treated as wrapping (full-day degenerate)', () => {
+    assert.equal(bandWraps({ start: 6, end: 6 }), true)
   })
 })
 


### PR DESCRIPTION
Cleanup from the self-review (review item #4). Independent of #560.

## Summary
- The `start >= end` "band wraps past midnight" check was spelled in three places (`bandWidth`, `resolveAction`'s `isWrap`, and the line view's `isWrapBand`). Extract a single `bandWraps(band)` helper and reuse it everywhere — one source of truth for the wrap convention.
- No behavior change; purely a DRY refactor.

## Test plan
- [x] `npm test` — 1445 pass / 0 fail (incl. new `bandWraps` tests)
- [x] `npm run lint`, `prettier --check`, `electron-vite build` clean