### PR TITLE
chore(sequences): OOM diagnostics + repro tooling (#564)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -275,6 +275,45 @@ npx electron-rebuild -f -w better-sqlite3
 2. Zoom in to reduce visible markers
 3. Filter to specific deployments
 
+### Explore tab crashes / "Worker terminated due to reaching memory limit"
+
+**Symptom:** On large studies, opening the Explore tab logs:
+
+```
+Error getting sequence-aware species distribution: Error [ERR_WORKER_OUT_OF_MEMORY]:
+Worker terminated due to reaching memory limit: JS heap out of memory
+```
+
+The error is caught (the app keeps running) but the affected stat fails to load.
+
+**Cause:** The sequence-aware queries (`src/main/services/sequences/worker.js`) have
+a fast SQL aggregation path that only handles a sequence gap of `null` or `0`. When
+a study's stored `sequenceGap` is **positive**, the worker falls back to dumping the
+entire observation×media join into a JS array and aggregating it with Maps. Peak heap
+scales with **row count × species** (e.g. ~2.2M rows / 92 species ≈ 1.5 GB), and the
+Explore tab makes it worse by running several such workers concurrently. The OOM
+fires when the worker's V8 old-space ceiling is below that footprint.
+
+See GitHub issue
+[#564](https://github.com/earthtoolsmaker/biowatch/issues/564) for the full analysis.
+
+**Diagnosing it** (the sequences worker logs each task to the main log):
+
+```
+[seq-worker:species-distribution] start gap=110 ... heap=18/1046MB
+[seq-worker:species-distribution] SLOW PATH (gap=110): SQL fast-path returned null, dumping rows
+[seq-worker:species-distribution] loaded 2187792 rows, heap=779MB — starting JS aggregation
+```
+
+A `SLOW PATH` line followed by a large `loaded N rows` and no matching
+`aggregation done` is the OOM signature. Watch them live with:
+
+```bash
+tail -f ~/.config/biowatch/logs/main.log | grep seq-worker
+```
+
+**Reproducing it on demand:** see "Reproducing the sequence-worker OOM" below.
+
 ---
 
 ## Platform-Specific Issues
@@ -415,6 +454,76 @@ visually re-theme, force-quit and relaunch — a stuck WebContents may not
 pick up new CSS variables until a fresh load.
 
 ---
+
+## Reproducing the sequence-worker OOM (developer tooling)
+
+Two helper scripts make the Explore-tab OOM (see above) reproducible and
+observable. They live in `scripts/` and drive the **running dev app** over the
+Chrome DevTools Protocol — they don't launch their own Electron.
+
+### One-time: where to do this
+
+This is a developer workflow, so do it in a dedicated git worktree to keep it
+off your feature branches (the repo keeps worktrees under `.worktrees/`):
+
+```bash
+git worktree add .worktrees/seq-worker-troubleshooting -b arthur/seq-worker-troubleshooting origin/main
+cd .worktrees/seq-worker-troubleshooting
+npm install
+```
+
+### Step 1 — launch the dev app wired for debugging
+
+```bash
+scripts/dev-debug.sh
+```
+
+This stops any existing dev/electron instance of this project, then relaunches
+`npm run dev` with:
+
+- `--remoteDebuggingPort 9222` — so the repro script can attach over CDP.
+- `SEQ_WORKER_MAX_OLD_MB=950` — caps the sequences worker's V8 old-space heap.
+  On a high-RAM machine the default ceiling is ~4 GB, which hides the OOM; the
+  cap reproduces the real-world crash (~1 GB ceiling). Override or disable:
+
+  ```bash
+  CAP=1200 scripts/dev-debug.sh   # different cap
+  CAP=0 scripts/dev-debug.sh      # no cap (default 4GB)
+  PORT=9333 scripts/dev-debug.sh  # different CDP port
+  ```
+
+The cap is honored by `src/main/services/sequences/runInWorker.js`; it has no
+effect when the env var is unset, so normal `npm run dev` is unaffected.
+
+### Step 2 — trigger and observe
+
+In another shell (same worktree):
+
+```bash
+# Explore mode (default): boots the app straight into the study's Explore tab
+# and lets the real UI fire all its concurrent work — the true crash path.
+node scripts/repro-seq-oom.mjs <studyId>
+
+# IPC mode: fire species-distribution + timeseries directly with a positive
+# gap, to attribute heap growth to a single worker.
+REPRO_MODE=ipc node scripts/repro-seq-oom.mjs <studyId> 120
+```
+
+It prints each task's outcome plus the new `[seq-worker:*]` log lines, and exits
+0 when it reproduces the OOM. A study only takes the slow (OOM-prone) path when
+its stored `sequenceGap` is positive; the script reports the stored gap, and IPC
+mode lets you force a positive gap regardless.
+
+Pick a large study id from `~/.config/biowatch/biowatch-data/studies/` — heap is
+driven by **row count**, not DB file size.
+
+### What the logging means
+
+`src/main/services/sequences/worker.js` logs one line per task:
+`[seq-worker:<type>] start gap=… heap=used/limitMB`, a `SLOW PATH` warning when
+the SQL fast-path bails, the loaded row count, and heap before/after the JS
+aggregation. `runInWorker.js` tags worker errors/exits with the task type so a
+crash names which of the concurrent workers died.
 
 ## Getting Help
 

--- a/scripts/dev-debug.sh
+++ b/scripts/dev-debug.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Launch the Biowatch dev app wired for sequence-worker OOM troubleshooting:
+#   - exposes the Chrome DevTools Protocol port so scripts/repro-seq-oom.mjs can
+#     attach over CDP (see docs/troubleshooting.md "Explore tab OOM").
+#   - optionally caps the sequences worker's V8 old-space heap so the OOM is
+#     reproducible on machines with lots of RAM (where the default ~4GB ceiling
+#     hides it). The cap is read by src/main/services/sequences/runInWorker.js.
+#
+# The dev port cannot be enabled on an already-running renderer, so this first
+# stops any existing dev/electron instances of THIS project, then relaunches.
+#
+# Usage:
+#   scripts/dev-debug.sh              # cap 950MB, port 9222 (defaults)
+#   CAP=1200 PORT=9333 scripts/dev-debug.sh
+#   CAP=0 scripts/dev-debug.sh        # no heap cap (default 4GB ceiling)
+#
+# Runs in the foreground; Ctrl-C to stop. Then in another shell:
+#   node scripts/repro-seq-oom.mjs <studyId>
+set -euo pipefail
+
+CAP="${CAP:-950}"
+PORT="${PORT:-9222}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+echo "→ Stopping existing dev/electron instances of this project..."
+# Match only processes belonging to this repo's node_modules to avoid touching
+# unrelated Electron apps.
+pkill -9 -f "${ROOT}/node_modules/.bin/electron-vite" 2>/dev/null || true
+pkill -9 -f "${ROOT}/node_modules/electron/dist/electron" 2>/dev/null || true
+
+# Wait for the debug port to free up (max ~10s).
+for _ in $(seq 1 10); do
+  if curl -s --max-time 1 "http://127.0.0.1:${PORT}/json/version" >/dev/null 2>&1; then
+    sleep 1
+  else
+    break
+  fi
+done
+
+if [ "${CAP}" -gt 0 ]; then
+  echo "→ Launching dev: worker heap cap=${CAP}MB, CDP port=${PORT}"
+  export SEQ_WORKER_MAX_OLD_MB="${CAP}"
+else
+  echo "→ Launching dev: no worker heap cap, CDP port=${PORT}"
+fi
+
+cd "${ROOT}"
+exec npm run dev -- --remoteDebuggingPort "${PORT}"

--- a/scripts/repro-seq-oom.mjs
+++ b/scripts/repro-seq-oom.mjs
@@ -1,0 +1,224 @@
+/**
+ * Reproduce the sequence-worker OOM (ERR_WORKER_OUT_OF_MEMORY) on large studies
+ * by attaching to a running Biowatch dev renderer over CDP.
+ *
+ * Two modes:
+ *   explore (default) — boots the app straight into the study's Explore tab and
+ *     lets the real UI fire ALL its concurrent work (species-distribution +
+ *     timeseries on the slow JS path, heatmap, daily-activity, overview-stats,
+ *     map markers, cached images). This is the real-world crash path.
+ *   ipc — directly invokes species-distribution + timeseries with a positive
+ *     gapSeconds (forces the slow path) without the renderer-side load. Useful
+ *     for attributing heap growth to a single worker.
+ *
+ * The OOM only fatally crashes when the worker's V8 old-space ceiling is below
+ * the slow path's ~1-1.5GB footprint. To reproduce on a 60GB/4GB-default box,
+ * relaunch dev with a constrained worker heap:
+ *   SEQ_WORKER_MAX_OLD_MB=950 npm run dev -- --remoteDebuggingPort 9222
+ *
+ * Usage:
+ *   node scripts/repro-seq-oom.mjs [studyId] [gapSeconds]
+ *
+ * Env:
+ *   REPRO_PORT   CDP port (default 9222)
+ *   REPRO_MODE   'explore' (default) | 'ipc'
+ *   REPRO_WAIT   seconds to watch the explore tab (default 60)
+ */
+
+import { chromium } from 'playwright-core'
+import { readFileSync, statSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+const PORT = process.env.REPRO_PORT || '9222'
+const MODE = process.env.REPRO_MODE || 'explore'
+const WAIT_S = Number(process.env.REPRO_WAIT || 60)
+const STUDY_ID = process.argv[2] || '7deea39a-0452-4642-bb38-a0f16cc335ce'
+const GAP_SECONDS = Number(process.argv[3] ?? 120)
+const MAIN_LOG = join(homedir(), '.config', 'biowatch', 'logs', 'main.log')
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function logSize() {
+  try {
+    return statSync(MAIN_LOG).size
+  } catch {
+    return 0
+  }
+}
+
+function newLogLines(fromByte) {
+  try {
+    return readFileSync(MAIN_LOG)
+      .subarray(fromByte)
+      .toString('utf8')
+      .split('\n')
+      .filter(
+        (l) =>
+          l.includes('seq-worker') ||
+          l.includes('OUT_OF_MEMORY') ||
+          l.includes('heap out of memory') ||
+          l.includes('rows')
+      )
+  } catch {
+    return []
+  }
+}
+
+const OOM_RE = /OUT_OF_MEMORY|worker exited|heap out of memory/i
+
+async function portAlive() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${PORT}/json/version`, {
+      signal: AbortSignal.timeout(2000)
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+async function findPage(browser) {
+  const pages = browser.contexts().flatMap((c) => c.pages())
+  for (const p of pages) {
+    try {
+      if (await p.evaluate(() => typeof window.api?.getSequenceGap === 'function')) return p
+    } catch {
+      // page may be mid-navigation; skip
+    }
+  }
+  return null
+}
+
+async function runExplore(browser, page, startByte) {
+  // Report the stored gap — the Explore tab passes no gap, so the worker uses
+  // metadata; a positive value here is what sends it down the OOM-prone path.
+  let storedGap = null
+  try {
+    storedGap = await page.evaluate((id) => window.api.getSequenceGap(id), STUDY_ID)
+  } catch {
+    /* ignore */
+  }
+  console.log(`Stored sequenceGap for study: ${JSON.stringify(storedGap)}`)
+  // Non-destructive: we do NOT mutate the study's stored gap. A positive stored
+  // gap is exactly the real-world condition that sends the Explore tab down the
+  // slow path; if it's null/0 this study uses the SQL fast path and won't OOM
+  // here (use REPRO_MODE=ipc with an explicit gap to force it).
+  const gapVal = storedGap?.data ?? storedGap
+  if (!(typeof gapVal === 'number' && gapVal > 0)) {
+    console.log(
+      `⚠ Stored gap is not positive — Explore tab will use the fast path. ` +
+        `Run with REPRO_MODE=ipc to force the slow path.`
+    )
+  }
+
+  let crashed = false
+  page.on('crash', () => {
+    crashed = true
+  })
+
+  const base = page.url().split('#')[0]
+  const target = `#/study/${STUDY_ID}/explore`
+  console.log(`Booting Explore tab: ${base}${target}\n`)
+  try {
+    await page.evaluate((h) => {
+      window.location.hash = h
+    }, target)
+    await page.reload({ waitUntil: 'commit', timeout: 15000 })
+  } catch (e) {
+    console.log(`(navigation interrupted: ${e.message})`)
+    crashed = true
+  }
+
+  const deadline = Date.now() + WAIT_S * 1000
+  let reproduced = false
+  while (Date.now() < deadline) {
+    if (crashed || !(await portAlive())) {
+      reproduced = true
+      console.log('→ App/renderer went down while loading the Explore tab (OOM crash).')
+      break
+    }
+    if (newLogLines(startByte).some((l) => OOM_RE.test(l))) {
+      reproduced = true
+      console.log('→ Worker OOM detected in main.log while loading the Explore tab.')
+      break
+    }
+    await sleep(1000)
+  }
+  return reproduced
+}
+
+async function runIpc(page) {
+  console.log(`Study: ${STUDY_ID}  gapSeconds=${GAP_SECONDS} (positive → slow path)\n`)
+  let reproduced = false
+  try {
+    const outcomes = await page.evaluate(
+      async ({ studyId, gap }) => {
+        const call = async (label, fn) => {
+          const t = performance.now()
+          try {
+            const res = await fn()
+            return { label, ok: true, ms: Math.round(performance.now() - t), error: res?.error }
+          } catch (e) {
+            return { label, ok: false, ms: Math.round(performance.now() - t), error: String(e) }
+          }
+        }
+        return Promise.all([
+          call('species-distribution', () =>
+            window.api.getSequenceAwareSpeciesDistribution(studyId, gap, null)
+          ),
+          call('timeseries', () => window.api.getSequenceAwareTimeseries(studyId, [], gap, null))
+        ])
+      },
+      { studyId: STUDY_ID, gap: GAP_SECONDS }
+    )
+    for (const o of outcomes) {
+      const err = o.error || ''
+      if (OOM_RE.test(err)) reproduced = true
+      console.log(
+        `  ${o.label}: ${o.ok && !o.error ? 'OK' : 'ERROR'} (${o.ms}ms)` +
+          (err ? `\n      ${err}` : '')
+      )
+    }
+  } catch (e) {
+    console.log(`=== IPC call aborted: ${e.message} ===`)
+    console.log('   → page/app closed mid-call: the worker OOM crashed the process.')
+    reproduced = true
+  }
+  return reproduced
+}
+
+async function main() {
+  console.log(`Attaching to CDP on http://127.0.0.1:${PORT} (mode=${MODE}) ...`)
+  let browser
+  try {
+    browser = await chromium.connectOverCDP(`http://127.0.0.1:${PORT}`)
+  } catch (e) {
+    console.error(`\n✗ Could not connect on port ${PORT}: ${e.message}`)
+    console.error('  Relaunch dev with: npm run dev -- --remoteDebuggingPort ' + PORT)
+    process.exit(2)
+  }
+
+  const page = await findPage(browser)
+  if (!page) {
+    console.error('✗ No renderer page exposing window.api was found.')
+    process.exit(2)
+  }
+  console.log(`Driving page: ${page.url()}`)
+
+  const startByte = logSize()
+  const reproduced =
+    MODE === 'ipc' ? await runIpc(page) : await runExplore(browser, page, startByte)
+
+  console.log('\n=== New [seq-worker:*] / OOM log lines ===')
+  for (const l of newLogLines(startByte)) console.log('  ' + l)
+
+  await browser.close().catch(() => {})
+  console.log(`\n${reproduced ? '✓ Reproduced the worker OOM.' : '— No OOM this run.'}`)
+  process.exit(reproduced ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(3)
+})

--- a/src/main/services/sequences/runInWorker.js
+++ b/src/main/services/sequences/runInWorker.js
@@ -8,6 +8,7 @@
 
 import { join } from 'path'
 import { Worker } from 'worker_threads'
+import log from '../logger.js'
 
 /**
  * @param {Object} workerData - Task parameters passed to the worker. Must
@@ -25,21 +26,36 @@ export function runInWorker(workerData) {
     // is a separate rollup input (see electron.vite.config.mjs) and lands
     // at out/main/sequences-worker.js.
     const workerPath = join(__dirname, 'sequences-worker.js')
-    const worker = new Worker(workerPath, { workerData })
+    // Optional heap cap (MB) for the worker's V8 old space. Unset in normal
+    // operation; used to reproduce / guard against the row-dump OOM on large
+    // studies (positive-gap slow path can balloon past 1.5GB).
+    const maxOldMb = Number(process.env.SEQ_WORKER_MAX_OLD_MB) || 0
+    const options = { workerData }
+    if (maxOldMb > 0) {
+      options.resourceLimits = { maxOldGenerationSizeMb: maxOldMb }
+    }
+    const worker = new Worker(workerPath, options)
+    // Tag rejections with the task type so an OOM crash names which of the
+    // (often several concurrent) workers died, independent of which IPC
+    // handler's catch block logs it.
+    const tag = `[seq-worker:${workerData?.type ?? 'unknown'}]`
 
     worker.on('message', (result) => {
       if (result.error) {
-        reject(new Error(result.error))
+        reject(new Error(`${tag} ${result.error}`))
       } else {
         resolve(result.data)
       }
     })
 
-    worker.on('error', reject)
+    worker.on('error', (error) => {
+      log.error(`${tag} worker error:`, error)
+      reject(error)
+    })
 
     worker.on('exit', (code) => {
       if (code !== 0) {
-        reject(new Error(`Sequence worker exited with code ${code}`))
+        reject(new Error(`${tag} worker exited with code ${code}`))
       }
     })
   })

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -9,6 +9,8 @@
  */
 
 import { parentPort, workerData } from 'worker_threads'
+import { getHeapStatistics } from 'v8'
+import log from '../logger.js'
 import {
   getDrizzleDb,
   getMetadata,
@@ -36,6 +38,12 @@ import {
   pivotPreAggregatedHeatmap
 } from './speciesCounts.js'
 
+// Live heap usage in MB — cheap to call, used to trace memory growth across
+// the row-dump + JS aggregation fallbacks that can OOM the worker.
+function heapMb() {
+  return Math.round(process.memoryUsage().heapUsed / 1048576)
+}
+
 async function run() {
   const {
     type,
@@ -58,6 +66,13 @@ async function run() {
     effectiveGapSeconds = meta?.sequenceGap ?? null
   }
 
+  const tag = `[seq-worker:${type}]`
+  const heapLimitMb = Math.round(getHeapStatistics().heap_size_limit / 1048576)
+  log.info(
+    `${tag} start gap=${effectiveGapSeconds} bbox=${bbox ? 'yes' : 'no'} ` +
+      `species=${speciesNames?.length ?? 0} heap=${heapMb()}/${heapLimitMb}MB`
+  )
+
   switch (type) {
     case 'species-distribution': {
       // Fast path: SQL aggregate handles gapSeconds === null and === 0, returns
@@ -66,8 +81,14 @@ async function run() {
       // row-dump + JS sequence grouping below.
       const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds, bbox)
       if (fast !== null) return fast
+      log.warn(
+        `${tag} SLOW PATH (gap=${effectiveGapSeconds}): SQL fast-path returned null, dumping rows`
+      )
       const rawData = await getSpeciesDistributionByMedia(dbPath, bbox)
-      return calculateSequenceAwareSpeciesCounts(rawData, effectiveGapSeconds)
+      log.info(`${tag} loaded ${rawData.length} rows, heap=${heapMb()}MB — starting JS aggregation`)
+      const result = calculateSequenceAwareSpeciesCounts(rawData, effectiveGapSeconds)
+      log.info(`${tag} aggregation done: ${result.length} species, heap=${heapMb()}MB`)
+      return result
     }
     case 'timeseries': {
       // Fast path: SQL aggregate handles gapSeconds === null and === 0,
@@ -82,8 +103,14 @@ async function run() {
         bbox
       )
       if (fastRows !== null) return pivotPreAggregatedTimeseries(fastRows)
+      log.warn(
+        `${tag} SLOW PATH (gap=${effectiveGapSeconds}): SQL fast-path returned null, dumping rows`
+      )
       const rawData = await getSpeciesTimeseriesByMedia(dbPath, speciesNames, bbox)
-      return calculateSequenceAwareTimeseries(rawData, effectiveGapSeconds)
+      log.info(`${tag} loaded ${rawData.length} rows, heap=${heapMb()}MB — starting JS aggregation`)
+      const result = calculateSequenceAwareTimeseries(rawData, effectiveGapSeconds)
+      log.info(`${tag} aggregation done, heap=${heapMb()}MB`)
+      return result
     }
     case 'heatmap': {
       // Fast path: SQL aggregate handles all three gap cases (per-media,
@@ -103,6 +130,9 @@ async function run() {
         effectiveGapSeconds
       )
       if (fastRows !== null) return pivotPreAggregatedHeatmap(fastRows)
+      log.warn(
+        `${tag} SLOW PATH (gap=${effectiveGapSeconds}): SQL fast-path returned null, dumping rows`
+      )
       const rawData = await getSpeciesHeatmapDataByMedia(
         dbPath,
         speciesNames,
@@ -111,7 +141,10 @@ async function run() {
         timeRange,
         includeNullTimestamps
       )
-      return calculateSequenceAwareHeatmap(rawData, effectiveGapSeconds)
+      log.info(`${tag} loaded ${rawData.length} rows, heap=${heapMb()}MB — starting JS aggregation`)
+      const result = calculateSequenceAwareHeatmap(rawData, effectiveGapSeconds)
+      log.info(`${tag} aggregation done, heap=${heapMb()}MB`)
+      return result
     }
     case 'daily-activity': {
       const rows = await getSequenceAwareDailyActivitySQL(


### PR DESCRIPTION
## Summary

Diagnostics and reproduction tooling for the Explore-tab `ERR_WORKER_OUT_OF_MEMORY` on large studies (#564). No behavior change in normal operation — logging is additive and the heap cap is opt-in via an env var.

- **`worker.js`**: per-task logging — `[seq-worker:<type>] start gap=… heap=used/limitMB`, a `SLOW PATH` marker when the SQL fast-path bails on a positive gap, the loaded row count, and heap before/after the JS aggregation.
- **`runInWorker.js`**: tag worker errors/exits with the task type (so a crash names which of the concurrent workers died); honor optional `SEQ_WORKER_MAX_OLD_MB` to cap the worker's V8 old-space (no effect when unset).
- **`scripts/repro-seq-oom.mjs`**: CDP-driven reproduction — `explore` mode boots the real Explore tab, `ipc` mode fires the heavy IPCs directly.
- **`scripts/dev-debug.sh`**: launch dev with the CDP port + heap cap, stopping stale instances first.
- **`docs/troubleshooting.md`**: document the OOM and the repro workflow.

## Context

Root cause (full analysis in #564): the sequence-aware queries only aggregate in SQL for gap `null`/`0`; a **positive** stored `sequenceGap` falls back to dumping the whole observation×media join into JS + Maps (~1.5 GB on a 2.2M-row / 92-species study). The Explore tab runs several such workers concurrently. This PR is the instrumentation + repro harness; the SQL-aggregation fix is separate.

## Test plan

- [x] `npm run format` — clean
- [x] `npm run lint` — 0 errors (warnings only in pre-existing files)
- [x] `npm test` — 1454 passed, 0 failed
- [x] Reproduced the OOM via `SEQ_WORKER_MAX_OLD_MB=950 scripts/dev-debug.sh` + `node scripts/repro-seq-oom.mjs <studyId>` (exact `ERR_WORKER_OUT_OF_MEMORY`, app survives)