### PR TITLE
fix(sequences): aggregate positive-gap sequences in SQL, drop JS row-dump (#564)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -286,23 +286,27 @@ Worker terminated due to reaching memory limit: JS heap out of memory
 
 The error is caught (the app keeps running) but the affected stat fails to load.
 
-**Cause:** The sequence-aware queries (`src/main/services/sequences/worker.js`) have
-a fast SQL aggregation path that only handles a sequence gap of `null` or `0`. When
-a study's stored `sequenceGap` is **positive**, the worker falls back to dumping the
+**Cause:** The sequence-aware queries (`src/main/services/sequences/worker.js`) used to
+have a fast SQL aggregation path that only handled a sequence gap of `null` or `0`. When
+a study's stored `sequenceGap` was **positive**, the worker fell back to dumping the
 entire observation×media join into a JS array and aggregating it with Maps. Peak heap
-scales with **row count × species** (e.g. ~2.2M rows / 92 species ≈ 1.5 GB), and the
-Explore tab makes it worse by running several such workers concurrently. The OOM
-fires when the worker's V8 old-space ceiling is below that footprint.
+scaled with **row count × species** (e.g. ~2.2M rows / 92 species ≈ 1.5 GB), and the
+Explore tab made it worse by running several such workers concurrently. The OOM
+fired when the worker's V8 old-space ceiling was below that footprint.
 
-See GitHub issue
-[#564](https://github.com/earthtoolsmaker/biowatch/issues/564) for the full analysis.
+**Fixed** in [#564](https://github.com/earthtoolsmaker/biowatch/issues/564): `species-distribution`
+and `timeseries` now aggregate every gap mode (including positive, via SQL window functions)
+entirely in SQLite — no JS row-dump, bounded memory. A `SLOW PATH` log line now only
+appears for the remaining JS fallback (heatmap blank-inclusion). The related
+`daily-activity` correctness issue is tracked in
+[#571](https://github.com/earthtoolsmaker/biowatch/issues/571).
 
 **Diagnosing it** (the sequences worker logs each task to the main log):
 
 ```
-[seq-worker:species-distribution] start gap=110 ... heap=18/1046MB
-[seq-worker:species-distribution] SLOW PATH (gap=110): SQL fast-path returned null, dumping rows
-[seq-worker:species-distribution] loaded 2187792 rows, heap=779MB — starting JS aggregation
+[seq-worker:timeseries] start gap=110 ... heap=18/1046MB
+[seq-worker:timeseries] SLOW PATH (gap=110): SQL fast-path returned null, dumping rows
+[seq-worker:timeseries] loaded 2187792 rows, heap=779MB — starting JS aggregation
 ```
 
 A `SLOW PATH` line followed by a large `loaded N rows` and no matching

--- a/scripts/bench-seq-sql.mjs
+++ b/scripts/bench-seq-sql.mjs
@@ -1,0 +1,85 @@
+/**
+ * Benchmark the sequence-aware SQL aggregates against the real studies in the
+ * local Biowatch data dir. Measures the positive-gap (time-gap window-function)
+ * path that replaced the JS row-dump, plus null/0 for comparison.
+ *
+ * Requires better-sqlite3 built for Node (npm rebuild better-sqlite3).
+ *
+ * Usage:
+ *   node scripts/bench-seq-sql.mjs [gapSeconds] [topN]
+ */
+import { readdirSync, statSync, existsSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+import {
+  getSequenceAwareSpeciesCountsSQL,
+  getSequenceAwareTimeseriesSQL
+} from '../src/main/database/index.js'
+
+const GAP = Number(process.argv[2] ?? 120)
+const TOP_N = Number(process.argv[3] ?? 8)
+const STUDIES = join(homedir(), '.config', 'biowatch', 'biowatch-data', 'studies')
+
+// Silence electron-log so the benchmark output stays clean.
+try {
+  const log = (await import('electron-log')).default
+  log.transports.file.level = false
+  log.transports.console.level = false
+} catch {
+  /* not available */
+}
+
+function fmtBytes(n) {
+  if (n > 1e9) return (n / 1e9).toFixed(1) + 'GB'
+  if (n > 1e6) return (n / 1e6).toFixed(0) + 'MB'
+  return (n / 1e3).toFixed(0) + 'KB'
+}
+
+async function timeIt(fn) {
+  const t = process.hrtime.bigint()
+  const rows = await fn()
+  const ms = Number(process.hrtime.bigint() - t) / 1e6
+  return { ms, n: rows?.length ?? 0 }
+}
+
+const dbs = readdirSync(STUDIES)
+  .map((id) => ({ id, path: join(STUDIES, id, 'study.db') }))
+  .filter((s) => existsSync(s.path))
+  .map((s) => ({ ...s, size: statSync(s.path).size }))
+  .sort((a, b) => b.size - a.size)
+  .slice(0, TOP_N)
+
+console.log(`Benchmarking ${dbs.length} studies, gap=${GAP}s (positive → window-function path)\n`)
+console.log(
+  [
+    'study'.padEnd(10),
+    'db'.padStart(6),
+    'spDist(+gap)'.padStart(14),
+    'timeseries(+gap)'.padStart(17),
+    'spDist(0)'.padStart(11)
+  ].join('  ')
+)
+console.log('-'.repeat(66))
+
+for (const db of dbs) {
+  try {
+    // Cold then warm — report warm (second) run; FS cache makes the first noisy.
+    await getSequenceAwareSpeciesCountsSQL(db.path, GAP)
+    const sp = await timeIt(() => getSequenceAwareSpeciesCountsSQL(db.path, GAP))
+    const ts = await timeIt(() => getSequenceAwareTimeseriesSQL(db.path, [], GAP))
+    const sp0 = await timeIt(() => getSequenceAwareSpeciesCountsSQL(db.path, 0))
+    console.log(
+      [
+        db.id.slice(0, 8).padEnd(10),
+        fmtBytes(db.size).padStart(6),
+        `${sp.ms.toFixed(0)}ms/${sp.n}`.padStart(14),
+        `${ts.ms.toFixed(0)}ms/${ts.n}`.padStart(17),
+        `${sp0.ms.toFixed(0)}ms`.padStart(11)
+      ].join('  ')
+    )
+  } catch (e) {
+    console.log(`${db.id.slice(0, 8).padEnd(10)}  ERROR: ${e.message}`)
+  }
+}
+process.exit(0)

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -240,7 +240,6 @@ export async function getSpeciesDistributionByMedia(dbPath, bbox = null) {
  */
 export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox = null) {
   const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
-  if (isPositiveGap) return null
 
   const startTime = Date.now()
   const studyId = getStudyIdFromPath(dbPath)
@@ -251,10 +250,88 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
   const bboxJoin = bbox ? 'INNER JOIN deployments d ON m.deploymentID = d.deploymentID' : ''
 
   const useEventIDPath = gapSeconds === 0
+  const pathLabel = isPositiveGap
+    ? `time-gap-${gapSeconds}s`
+    : useEventIDPath
+      ? 'eventID'
+      : 'per-media'
 
   try {
     let rows
-    if (useEventIDPath) {
+    if (isPositiveGap) {
+      // Time-gap path: group each species' valid-timestamp media into sequences
+      // via window functions (boundary on gap > threshold, video, or deployment
+      // change), take MAX(per-media count) per sequence, SUM by species. Mirrors
+      // groupMediaIntoSequences + calculateSequenceAwareSpeciesCounts. Null-ts
+      // media can't be ordered into sequences, so each counts individually
+      // (UNION), matching the nullTimestampMedia branch in speciesCounts.js.
+      rows = sqlite
+        .prepare(
+          `
+          WITH per_media AS (
+            SELECT o.scientificName AS scientificName,
+                   m.mediaID AS mediaID,
+                   m.deploymentID AS deploymentID,
+                   m.timestamp AS ts,
+                   CASE WHEN m.fileMediatype LIKE 'video/%' THEN 1 ELSE 0 END AS is_video,
+                   CASE
+                     WHEN m.timestamp IS NULL OR m.timestamp = '' OR julianday(m.timestamp) IS NULL
+                     THEN 1 ELSE 0
+                   END AS is_null_ts,
+                   COUNT(o.observationID) AS cnt
+              FROM observations o
+              INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
+              WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+                ${bboxClause}
+              GROUP BY o.scientificName, m.mediaID
+          ),
+          valid AS (SELECT * FROM per_media WHERE is_null_ts = 0),
+          marked AS (
+            SELECT *,
+              CASE
+                WHEN LAG(mediaID) OVER w IS NULL THEN 1
+                WHEN is_video = 1 THEN 1
+                WHEN LAG(is_video) OVER w = 1 THEN 1
+                WHEN deploymentID IS NULL THEN 1
+                WHEN LAG(deploymentID) OVER w IS NULL THEN 1
+                WHEN deploymentID != LAG(deploymentID) OVER w THEN 1
+                WHEN (julianday(ts) - julianday(LAG(ts) OVER w)) * 86400 > ? THEN 1
+                ELSE 0
+              END AS is_new
+              FROM valid
+              WINDOW w AS (PARTITION BY scientificName ORDER BY ts, mediaID)
+          ),
+          sequenced AS (
+            SELECT scientificName, cnt,
+                   SUM(is_new) OVER (PARTITION BY scientificName ORDER BY ts, mediaID
+                                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS seq_id
+              FROM marked
+          ),
+          per_seq AS (
+            SELECT scientificName, seq_id, MAX(cnt) AS max_cnt
+              FROM sequenced
+              GROUP BY scientificName, seq_id
+          ),
+          valid_totals AS (
+            SELECT scientificName, SUM(max_cnt) AS count
+              FROM per_seq GROUP BY scientificName
+          ),
+          null_ts_totals AS (
+            SELECT scientificName, SUM(cnt) AS count
+              FROM per_media WHERE is_null_ts = 1
+              GROUP BY scientificName
+          )
+          SELECT scientificName, SUM(count) AS count FROM (
+            SELECT scientificName, count FROM valid_totals
+            UNION ALL
+            SELECT scientificName, count FROM null_ts_totals
+          )
+          GROUP BY scientificName ORDER BY count DESC
+        `
+        )
+        .all(...bboxParams, gapSeconds)
+    } else if (useEventIDPath) {
       // eventID path: per (species, eventID) take MAX(per-media count), SUM by species.
       // Media without eventID contribute as their own single-media "event" via COALESCE.
       // Null-timestamp media are separated out and contribute as individual single-media
@@ -333,7 +410,7 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
 
     const elapsed = Date.now() - startTime
     log.info(
-      `[SQL-agg] sequence-aware species counts (gap=${gapSeconds}, path=${useEventIDPath ? 'eventID' : 'per-media'}): ${rows.length} species in ${elapsed}ms`
+      `[SQL-agg] sequence-aware species counts (gap=${gapSeconds}, path=${pathLabel}): ${rows.length} species in ${elapsed}ms`
     )
     return rows
   } catch (error) {
@@ -364,8 +441,12 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
  *    (not positive)            → "each media is its own sequence": MAX
  *                                reduces to obs count per media, SUM
  *                                reduces to COUNT(observationID).
- *  - gapSeconds > 0            → returns null (JS fallback required for
- *                                time-gap-based sequence grouping).
+ *  - gapSeconds > 0            → time-gap sequence grouping via window
+ *                                functions, partitioned by (species, week) so
+ *                                sequences never cross a week boundary.
+ *
+ * Returns null only when BLANK_SENTINEL is requested (blanks still need the JS
+ * path); every numeric/null gap is handled in SQL.
  *
  * @param {string} dbPath
  * @param {Array<string>} speciesNames - scientificName filter (empty = all)
@@ -379,7 +460,6 @@ export async function getSequenceAwareTimeseriesSQL(
   bbox = null
 ) {
   const isPositiveGap = typeof gapSeconds === 'number' && gapSeconds > 0
-  if (isPositiveGap) return null
 
   const regularSpecies = speciesNames.filter((s) => s !== BLANK_SENTINEL)
   // Fast path only handles regular-species filtering. Blank-inclusion requests
@@ -392,6 +472,11 @@ export async function getSequenceAwareTimeseriesSQL(
   const sqlite = manager.getSqlite()
 
   const useEventIDPath = gapSeconds === 0
+  const pathLabel = isPositiveGap
+    ? `time-gap-${gapSeconds}s`
+    : useEventIDPath
+      ? 'eventID'
+      : 'per-media'
   const speciesPlaceholders = regularSpecies.map(() => '?').join(',')
   const speciesFilter =
     regularSpecies.length > 0 ? `AND o.scientificName IN (${speciesPlaceholders})` : ''
@@ -400,7 +485,67 @@ export async function getSequenceAwareTimeseriesSQL(
 
   try {
     let rows
-    if (useEventIDPath) {
+    if (isPositiveGap) {
+      // Time-gap path: per (species, week) group media into sequences via window
+      // functions, MAX(per-media count) per sequence, SUM by (species, week).
+      // Partitioning the window by weekStart mirrors calculateSequenceAwareTimeseries,
+      // which buckets observations by week BEFORE sequence-grouping — so a burst
+      // straddling a week boundary becomes two sequences. Null-ts media have no
+      // week and are excluded (matches the JS "if (!week) continue").
+      rows = sqlite
+        .prepare(
+          `
+          WITH per_media AS (
+            SELECT o.scientificName AS scientificName,
+                   m.mediaID AS mediaID,
+                   m.deploymentID AS deploymentID,
+                   m.timestamp AS ts,
+                   date(substr(m.timestamp, 1, 10), 'weekday 0', '-7 days') AS weekStart,
+                   CASE WHEN m.fileMediatype LIKE 'video/%' THEN 1 ELSE 0 END AS is_video,
+                   COUNT(*) AS media_count
+              FROM observations o
+              INNER JOIN media m ON o.mediaID = m.mediaID
+              ${bboxJoin}
+              WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
+                AND m.timestamp IS NOT NULL
+                ${speciesFilter}
+                ${bboxClause}
+              GROUP BY o.scientificName, o.mediaID
+          ),
+          marked AS (
+            SELECT *,
+              CASE
+                WHEN LAG(mediaID) OVER w IS NULL THEN 1
+                WHEN is_video = 1 THEN 1
+                WHEN LAG(is_video) OVER w = 1 THEN 1
+                WHEN deploymentID IS NULL THEN 1
+                WHEN LAG(deploymentID) OVER w IS NULL THEN 1
+                WHEN deploymentID != LAG(deploymentID) OVER w THEN 1
+                WHEN (julianday(ts) - julianday(LAG(ts) OVER w)) * 86400 > ? THEN 1
+                ELSE 0
+              END AS is_new
+              FROM per_media
+              WINDOW w AS (PARTITION BY scientificName, weekStart ORDER BY ts, mediaID)
+          ),
+          sequenced AS (
+            SELECT scientificName, weekStart, media_count,
+                   SUM(is_new) OVER (PARTITION BY scientificName, weekStart ORDER BY ts, mediaID
+                                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS seq_id
+              FROM marked
+          ),
+          per_seq AS (
+            SELECT scientificName, weekStart, seq_id, MAX(media_count) AS max_count
+              FROM sequenced
+              GROUP BY scientificName, weekStart, seq_id
+          )
+          SELECT scientificName, weekStart, SUM(max_count) AS count
+            FROM per_seq
+            GROUP BY scientificName, weekStart
+            ORDER BY weekStart
+        `
+        )
+        .all(...regularSpecies, ...bboxParams, gapSeconds)
+    } else if (useEventIDPath) {
       rows = sqlite
         .prepare(
           `
@@ -453,7 +598,7 @@ export async function getSequenceAwareTimeseriesSQL(
 
     const elapsed = Date.now() - startTime
     log.info(
-      `[SQL-agg] sequence-aware timeseries (gap=${gapSeconds}, path=${useEventIDPath ? 'eventID' : 'per-media'}): ${rows.length} (species,week) rows in ${elapsed}ms`
+      `[SQL-agg] sequence-aware timeseries (gap=${gapSeconds}, path=${pathLabel}): ${rows.length} (species,week) rows in ${elapsed}ms`
     )
     return rows
   } catch (error) {

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -259,16 +259,18 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
   try {
     let rows
     if (isPositiveGap) {
-      // Time-gap path: group each species' valid-timestamp media into sequences
-      // via window functions (boundary on gap > threshold, video, or deployment
-      // change), take MAX(per-media count) per sequence, SUM by species. Mirrors
-      // groupMediaIntoSequences + calculateSequenceAwareSpeciesCounts. Null-ts
-      // media can't be ordered into sequences, so each counts individually
-      // (UNION), matching the nullTimestampMedia branch in speciesCounts.js.
+      // Time-gap path. Mirrors groupMediaIntoSequences + calculateSequenceAwareSpeciesCounts:
+      // media are grouped into sequences over the GLOBAL media stream (boundary
+      // on gap > threshold, video, or deployment change) — NOT per species — and
+      // then each species takes MAX(per-media count) within a sequence, SUM by
+      // species. Sequencing per-species would be wrong: a media of another
+      // species can bridge a time gap between two media of this species.
+      // Null-ts media can't be ordered, so each counts individually (UNION),
+      // matching the nullTimestampMedia branch in speciesCounts.js.
       rows = sqlite
         .prepare(
           `
-          WITH per_media AS (
+          WITH mc AS (
             SELECT o.scientificName AS scientificName,
                    m.mediaID AS mediaID,
                    m.deploymentID AS deploymentID,
@@ -286,9 +288,13 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
                 ${bboxClause}
               GROUP BY o.scientificName, m.mediaID
           ),
-          valid AS (SELECT * FROM per_media WHERE is_null_ts = 0),
+          media_level AS (
+            SELECT mediaID, deploymentID, ts, MAX(is_video) AS is_video
+              FROM mc WHERE is_null_ts = 0
+              GROUP BY mediaID, deploymentID, ts
+          ),
           marked AS (
-            SELECT *,
+            SELECT mediaID, ts,
               CASE
                 WHEN LAG(mediaID) OVER w IS NULL THEN 1
                 WHEN is_video = 1 THEN 1
@@ -299,19 +305,19 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
                 WHEN (julianday(ts) - julianday(LAG(ts) OVER w)) * 86400 > ? THEN 1
                 ELSE 0
               END AS is_new
-              FROM valid
-              WINDOW w AS (PARTITION BY scientificName ORDER BY ts, mediaID)
+              FROM media_level
+              WINDOW w AS (ORDER BY ts, mediaID)
           ),
-          sequenced AS (
-            SELECT scientificName, cnt,
-                   SUM(is_new) OVER (PARTITION BY scientificName ORDER BY ts, mediaID
+          seq AS (
+            SELECT mediaID,
+                   SUM(is_new) OVER (ORDER BY ts, mediaID
                                      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS seq_id
               FROM marked
           ),
           per_seq AS (
-            SELECT scientificName, seq_id, MAX(cnt) AS max_cnt
-              FROM sequenced
-              GROUP BY scientificName, seq_id
+            SELECT mc.scientificName AS scientificName, seq.seq_id AS seq_id, MAX(mc.cnt) AS max_cnt
+              FROM mc JOIN seq ON mc.mediaID = seq.mediaID
+              GROUP BY mc.scientificName, seq.seq_id
           ),
           valid_totals AS (
             SELECT scientificName, SUM(max_cnt) AS count
@@ -319,7 +325,7 @@ export async function getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds, bbox 
           ),
           null_ts_totals AS (
             SELECT scientificName, SUM(cnt) AS count
-              FROM per_media WHERE is_null_ts = 1
+              FROM mc WHERE is_null_ts = 1
               GROUP BY scientificName
           )
           SELECT scientificName, SUM(count) AS count FROM (
@@ -486,16 +492,18 @@ export async function getSequenceAwareTimeseriesSQL(
   try {
     let rows
     if (isPositiveGap) {
-      // Time-gap path: per (species, week) group media into sequences via window
-      // functions, MAX(per-media count) per sequence, SUM by (species, week).
-      // Partitioning the window by weekStart mirrors calculateSequenceAwareTimeseries,
-      // which buckets observations by week BEFORE sequence-grouping — so a burst
-      // straddling a week boundary becomes two sequences. Null-ts media have no
-      // week and are excluded (matches the JS "if (!week) continue").
+      // Time-gap path. Mirrors calculateSequenceAwareTimeseries, which buckets
+      // observations by week BEFORE sequence-grouping, and within a week groups
+      // the GLOBAL media stream (not per species) then takes MAX(per-media count)
+      // per species per sequence. So sequencing is per-week at the media level
+      // (PARTITION BY weekStart) — NOT per (species, week); per-species would let
+      // a same-week media of another species fail to bridge the gap correctly.
+      // A burst straddling a week boundary still becomes two sequences. Null-ts
+      // media have no week and are excluded (matches JS "if (!week) continue").
       rows = sqlite
         .prepare(
           `
-          WITH per_media AS (
+          WITH mc AS (
             SELECT o.scientificName AS scientificName,
                    m.mediaID AS mediaID,
                    m.deploymentID AS deploymentID,
@@ -508,12 +516,18 @@ export async function getSequenceAwareTimeseriesSQL(
               ${bboxJoin}
               WHERE o.scientificName IS NOT NULL AND o.scientificName != ''
                 AND m.timestamp IS NOT NULL
+                AND julianday(m.timestamp) IS NOT NULL
                 ${speciesFilter}
                 ${bboxClause}
               GROUP BY o.scientificName, o.mediaID
           ),
+          media_level AS (
+            SELECT mediaID, deploymentID, ts, weekStart, MAX(is_video) AS is_video
+              FROM mc
+              GROUP BY mediaID, deploymentID, ts, weekStart
+          ),
           marked AS (
-            SELECT *,
+            SELECT mediaID, ts, weekStart,
               CASE
                 WHEN LAG(mediaID) OVER w IS NULL THEN 1
                 WHEN is_video = 1 THEN 1
@@ -524,19 +538,20 @@ export async function getSequenceAwareTimeseriesSQL(
                 WHEN (julianday(ts) - julianday(LAG(ts) OVER w)) * 86400 > ? THEN 1
                 ELSE 0
               END AS is_new
-              FROM per_media
-              WINDOW w AS (PARTITION BY scientificName, weekStart ORDER BY ts, mediaID)
+              FROM media_level
+              WINDOW w AS (PARTITION BY weekStart ORDER BY ts, mediaID)
           ),
-          sequenced AS (
-            SELECT scientificName, weekStart, media_count,
-                   SUM(is_new) OVER (PARTITION BY scientificName, weekStart ORDER BY ts, mediaID
+          seq AS (
+            SELECT mediaID, weekStart,
+                   SUM(is_new) OVER (PARTITION BY weekStart ORDER BY ts, mediaID
                                      ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS seq_id
               FROM marked
           ),
           per_seq AS (
-            SELECT scientificName, weekStart, seq_id, MAX(media_count) AS max_count
-              FROM sequenced
-              GROUP BY scientificName, weekStart, seq_id
+            SELECT mc.scientificName AS scientificName, seq.weekStart AS weekStart,
+                   seq.seq_id AS seq_id, MAX(mc.media_count) AS max_count
+              FROM mc JOIN seq ON mc.mediaID = seq.mediaID
+              GROUP BY mc.scientificName, seq.weekStart, seq.seq_id
           )
           SELECT scientificName, weekStart, SUM(max_count) AS count
             FROM per_seq

--- a/src/main/services/sequences/worker.js
+++ b/src/main/services/sequences/worker.js
@@ -14,7 +14,6 @@ import log from '../logger.js'
 import {
   getDrizzleDb,
   getMetadata,
-  getSpeciesDistributionByMedia,
   getSpeciesTimeseriesByMedia,
   getSpeciesHeatmapDataByMedia,
   getSequenceAwareSpeciesCountsSQL,
@@ -30,7 +29,6 @@ import {
 } from '../../database/index.js'
 import { getPaginatedSequences } from './pagination.js'
 import {
-  calculateSequenceAwareSpeciesCounts,
   calculateSequenceAwareTimeseries,
   calculateSequenceAwareHeatmap,
   pivotPreAggregatedTimeseries,
@@ -75,20 +73,11 @@ async function run() {
 
   switch (type) {
     case 'species-distribution': {
-      // Fast path: SQL aggregate handles gapSeconds === null and === 0, returns
-      // the final [{scientificName, count}] directly (83 rows, not 1.65M).
-      // Returns null for positive gapSeconds, in which case we fall back to the
-      // row-dump + JS sequence grouping below.
-      const fast = await getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds, bbox)
-      if (fast !== null) return fast
-      log.warn(
-        `${tag} SLOW PATH (gap=${effectiveGapSeconds}): SQL fast-path returned null, dumping rows`
-      )
-      const rawData = await getSpeciesDistributionByMedia(dbPath, bbox)
-      log.info(`${tag} loaded ${rawData.length} rows, heap=${heapMb()}MB — starting JS aggregation`)
-      const result = calculateSequenceAwareSpeciesCounts(rawData, effectiveGapSeconds)
-      log.info(`${tag} aggregation done: ${result.length} species, heap=${heapMb()}MB`)
-      return result
+      // Computed entirely in SQL for every gap mode (per-media, eventID, and
+      // time-gap via window functions), so there is no JS row-dump fallback —
+      // see getSequenceAwareSpeciesCountsSQL. This is what keeps the worker off
+      // the multi-GB heap path that used to OOM on large studies.
+      return getSequenceAwareSpeciesCountsSQL(dbPath, effectiveGapSeconds, bbox)
     }
     case 'timeseries': {
       // Fast path: SQL aggregate handles gapSeconds === null and === 0,

--- a/test/main/database/queries/sequenceAwareSQL.fuzz.test.js
+++ b/test/main/database/queries/sequenceAwareSQL.fuzz.test.js
@@ -1,0 +1,196 @@
+/**
+ * Randomized parity fuzz: for many seeded-random studies and several gap
+ * values, assert the SQL aggregates exactly match the JS reference pipeline for
+ * BOTH species-distribution and timeseries. Exercises edge-case interactions
+ * (gap boundaries × videos × deployment changes × null timestamps × multi-row
+ * per-media counts × week boundaries) that hand-written fixtures miss.
+ *
+ * Deterministic: a seeded PRNG makes any failure reproducible from the seed
+ * printed in the assertion label.
+ */
+
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+
+import {
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations,
+  getSpeciesDistributionByMedia,
+  getSpeciesTimeseriesByMedia,
+  getSequenceAwareSpeciesCountsSQL,
+  getSequenceAwareTimeseriesSQL
+} from '../../../../src/main/database/index.js'
+import {
+  calculateSequenceAwareSpeciesCounts,
+  calculateSequenceAwareTimeseries
+} from '../../../../src/main/services/sequences/speciesCounts.js'
+
+let testBiowatchDataPath
+let testDbPath
+let testStudyId
+
+beforeEach(async () => {
+  try {
+    const log = (await import('electron-log')).default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    /* ignore */
+  }
+  testStudyId = `fuzz-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-fuzz-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath))
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+})
+
+// mulberry32 — small deterministic PRNG.
+function rng(seed) {
+  let a = seed >>> 0
+  return () => {
+    a |= 0
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const SPECIES = ['Deer', 'Fox', 'Boar', 'Hare', 'Badger']
+const DEPLOYMENTS = ['d1', 'd2', 'd3']
+// Base time near a Sunday week boundary so bursts straddle weeks sometimes.
+const BASE = DateTime.fromISO('2024-01-05T12:00:00Z')
+
+function genStudy(rand) {
+  const deployments = {}
+  for (const id of DEPLOYMENTS) {
+    deployments[id] = {
+      deploymentID: id,
+      locationID: `loc-${id}`,
+      locationName: id,
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-02-01T00:00:00Z'),
+      latitude: 0,
+      longitude: 0
+    }
+  }
+
+  const media = {}
+  const observations = []
+  const videoIds = []
+  const nMedia = 40 + Math.floor(rand() * 50)
+  for (let i = 0; i < nMedia; i++) {
+    const id = `m${i}`
+    const isNull = rand() < 0.12
+    const isVideo = rand() < 0.1
+    // Spread over ~6 days in tight-ish clusters so gaps cross thresholds.
+    const offsetSec = Math.floor(rand() * 6 * 24 * 3600)
+    const ts = isNull ? null : BASE.plus({ seconds: offsetSec })
+    media[`${id}.x`] = {
+      mediaID: id,
+      deploymentID: DEPLOYMENTS[Math.floor(rand() * DEPLOYMENTS.length)],
+      timestamp: ts,
+      filePath: `p/${id}`,
+      fileName: `${id}.x`,
+      importFolder: 'p',
+      folderName: 'f'
+    }
+    if (isVideo) videoIds.push(id)
+    // 1-3 distinct species on this media, each with a random per-media count.
+    const k = 1 + Math.floor(rand() * 3)
+    const used = new Set()
+    for (let s = 0; s < k; s++) {
+      const sp = SPECIES[Math.floor(rand() * SPECIES.length)]
+      if (used.has(sp)) continue
+      used.add(sp)
+      const cnt = 1 + Math.floor(rand() * 4)
+      for (let c = 0; c < cnt; c++) {
+        observations.push({
+          observationID: `${id}-${sp}-${c}`,
+          mediaID: id,
+          deploymentID: media[`${id}.x`].deploymentID,
+          eventID: null,
+          scientificName: sp,
+          count: 1
+        })
+      }
+    }
+  }
+  return { deployments, media, observations, videoIds }
+}
+
+async function seed(dbPath, study) {
+  const manager = await createImageDirectoryDatabase(dbPath)
+  await insertDeployments(manager, study.deployments)
+  await insertMedia(manager, study.media)
+  await insertObservations(manager, study.observations)
+  // insertMedia drops fileMediatype, so mark videos via raw SQL.
+  for (const id of study.videoIds) {
+    manager
+      .getSqlite()
+      .prepare('UPDATE media SET fileMediatype = ? WHERE mediaID = ?')
+      .run('video/mp4', id)
+  }
+  return manager
+}
+
+const normCounts = (arr) =>
+  [...arr]
+    .map((r) => ({ s: r.scientificName, c: Number(r.count) }))
+    .sort((a, b) => a.s.localeCompare(b.s))
+
+const normTsSql = (rows) =>
+  rows.map((r) => `${r.weekStart}|${r.scientificName}=${Number(r.count)}`).sort()
+const normTsJs = (js) => {
+  const out = []
+  for (const wk of js.timeseries)
+    for (const [k, v] of Object.entries(wk))
+      if (k !== 'date') out.push(`${wk.date}|${k}=${Number(v)}`)
+  return out.sort()
+}
+
+describe('sequence-aware SQL — randomized parity vs JS reference', () => {
+  const GAPS = [null, 0, 30, 90, 300, 3600, 86400]
+  const TRIALS = Number(process.env.FUZZ_TRIALS) || 12
+
+  for (let trial = 0; trial < TRIALS; trial++) {
+    test(`trial ${trial}`, async () => {
+      const seed1 = 1000 + trial * 7919
+      const rand = rng(seed1)
+      await seed(testDbPath, genStudy(rand))
+
+      const rawDist = await getSpeciesDistributionByMedia(testDbPath)
+      const rawTs = await getSpeciesTimeseriesByMedia(testDbPath, [])
+
+      for (const gap of GAPS) {
+        // species-distribution
+        const sqlD = await getSequenceAwareSpeciesCountsSQL(testDbPath, gap)
+        const jsD = calculateSequenceAwareSpeciesCounts(rawDist, gap)
+        assert.deepEqual(
+          normCounts(sqlD),
+          normCounts(jsD),
+          `species-distribution mismatch: seed=${seed1} gap=${gap}`
+        )
+
+        // timeseries
+        const sqlT = await getSequenceAwareTimeseriesSQL(testDbPath, [], gap)
+        const jsT = calculateSequenceAwareTimeseries(rawTs, gap)
+        assert.deepEqual(
+          normTsSql(sqlT),
+          normTsJs(jsT),
+          `timeseries mismatch: seed=${seed1} gap=${gap}`
+        )
+      }
+    })
+  }
+})

--- a/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
+++ b/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
@@ -64,9 +64,11 @@ async function assertParity(dbPath, gapSeconds, label) {
   const jsResult = calculateSequenceAwareSpeciesCounts(rawRows, gapSeconds)
 
   const sqlResult = await getSequenceAwareSpeciesCountsSQL(dbPath, gapSeconds)
-  if (sqlResult === null) {
-    return { skipped: true, gapSeconds, label }
-  }
+  assert.notEqual(
+    sqlResult,
+    null,
+    `SQL path returned null (unhandled gap) for gap=${gapSeconds} (${label})`
+  )
 
   const norm = (arr) =>
     [...arr]
@@ -390,51 +392,14 @@ describe('getSequenceAwareSpeciesCountsSQL — parity with JS pipeline', () => {
     await assertParity(testDbPath, 0, 'eventID-gap with null-ts')
   })
 
-  test('positive gapSeconds: SQL path returns null (JS fallback)', async () => {
-    await seed(testDbPath, {
-      deployments: {
-        d1: {
-          deploymentID: 'd1',
-          locationID: 'l1',
-          locationName: 'A',
-          deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
-          deploymentEnd: DateTime.fromISO('2024-01-02T00:00:00Z'),
-          latitude: 0,
-          longitude: 0
-        }
-      },
-      media: {
-        'm1.jpg': {
-          mediaID: 'm1',
-          deploymentID: 'd1',
-          timestamp: DateTime.fromISO('2024-01-01T10:00:00Z'),
-          filePath: 'x/m1.jpg',
-          fileName: 'm1.jpg',
-          importFolder: 'x',
-          folderName: 'f'
-        }
-      },
-      observations: [
-        {
-          observationID: 'o1',
-          mediaID: 'm1',
-          deploymentID: 'd1',
-          eventID: 'e1',
-          scientificName: 'Deer',
-          count: 1
-        }
-      ]
-    })
-    const sql = await getSequenceAwareSpeciesCountsSQL(testDbPath, 120)
-    assert.equal(sql, null, 'positive gap should return null so caller falls back to JS')
-  })
-
-  test('empty DB returns empty array (gap=null and gap=0)', async () => {
+  test('empty DB returns empty array (gap=null, gap=0, positive gap)', async () => {
     await createImageDirectoryDatabase(testDbPath)
     const sqlNull = await getSequenceAwareSpeciesCountsSQL(testDbPath, null)
     const sqlZero = await getSequenceAwareSpeciesCountsSQL(testDbPath, 0)
+    const sqlPositive = await getSequenceAwareSpeciesCountsSQL(testDbPath, 120)
     assert.deepEqual(sqlNull, [])
     assert.deepEqual(sqlZero, [])
+    assert.deepEqual(sqlPositive, [])
   })
 
   test('media with empty-string eventID becomes its own event (COALESCE NULLIF path)', async () => {
@@ -493,5 +458,169 @@ describe('getSequenceAwareSpeciesCountsSQL — parity with JS pipeline', () => {
     })
     await assertParity(testDbPath, null, 'null-gap, no-eventID')
     await assertParity(testDbPath, 0, 'eventID-gap, no-eventID')
+  })
+})
+
+describe('getSequenceAwareSpeciesCountsSQL — positive-gap parity with JS pipeline', () => {
+  const dep = (id, lat, lng) => ({
+    deploymentID: id,
+    locationID: `loc-${id}`,
+    locationName: id,
+    deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+    deploymentEnd: DateTime.fromISO('2024-01-31T00:00:00Z'),
+    latitude: lat,
+    longitude: lng
+  })
+  const med = (id, deploymentID, iso, extra = {}) => ({
+    mediaID: id,
+    deploymentID,
+    timestamp: iso ? DateTime.fromISO(iso) : null,
+    filePath: `p/${id}.jpg`,
+    fileName: `${id}.jpg`,
+    importFolder: 'p',
+    folderName: 'f',
+    ...extra
+  })
+  // N observation rows for (species, media) so COUNT(observationID) == cnt.
+  const obs = (mediaID, deploymentID, scientificName, cnt, eventID = null) =>
+    Array.from({ length: cnt }, (_, i) => ({
+      observationID: `${mediaID}-${scientificName}-${i}`,
+      mediaID,
+      deploymentID,
+      eventID,
+      scientificName,
+      count: 1
+    }))
+
+  test('time-gap split: one deployment, sequences break past the gap', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-05T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-05T10:05:00Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 5),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    // gap=120: {m1,m2}=max(2,5)=5, {m3}=3 → Deer=8. gap=20: each alone → 10.
+    const raw = await getSpeciesDistributionByMedia(testDbPath)
+    assert.equal(
+      calculateSequenceAwareSpeciesCounts(raw, 120).find((r) => r.scientificName === 'Deer').count,
+      8
+    )
+    assert.equal(
+      calculateSequenceAwareSpeciesCounts(raw, 20).find((r) => r.scientificName === 'Deer').count,
+      10
+    )
+    await assertParity(testDbPath, 120, 'gap-120 split')
+    await assertParity(testDbPath, 20, 'gap-20 all-singletons')
+    await assertParity(testDbPath, 600, 'gap-600 all-grouped')
+  })
+
+  test('deployment boundary: within gap but different deployments never group', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0), d2: dep('d2', 1, 1) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd2', '2024-01-05T10:00:10Z')
+      },
+      observations: [...obs('m1', 'd1', 'Fox', 2), ...obs('m2', 'd2', 'Fox', 4)]
+    })
+    await assertParity(testDbPath, 120, 'cross-deployment')
+  })
+
+  test('video boundary: a video is never grouped with neighbors', async () => {
+    // insertMedia does not carry fileMediatype, so set it directly after seed.
+    const manager = await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.mp4': med('m2', 'd1', '2024-01-05T10:00:05Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-05T10:00:10Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 7),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    manager
+      .getSqlite()
+      .prepare("UPDATE media SET fileMediatype = 'video/mp4' WHERE mediaID = 'm2'")
+      .run()
+    // m2 video isolates: {m1}=2, {m2}=7, {m3}=3 → Deer=12 (no grouping despite 5s gaps).
+    const raw = await getSpeciesDistributionByMedia(testDbPath)
+    assert.equal(
+      calculateSequenceAwareSpeciesCounts(raw, 120).find((r) => r.scientificName === 'Deer').count,
+      12
+    )
+    await assertParity(testDbPath, 120, 'video-isolated')
+  })
+
+  test('null-timestamp media count individually alongside grouped valid-ts', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-05T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', null)
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 5),
+        ...obs('m3', 'd1', 'Deer', 4)
+      ]
+    })
+    // {m1,m2}=5, null-ts m3=4 → Deer=9.
+    const raw = await getSpeciesDistributionByMedia(testDbPath)
+    assert.equal(
+      calculateSequenceAwareSpeciesCounts(raw, 120).find((r) => r.scientificName === 'Deer').count,
+      9
+    )
+    await assertParity(testDbPath, 120, 'with null-ts')
+  })
+
+  test('multiple species are sequenced independently (partition by species)', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-05T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-05T10:01:00Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m1', 'd1', 'Fox', 1),
+        ...obs('m2', 'd1', 'Deer', 5),
+        ...obs('m3', 'd1', 'Fox', 3)
+      ]
+    })
+    await assertParity(testDbPath, 120, 'two species interleaved')
+    await assertParity(testDbPath, 20, 'two species, all singletons')
+  })
+
+  test('bbox filter applies under positive gap', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 10, 10), d2: dep('d2', 50, 50) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd2', '2024-01-05T10:00:30Z')
+      },
+      observations: [...obs('m1', 'd1', 'Deer', 2), ...obs('m2', 'd2', 'Deer', 5)]
+    })
+    const bbox = { north: 20, south: 0, east: 20, west: 0 } // only d1
+    const raw = await getSpeciesDistributionByMedia(testDbPath, bbox)
+    const js = calculateSequenceAwareSpeciesCounts(raw, 120)
+    const sql = await getSequenceAwareSpeciesCountsSQL(testDbPath, 120, bbox)
+    assert.notEqual(sql, null)
+    const norm = (a) =>
+      [...a]
+        .map((r) => ({ scientificName: r.scientificName, count: Number(r.count) }))
+        .sort((x, y) => x.scientificName.localeCompare(y.scientificName))
+    assert.deepEqual(norm(sql), norm(js))
   })
 })

--- a/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
+++ b/test/main/database/queries/sequenceAwareSpeciesCountsSQL.test.js
@@ -584,7 +584,7 @@ describe('getSequenceAwareSpeciesCountsSQL — positive-gap parity with JS pipel
     await assertParity(testDbPath, 120, 'with null-ts')
   })
 
-  test('multiple species are sequenced independently (partition by species)', async () => {
+  test('multiple species share the global media sequence', async () => {
     await seed(testDbPath, {
       deployments: { d1: dep('d1', 0, 0) },
       media: {
@@ -601,6 +601,30 @@ describe('getSequenceAwareSpeciesCountsSQL — positive-gap parity with JS pipel
     })
     await assertParity(testDbPath, 120, 'two species interleaved')
     await assertParity(testDbPath, 20, 'two species, all singletons')
+  })
+
+  test('a media of another species bridges a time gap (global, not per-species)', async () => {
+    // m1(Deer,t=0), m2(Fox,t=50s), m3(Deer,t=100s), gap=90s. The Deer-to-Deer
+    // direct gap (100s) exceeds 90s, but the Fox media at t=50 bridges it, so all
+    // three form ONE global sequence. Deer = max(2,3) = 3, NOT 2+3 = 5 (which is
+    // what per-species sequencing would wrongly produce). Regression guard for
+    // the global-vs-per-species fix.
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1', 0, 0) },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-05T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-05T10:00:50Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-05T10:01:40Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Fox', 1),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    const sql = await getSequenceAwareSpeciesCountsSQL(testDbPath, 90)
+    assert.equal(sql.find((r) => r.scientificName === 'Deer').count, 3, 'bridged → one sequence')
+    await assertParity(testDbPath, 90, 'cross-species bridge')
   })
 
   test('bbox filter applies under positive gap', async () => {

--- a/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
+++ b/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
@@ -170,6 +170,31 @@ describe('getSequenceAwareTimeseriesSQL — positive-gap parity with JS pipeline
     await assertTsParity(testDbPath, [], 120, 'all species')
   })
 
+  test('a media of another species bridges a time gap within a week (global)', async () => {
+    // Same discriminator as the species-counts suite: m2(Fox) at t=50s bridges
+    // the 100s Deer-to-Deer gap so all three are one sequence in the week.
+    // Deer = max(2,3) = 3, not 2+3 = 5. Regression guard for global sequencing.
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-09T10:00:50Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-09T10:01:40Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Fox', 1),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    const sql = await getSequenceAwareTimeseriesSQL(testDbPath, [], 90)
+    const deer = sql
+      .filter((r) => r.scientificName === 'Deer')
+      .reduce((a, r) => a + Number(r.count), 0)
+    assert.equal(deer, 3, 'bridged → one sequence within the week')
+    await assertTsParity(testDbPath, [], 90, 'cross-species bridge within week')
+  })
+
   test('null-timestamp media excluded from timeseries', async () => {
     await seed(testDbPath, {
       deployments: { d1: dep('d1') },

--- a/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
+++ b/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
@@ -1,0 +1,189 @@
+/**
+ * Parity tests for the timeseries SQL-aggregate path vs the JS pipeline.
+ *
+ * For each fixture + gap value, assert that getSequenceAwareTimeseriesSQL
+ * produces the same per-(week, species) counts as
+ * calculateSequenceAwareTimeseries(getSpeciesTimeseriesByMedia(...), gap).
+ *
+ * The JS path groups observations by week FIRST, then sequence-groups within
+ * each week — so a burst that straddles a week boundary becomes two sequences.
+ * The SQL path must mirror that by partitioning sequences on (species, week).
+ */
+
+import { test, beforeEach, afterEach, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdirSync, rmSync, existsSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { DateTime } from 'luxon'
+
+import {
+  createImageDirectoryDatabase,
+  insertDeployments,
+  insertMedia,
+  insertObservations,
+  getSpeciesTimeseriesByMedia,
+  getSequenceAwareTimeseriesSQL
+} from '../../../../src/main/database/index.js'
+import { calculateSequenceAwareTimeseries } from '../../../../src/main/services/sequences/speciesCounts.js'
+
+let testDbPath
+let testStudyId
+let testBiowatchDataPath
+
+beforeEach(async () => {
+  try {
+    const electronLog = await import('electron-log')
+    const log = electronLog.default
+    log.transports.file.level = false
+    log.transports.console.level = false
+  } catch {
+    // not available, fine
+  }
+  testStudyId = `test-ts-agg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  testBiowatchDataPath = join(tmpdir(), 'biowatch-ts-agg-test', testStudyId)
+  testDbPath = join(testBiowatchDataPath, 'studies', testStudyId, 'study.db')
+  mkdirSync(join(testBiowatchDataPath, 'studies', testStudyId), { recursive: true })
+})
+
+afterEach(() => {
+  if (existsSync(testBiowatchDataPath)) {
+    rmSync(testBiowatchDataPath, { recursive: true, force: true })
+  }
+})
+
+async function seed(dbPath, { deployments, media, observations }) {
+  const manager = await createImageDirectoryDatabase(dbPath)
+  await insertDeployments(manager, deployments)
+  await insertMedia(manager, media)
+  await insertObservations(manager, observations)
+  return manager
+}
+
+// Flatten the JS { timeseries: [{date, [sp]: n}], ... } shape into the flat
+// `weekStart|species=count` keys the SQL path returns, for order-insensitive
+// comparison.
+function normFromJs(jsResult) {
+  const out = []
+  for (const week of jsResult.timeseries) {
+    for (const [k, v] of Object.entries(week)) {
+      if (k === 'date') continue
+      out.push(`${week.date}|${k}=${Number(v)}`)
+    }
+  }
+  return out.sort()
+}
+
+function normFromSql(rows) {
+  return rows.map((r) => `${r.weekStart}|${r.scientificName}=${Number(r.count)}`).sort()
+}
+
+async function assertTsParity(dbPath, speciesNames, gapSeconds, label) {
+  const raw = await getSpeciesTimeseriesByMedia(dbPath, speciesNames)
+  const js = calculateSequenceAwareTimeseries(raw, gapSeconds)
+  const sql = await getSequenceAwareTimeseriesSQL(dbPath, speciesNames, gapSeconds)
+  assert.notEqual(sql, null, `SQL path returned null (unhandled) for gap=${gapSeconds} (${label})`)
+  assert.deepEqual(
+    normFromSql(sql),
+    normFromJs(js),
+    `timeseries SQL vs JS parity mismatch for gap=${gapSeconds} (${label})`
+  )
+}
+
+const dep = (id) => ({
+  deploymentID: id,
+  locationID: `loc-${id}`,
+  locationName: id,
+  deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+  deploymentEnd: DateTime.fromISO('2024-02-28T00:00:00Z'),
+  latitude: 0,
+  longitude: 0
+})
+const med = (id, deploymentID, iso) => ({
+  mediaID: id,
+  deploymentID,
+  timestamp: iso ? DateTime.fromISO(iso) : null,
+  filePath: `p/${id}.jpg`,
+  fileName: `${id}.jpg`,
+  importFolder: 'p',
+  folderName: 'f'
+})
+const obs = (mediaID, deploymentID, scientificName, cnt) =>
+  Array.from({ length: cnt }, (_, i) => ({
+    observationID: `${mediaID}-${scientificName}-${i}`,
+    mediaID,
+    deploymentID,
+    eventID: null,
+    scientificName,
+    count: 1
+  }))
+
+describe('getSequenceAwareTimeseriesSQL — positive-gap parity with JS pipeline', () => {
+  test('within-week time-gap split', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-09T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-09T10:05:00Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 5),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    await assertTsParity(testDbPath, [], 120, 'within-week split')
+    await assertTsParity(testDbPath, [], 20, 'within-week singletons')
+  })
+
+  test('burst across a week boundary splits into per-week sequences', async () => {
+    // 2024-01-07 is a Sunday → start of a new week for date(.., 'weekday 0','-7 days').
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-06T23:59:30Z'), // Saturday, week A
+        'm2.jpg': med('m2', 'd1', '2024-01-07T00:00:30Z') // Sunday, week B (60s later)
+      },
+      observations: [...obs('m1', 'd1', 'Deer', 4), ...obs('m2', 'd1', 'Deer', 6)]
+    })
+    // Within gap=120 by time, but different weeks → two sequences → week A=4, week B=6.
+    await assertTsParity(testDbPath, [], 120, 'week-spanning burst')
+  })
+
+  test('species filter under positive gap', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-09T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-09T10:01:00Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Fox', 5),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    await assertTsParity(testDbPath, ['Deer'], 120, 'filter to Deer')
+    await assertTsParity(testDbPath, [], 120, 'all species')
+  })
+
+  test('null-timestamp media excluded from timeseries', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', null)
+      },
+      observations: [...obs('m1', 'd1', 'Deer', 2), ...obs('m2', 'd1', 'Deer', 9)]
+    })
+    await assertTsParity(testDbPath, [], 120, 'null-ts excluded')
+  })
+
+  test('empty DB returns empty array for positive gap', async () => {
+    await createImageDirectoryDatabase(testDbPath)
+    const sql = await getSequenceAwareTimeseriesSQL(testDbPath, [], 120)
+    assert.deepEqual(sql, [])
+  })
+})

--- a/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
+++ b/test/main/database/queries/sequenceAwareTimeseriesSQL.test.js
@@ -5,9 +5,10 @@
  * produces the same per-(week, species) counts as
  * calculateSequenceAwareTimeseries(getSpeciesTimeseriesByMedia(...), gap).
  *
- * The JS path groups observations by week FIRST, then sequence-groups within
- * each week — so a burst that straddles a week boundary becomes two sequences.
- * The SQL path must mirror that by partitioning sequences on (species, week).
+ * The JS path groups observations by week FIRST, then sequence-groups the
+ * global media stream within each week (not per species) — so a burst that
+ * straddles a week boundary becomes two sequences. The SQL path mirrors that by
+ * sequencing media partitioned on weekStart, then taking per-species MAX.
  */
 
 import { test, beforeEach, afterEach, describe } from 'node:test'
@@ -179,6 +180,68 @@ describe('getSequenceAwareTimeseriesSQL — positive-gap parity with JS pipeline
       observations: [...obs('m1', 'd1', 'Deer', 2), ...obs('m2', 'd1', 'Deer', 9)]
     })
     await assertTsParity(testDbPath, [], 120, 'null-ts excluded')
+  })
+
+  test('deployment boundary within a week never groups', async () => {
+    await seed(testDbPath, {
+      deployments: { d1: dep('d1'), d2: dep('d2') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd2', '2024-01-09T10:00:10Z')
+      },
+      observations: [...obs('m1', 'd1', 'Deer', 2), ...obs('m2', 'd2', 'Deer', 5)]
+    })
+    await assertTsParity(testDbPath, [], 120, 'cross-deployment within week')
+  })
+
+  test('video boundary within a week never groups', async () => {
+    const manager = await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.mp4': med('m2', 'd1', '2024-01-09T10:00:05Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-09T10:00:10Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 7),
+        ...obs('m3', 'd1', 'Deer', 3)
+      ]
+    })
+    manager
+      .getSqlite()
+      .prepare("UPDATE media SET fileMediatype = 'video/mp4' WHERE mediaID = 'm2'")
+      .run()
+    await assertTsParity(testDbPath, [], 120, 'video isolated within week')
+  })
+
+  test('non-null but unparseable timestamps are excluded (no null-week row)', async () => {
+    // insertMedia rejects bad timestamps (.toISO()), so corrupt them via raw SQL.
+    const manager = await seed(testDbPath, {
+      deployments: { d1: dep('d1') },
+      media: {
+        'm1.jpg': med('m1', 'd1', '2024-01-09T10:00:00Z'),
+        'm2.jpg': med('m2', 'd1', '2024-01-09T10:00:30Z'),
+        'm3.jpg': med('m3', 'd1', '2024-01-09T10:01:00Z')
+      },
+      observations: [
+        ...obs('m1', 'd1', 'Deer', 2),
+        ...obs('m2', 'd1', 'Deer', 9),
+        ...obs('m3', 'd1', 'Deer', 4)
+      ]
+    })
+    manager
+      .getSqlite()
+      .prepare("UPDATE media SET timestamp = 'not-a-date' WHERE mediaID = 'm2'")
+      .run()
+    manager.getSqlite().prepare("UPDATE media SET timestamp = '' WHERE mediaID = 'm3'").run()
+    const sql = await getSequenceAwareTimeseriesSQL(testDbPath, [], 120)
+    assert.equal(
+      sql.filter((r) => r.weekStart == null).length,
+      0,
+      'must not emit weekStart=null rows for unparseable timestamps'
+    )
+    await assertTsParity(testDbPath, [], 120, 'unparseable timestamps excluded')
   })
 
   test('empty DB returns empty array for positive gap', async () => {


### PR DESCRIPTION
## Summary

Fixes the Explore-tab `ERR_WORKER_OUT_OF_MEMORY` on large studies (#564). A **positive** stored `sequenceGap` used to fall back to dumping the whole observation×media join into the worker and grouping in JS (~2.2M rows, ~3.3 GB RSS). This computes the time-gap sequence grouping **entirely in SQL** via window functions.

Sequence-aware counting groups media into sequences over the **global media stream** (one media → one sequence, by deployment + time-gap + video), then takes per-species `MAX` within each sequence (matching `groupMediaIntoSequences` + `calculateSequenceAwareSpeciesCounts`). The SQL sequences a **media-level** CTE, then JOINs per-(species, media) counts:

- **`getSequenceAwareSpeciesCountsSQL`** — media-level sequencing (global stream); null-timestamp media counted individually (UNION).
- **`getSequenceAwareTimeseriesSQL`** — media-level sequencing partitioned by `weekStart` only (JS buckets by week first, then sequences the global stream within the week); null/unparseable-timestamp media excluded.
- **`worker.js`** — species-distribution always uses SQL; removed the dead row-dump fallback + imports.

## Correctness

Parity against the JS reference (`SQL == calculateSequenceAware*`), including a **randomized fuzz test** (`sequenceAwareSQL.fuzz.test.js`) over seeded-random studies (videos, deployments, null timestamps, multi-row counts, week boundaries) across 7 gap values for both functions. A 50-trial stress run is clean.

> The fuzz test caught a real bug during review: an earlier version partitioned the sequence window by `scientificName`, which over-counts when a media of another species bridges a time gap. Fixed by sequencing at the media level. The sibling `getSequenceAwareDailyActivitySQL` has the same flaw (SQL-only, no parity oracle) — filed as #571, out of scope here. `getSequenceAwareHeatmapSQL` is correct (media-level, partitioned by location).

Full suite: **1479 pass, 0 fail.**

## Performance

On the largest study (3.44M obs / 2.81M media), controlled same-process A/B, identical result:

| Path | median | memory |
|---|---|---|
| **New SQL window path** | **~11 s** | bounded |
| Old JS row-dump (query + aggregate) | ~19.8 s | ~3.3 GB RSS |

~1.8× faster and bounded-memory — no more OOM. Residual cost is the inherent CPU of sequence aggregation over millions of rows (sort-bound; read pragmas gave no improvement — measured). Sub-second would require result caching (separate feature). `scripts/bench-seq-sql.mjs` added for measurement.

Closes #564