### PR TITLE
feat(explore): default to Both view on wide screens, Map otherwise

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -51,7 +51,7 @@ import SpeciesRailToggle from './ui/SpeciesRailToggle'
 import SelectedSpeciesChips from './ui/SelectedSpeciesChips'
 import Gallery from './media/Gallery'
 import { useIsLgUp } from './hooks/useIsLgUp'
-import { getAvailableViewModes, clampViewMode } from './utils/viewLayout'
+import { getAvailableViewModes, clampViewMode, initialViewMode } from './utils/viewLayout'
 import SpeciesDistribution from './ui/speciesDistribution'
 import TimelineChart from './ui/timeseries'
 import { useImportStatus } from './hooks/import'
@@ -1154,12 +1154,14 @@ export default function Activity({ studyData, studyId }) {
   const { sequenceGap, setSequenceGap } = useSequenceGap(actualStudyId)
   const { showFilterCharts } = useShowFilterCharts(actualStudyId)
 
-  // Explore view toggle: 'map' | 'gallery' | 'both'. Defaults to 'map'
-  // (not persisted). 'both' is only available at lg+; clamp to 'map' if the
-  // window is narrower so a stale 'both' selection can't render off-breakpoint.
+  // Explore view toggle: 'map' | 'gallery' | 'both' (not persisted). 'both' is
+  // only available at lg+; clamp to 'map' if the window is narrower so a stale
+  // 'both' selection can't render off-breakpoint.
   const isLgUp = useIsLgUp()
-  // Open in 'both' when deep-linked with ?view=both (clamps to 'map' below lg).
-  const [viewModeRaw, setViewMode] = useState(deepLinkView === 'both' ? 'both' : 'map')
+  // Default to 'both' on wide screens (lg+) and 'map' below; an explicit
+  // deep-link view (?view=both / ?view=gallery) wins. isLgUp defaults to true
+  // before its effect runs (desktop-first), so the wide default holds on mount.
+  const [viewModeRaw, setViewMode] = useState(() => initialViewMode(deepLinkView, isLgUp))
   const viewMode = clampViewMode(viewModeRaw, isLgUp)
   // Memoized so ViewModeToggle gets a stable `modes` identity — otherwise its
   // ResizeObserver effect tears down and re-subscribes on every Activity render.

--- a/src/renderer/src/utils/viewLayout.js
+++ b/src/renderer/src/utils/viewLayout.js
@@ -21,3 +21,14 @@ export function clampViewMode(mode, isLgUp) {
   if (mode === 'both' && !isLgUp) return 'map'
   return mode
 }
+
+/**
+ * Initial view mode for the Explore tab. An explicit deep-link view wins when
+ * it names a valid mode; otherwise default to 'both' at lg+ and 'map' below.
+ * The result is still passed through clampViewMode at render, so a deep-linked
+ * 'both' below lg collapses to 'map'.
+ */
+export function initialViewMode(deepLinkView, isLgUp) {
+  if (VIEW_MODES.includes(deepLinkView)) return deepLinkView
+  return isLgUp ? 'both' : 'map'
+}

--- a/test/renderer/viewLayout.test.js
+++ b/test/renderer/viewLayout.test.js
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict'
 import {
   VIEW_MODES,
   getAvailableViewModes,
-  clampViewMode
+  clampViewMode,
+  initialViewMode
 } from '../../src/renderer/src/utils/viewLayout.js'
 
 describe('viewLayout', () => {
@@ -28,5 +29,26 @@ describe('viewLayout', () => {
     assert.equal(clampViewMode('map', false), 'map')
     assert.equal(clampViewMode('gallery', false), 'gallery')
     assert.equal(clampViewMode('gallery', true), 'gallery')
+  })
+
+  describe('initialViewMode', () => {
+    test('defaults to both at lg and up with no deep-link view', () => {
+      assert.equal(initialViewMode(null, true), 'both')
+    })
+
+    test('defaults to map below lg with no deep-link view', () => {
+      assert.equal(initialViewMode(null, false), 'map')
+    })
+
+    test('an explicit deep-link view wins over the size default', () => {
+      assert.equal(initialViewMode('gallery', true), 'gallery')
+      assert.equal(initialViewMode('map', true), 'map')
+      assert.equal(initialViewMode('both', false), 'both')
+    })
+
+    test('ignores an unknown deep-link view and falls back to the size default', () => {
+      assert.equal(initialViewMode('bogus', true), 'both')
+      assert.equal(initialViewMode('', false), 'map')
+    })
   })
 })


### PR DESCRIPTION
## Summary

Closes #569. The **Explore** tab always opened in **Map** regardless of screen width. It now defaults to **Both** (map + gallery side by side) on wide screens and falls back to **Map** on narrower windows.

- On `lg` and up (viewport ≥ 1024px, where **Both** is offered), Explore opens in **Both** by default.
- Below `lg`, where **Both** isn't available, it opens in **Map** (unchanged).
- An explicit deep-link view (`?view=both` / `?view=gallery` / `?view=map`) still wins over the default.

## Implementation

- `src/renderer/src/utils/viewLayout.js` — new pure helper `initialViewMode(deepLinkView, isLgUp)`: a valid deep-link view wins; otherwise `'both'` at lg+ and `'map'` below.
- `src/renderer/src/activity.jsx` — `viewModeRaw` is initialized from `initialViewMode(...)` via a lazy `useState` initializer.
- `test/renderer/viewLayout.test.js` — added 4 tests (wide default, narrow default, deep-link precedence, unknown-view fallback).

This also fixes a latent bug: the old `deepLinkView === 'both'` check silently dropped `?view=gallery` / `?view=map` deep links.

## Edge cases

- Deep-link view is not overridden by the size default.
- `useIsLgUp()` defaults to `true` before its effect runs (desktop-first), so the lazy initializer reads the wide default on mount with no flash of the narrow layout.
- `clampViewMode` (applied at render) downgrades `'both'` → `'map'` if the window later shrinks below lg, so resize is handled.

## Verification

- `npm run format` — clean
- `npm run lint` — 0 errors
- `npm test` — 1458 pass, 0 fail