### PR TITLE
feat(overview): hover zoom on capture cards + spring-pop species hover cards

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -377,6 +377,16 @@ input::-webkit-inner-spin-button {
   }
 }
 
+/* Respect reduced-motion: drop the pop/slide entrances for the hover cards
+   and tooltips, leaving them to appear instantly. */
+@media (prefers-reduced-motion: reduce) {
+  .species-hovercard[data-state='open'],
+  .species-hovercard[data-state='closed'],
+  [data-radix-tooltip-content] {
+    animation: none;
+  }
+}
+
 @keyframes tooltip-slide-down {
   from {
     opacity: 0;

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -357,6 +357,26 @@ input::-webkit-inner-spin-button {
   animation: tooltip-fade-out 100ms ease-in;
 }
 
+/* Species detail hover card (Best captures + Featured species) — spring pop in,
+   gentle fade out. The pop is a pure scale, so it's direction-independent. */
+.species-hovercard[data-state='open'] {
+  animation: hovercard-pop 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.species-hovercard[data-state='closed'] {
+  animation: tooltip-fade-out 100ms ease-in;
+}
+
+@keyframes hovercard-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.82);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 @keyframes tooltip-slide-down {
   from {
     opacity: 0;

--- a/src/renderer/src/overview/CommonSpeciesFallback.jsx
+++ b/src/renderer/src/overview/CommonSpeciesFallback.jsx
@@ -172,14 +172,14 @@ function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
   }, [scrollSignal])
 
   return (
-    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={200} closeDelay={120}>
+    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={400} closeDelay={120}>
       <HoverCard.Trigger asChild>
         <button
           type="button"
           onClick={() => onClick(species.scientificName)}
-          className="flex-shrink-0 w-56 rounded-lg overflow-hidden cursor-pointer border border-border shadow hover:shadow-md transition-shadow text-left bg-card"
+          className="group flex-shrink-0 w-56 rounded-lg overflow-hidden cursor-pointer border border-border shadow hover:shadow-md transition-shadow text-left bg-card"
         >
-          <div className="relative w-full h-40 bg-muted">
+          <div className="relative w-full h-40 bg-muted overflow-hidden">
             {imageError ? (
               <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
                 <CameraOff size={24} />
@@ -188,7 +188,7 @@ function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
               <img
                 src={species.info.imageUrl}
                 alt={species.scientificName}
-                className="w-full h-full object-cover"
+                className="w-full h-full object-cover transition-transform duration-300 ease-out group-hover:scale-110"
                 loading="lazy"
                 onError={() => setImageError(true)}
                 referrerPolicy="no-referrer"
@@ -214,7 +214,7 @@ function SpeciesReferenceCard({ species, studyId, onClick, scrollSignal }) {
           align="center"
           avoidCollisions={true}
           collisionPadding={16}
-          className="z-[10000]"
+          className="species-hovercard z-[10000]"
         >
           <SpeciesTooltipContent
             imageData={{ scientificName: species.scientificName }}

--- a/src/renderer/src/overview/KpiBand.jsx
+++ b/src/renderer/src/overview/KpiBand.jsx
@@ -370,7 +370,7 @@ function ThreatenedSpeciesRow({ studyId, scientificName, iucn, onClick, scrollSi
   }, [scrollSignal])
   return (
     <li>
-      <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={200} closeDelay={120}>
+      <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={400} closeDelay={120}>
         <HoverCard.Trigger asChild>
           <button
             type="button"
@@ -401,7 +401,7 @@ function ThreatenedSpeciesRow({ studyId, scientificName, iucn, onClick, scrollSi
             align="center"
             avoidCollisions={true}
             collisionPadding={16}
-            className="z-[10001]"
+            className="species-hovercard z-[10001]"
           >
             <SpeciesTooltipContent imageData={{ scientificName }} studyId={studyId} size="lg" />
           </HoverCard.Content>

--- a/src/renderer/src/overview/SpeciesDistribution.jsx
+++ b/src/renderer/src/overview/SpeciesDistribution.jsx
@@ -50,7 +50,7 @@ function SpeciesRow({
         key={species.scientificName}
         open={hoverOpen}
         onOpenChange={setHoverOpen}
-        openDelay={200}
+        openDelay={400}
         closeDelay={120}
       >
         <HoverCard.Trigger asChild>
@@ -80,7 +80,7 @@ function SpeciesRow({
               align="center"
               avoidCollisions={true}
               collisionPadding={16}
-              className="z-[10000]"
+              className="species-hovercard z-[10000]"
             >
               <SpeciesTooltipContent imageData={tooltipImageData} studyId={studyId} size="lg" />
             </HoverCard.Content>

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -646,9 +646,9 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
     <button
       type="button"
       onClick={() => onClick(media)}
-      className="flex-shrink-0 w-56 rounded-lg overflow-hidden cursor-pointer border border-border shadow hover:shadow-md transition-shadow text-left bg-card"
+      className="group flex-shrink-0 w-56 rounded-lg overflow-hidden cursor-pointer border border-border shadow hover:shadow-md transition-shadow text-left bg-card"
     >
-      <div className="relative w-full h-40 bg-muted">
+      <div className="relative w-full h-40 bg-muted overflow-hidden">
         {isVideo ? (
           <>
             {/* Video placeholder background */}
@@ -671,14 +671,14 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
               <img
                 src={thumbnailUrl}
                 alt={media.fileName || `Video ${media.mediaID}`}
-                className="relative z-10 w-full h-full object-cover"
+                className="relative z-10 w-full h-full object-cover transition-transform duration-300 ease-out group-hover:scale-110"
                 loading="lazy"
               />
             ) : (
               /* Video element - overlays placeholder when it loads successfully */
               <video
                 src={constructImageUrl(media.filePath, studyId)}
-                className={`relative z-10 w-full h-full object-cover ${imageError ? 'hidden' : ''}`}
+                className={`relative z-10 w-full h-full object-cover transition-transform duration-300 ease-out group-hover:scale-110 ${imageError ? 'hidden' : ''}`}
                 onError={() => setImageError(true)}
                 muted
                 preload="metadata"
@@ -695,7 +695,7 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
             <img
               src={constructImageUrl(media.filePath, studyId)}
               alt={media.scientificName || 'Wildlife'}
-              className={`w-full h-full object-cover ${imageError ? 'hidden' : ''}`}
+              className={`w-full h-full object-cover transition-transform duration-300 ease-out group-hover:scale-110 ${imageError ? 'hidden' : ''}`}
               onError={() => setImageError(true)}
               loading="lazy"
             />
@@ -725,8 +725,12 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
   if (!info?.imageUrl && !info?.blurb) return cardButton
 
   return (
-    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={200} closeDelay={120}>
-      <HoverCard.Trigger asChild>{cardButton}</HoverCard.Trigger>
+    <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={400} closeDelay={120}>
+      {/* Static wrapper is the anchor: the card lifts on hover, but the popup
+          stays put because it's positioned off this non-transforming element. */}
+      <HoverCard.Trigger asChild>
+        <div className="flex-shrink-0">{cardButton}</div>
+      </HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
           side="top"
@@ -734,7 +738,7 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
           align="center"
           avoidCollisions={true}
           collisionPadding={16}
-          className="z-[10000]"
+          className="species-hovercard z-[10000]"
         >
           <SpeciesTooltipContent
             imageData={{ scientificName: media.scientificName }}

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -726,11 +726,7 @@ function MediaCard({ media, onClick, studyId, scrollSignal }) {
 
   return (
     <HoverCard.Root open={hoverOpen} onOpenChange={setHoverOpen} openDelay={400} closeDelay={120}>
-      {/* Static wrapper is the anchor: the card lifts on hover, but the popup
-          stays put because it's positioned off this non-transforming element. */}
-      <HoverCard.Trigger asChild>
-        <div className="flex-shrink-0">{cardButton}</div>
-      </HoverCard.Trigger>
+      <HoverCard.Trigger asChild>{cardButton}</HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
           side="top"

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -107,7 +107,7 @@ function SpeciesRow({
         key={species.scientificName || index}
         open={hoverOpen}
         onOpenChange={setHoverOpen}
-        openDelay={200}
+        openDelay={400}
         closeDelay={120}
       >
         <HoverCard.Trigger asChild>{rowContent}</HoverCard.Trigger>
@@ -118,7 +118,7 @@ function SpeciesRow({
             align="start"
             avoidCollisions={true}
             collisionPadding={16}
-            className="z-[10000]"
+            className="species-hovercard z-[10000]"
           >
             {isPseudoEntry ? (
               <PseudoSpeciesTooltipContent entry={pseudoEntry} />


### PR DESCRIPTION
Closes #572.

## What

A small set of UI hover refinements for the Overview page (and the shared species hover card used on Explore/Media).

### Image zoom on capture cards
The card image scales to 110% inside its fixed frame on hover (`overflow-hidden` clips it, so the card itself never changes size — no layout shift in the horizontal scroll strips).
- **Best captures** carousel (`BestMediaCarousel.jsx`)
- **Featured species** carousel (`CommonSpeciesFallback.jsx`)

### Spring-pop species hover card
The species detail hover card now animates in with a spring "pop" (scale 0.82 → 1, 260ms back-out easing) and fades out on close, with a consistent **400ms** open delay everywhere. Applied across:
- Best captures + Featured species cards
- Stats band → **Threatened species** list (`KpiBand.jsx`)
- **Species distribution** list on Overview (`overview/SpeciesDistribution.jsx`)
- **Species distribution right pane** on Explore + Media (`ui/speciesDistribution.jsx`)

The animation lives in one place — the `.species-hovercard` rule in `main.css`.

## Notes
- An earlier iteration also lifted the whole card with a growing `box-shadow`. We dropped it: `box-shadow` can't be GPU-composited, so it repainted on the main thread every frame and caused visible hover jank. Everything kept here uses `transform` + `opacity` only.

## Verification
- `prettier` clean, `eslint` 0 errors
- `npm test` → 1454 passed, 0 failed