### PR TITLE
feat(explore): raise density heatmap opacity floor for visibility

### DIFF
--- a/src/renderer/src/activity.jsx
+++ b/src/renderer/src/activity.jsx
@@ -281,7 +281,7 @@ function HeatmapLayer({ points, max, gradient, areaFilter }) {
       blur: 20,
       max,
       maxZoom: 12,
-      minOpacity: 0.25,
+      minOpacity: 0.45,
       gradient
     })
     layer.addTo(map)


### PR DESCRIPTION
## What

The "Density" encoding on the Explore map is a `leaflet.heat` layer. Its opacity floor (`minOpacity`) was `0.25`, leaving low-density areas too faint to see — especially over satellite imagery and forest canopy.

This raises the floor to `0.45`, so the density surface is clearly visible while still fading toward sparse edges.

## Change

- `src/renderer/src/activity.jsx`: `minOpacity: 0.25 → 0.45` in `HeatmapLayer`.

One-line change; no behavior change beyond the rendered opacity.

## Verification

- `npm run format` — clean
- `npm run lint` — 0 errors (pre-existing warnings only)
- `npm test` — 1454 passing