### PR TITLE
fix(timezones): day-period filter, activity, and display use deployment-local time

### DIFF
--- a/docs/data-formats.md
+++ b/docs/data-formats.md
@@ -90,7 +90,7 @@ cameraID / cameraModel / coordinateUncertainty = NULL`, and `deploymentStart`
 | --------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mediaID`       | string   | Unique media identifier (primary key)                                                                                                                                                                                                                                   |
 | `deploymentID`  | string   | Foreign key to deployments                                                                                                                                                                                                                                              |
-| `timestamp`     | datetime | Capture timestamp (ISO 8601)                                                                                                                                                                                                                                            |
+| `timestamp`     | datetime | Capture timestamp (ISO 8601), stored in **deployment-local** time keeping the source offset — see [dates-and-timezones.md](dates-and-timezones.md)                                                                                                                      |
 | `filePath`      | string   | Relative path to media file or HTTP URL                                                                                                                                                                                                                                 |
 | `filePublic`    | boolean  | Whether file is publicly accessible                                                                                                                                                                                                                                     |
 | `fileMediatype` | string   | MIME type (e.g., `image/jpeg`, `video/mp4`)                                                                                                                                                                                                                             |
@@ -285,13 +285,13 @@ Round-trip format used by the Deployments-tab **Export CSV** / **Import CSV** bu
 
 ### Columns
 
-| Column         | Required on import? | Editable on import? | Notes                                                                                          |
-| -------------- | ------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
-| `deploymentID` | Yes (row key)       | No                  | Rows whose ID is missing from the DB are skipped with a warning.                               |
-| `locationID`   | No                  | No                  | Treated as read-only context. A CSV value differing from the DB raises a per-cell warning.     |
+| Column         | Required on import? | Editable on import? | Notes                                                                                         |
+| -------------- | ------------------- | ------------------- | --------------------------------------------------------------------------------------------- |
+| `deploymentID` | Yes (row key)       | No                  | Rows whose ID is missing from the DB are skipped with a warning.                              |
+| `locationID`   | No                  | No                  | Treated as read-only context. A CSV value differing from the DB raises a per-cell warning.    |
 | `locationName` | No                  | Yes                 | Empty = leave existing value. Propagates to every deployment sharing the resolved locationID. |
-| `latitude`     | No                  | Yes                 | Decimal degrees. Must be in `[-90, 90]` when non-empty. Empty = leave existing value.          |
-| `longitude`    | No                  | Yes                 | Decimal degrees. Must be in `[-180, 180]` when non-empty. Empty = leave existing value.        |
+| `latitude`     | No                  | Yes                 | Decimal degrees. Must be in `[-90, 90]` when non-empty. Empty = leave existing value.         |
+| `longitude`    | No                  | Yes                 | Decimal degrees. Must be in `[-180, 180]` when non-empty. Empty = leave existing value.       |
 
 **Encoding:** UTF-8 with RFC-4180 quoting (`escapeCSV` shares the implementation with the CamtrapDP export). Unknown columns are silently ignored. Missing the `deploymentID` header is a hard parse error.
 

--- a/docs/dates-and-timezones.md
+++ b/docs/dates-and-timezones.md
@@ -1,0 +1,90 @@
+# Dates and Timezones
+
+How Biowatch stores, filters, and displays capture timestamps.
+
+## Principle: store deployment-local time
+
+Camera-trap analysis is about the **camera's local clock** — "dawn", "day",
+"dusk", and "night" only make sense in the timezone where the camera sits. So
+Biowatch stores each capture timestamp in its **deployment-local time**,
+keeping the source UTC offset:
+
+```
+2020-12-16T10:28:18.000+01:00     ← Belgian deployment, local clock 10:28
+2017-04-10T06:06:24.000+02:00     ← South African deployment, local clock 06:06
+```
+
+The literal wall-clock portion (`10:28`, `06:06`) is the camera's local time.
+Everything downstream — filtering, the activity histogram, and the gallery
+display — reads that local wall clock.
+
+## Import: preserve the wall clock, never convert to UTC
+
+Importers must keep the source offset (or, for offset-less sources, the literal
+wall clock) and must **not** call `.toUTC()`:
+
+| Parser           | Source format                 | How local time is preserved                                                                |
+| ---------------- | ----------------------------- | ------------------------------------------------------------------------------------------ |
+| CamtrapDP / GBIF | ISO 8601, usually with offset | `DateTime.fromISO(x, { setZone: true }).toISO()` (`parsers/camtrapDP.js`)                  |
+| LILA (COCO)      | ISO or `yyyy-MM-dd HH:mm:ss`  | `fromISO(x, { setZone: true })` / `fromFormat(...)` (`parsers/lila-helpers.js`)            |
+| Deepfaune        | `yyyy:MM:dd HH:mm:ss` (naive) | `fromFormat(...).toISO()` — naive wall clock kept                                          |
+| WildlifeInsights | SQL datetime (naive)          | `fromSQL(...).toISO()` — naive wall clock kept                                             |
+| Image directory  | EXIF + GPS                    | `geo-tz` resolves the deployment zone; stored local-with-offset (`services/prediction.js`) |
+
+`{ setZone: true }` is the key: for an offset-bearing input it keeps that
+offset; for a naive input it keeps the wall-clock numbers (labelling them with
+the runtime zone). Either way the **hour you read off the string is the
+camera's local hour**.
+
+> Historical note: CamtrapDP and LILA previously did `.toUTC()`, which discarded
+> the offset. Studies imported before the fix are stored as UTC (`…Z`) and
+> behave as if the deployment timezone were UTC. **Re-import** such a study to
+> get correct deployment-local behavior; there is no in-place backfill.
+
+## Filter: read the local hour off the string
+
+The day-period filter (`timeRange`) and the activity histogram extract the hour
+directly from the stored string, with no timezone conversion:
+
+```sql
+CAST(substr(timestamp, 12, 2) AS INTEGER)   -- the HH of YYYY-MM-DD?HH:MM:...
+```
+
+See `localHourExpr` / `localHourExprRaw` in
+`src/main/database/queries/sequences.js`, used by the filter
+(`sequences.js`, `species.js`) and the daily-activity query (`species.js`).
+
+We deliberately avoid `strftime('%H', ts)` (reads UTC for tz-aware strings) and
+`strftime('%H', ts, 'localtime')` (converts to the **viewer's machine** zone).
+`substr` is timezone-independent, so filtering is deterministic regardless of
+where the app runs, and matches the displayed time.
+
+The presets live in `src/renderer/src/utils/dayPeriods.js` and are half-open
+`[start, end)` hour ranges in 24h local clock time (Night wraps midnight).
+
+## Display: render the stored offset, not the machine zone
+
+`src/renderer/src/utils/formatTimestamp.js` renders capture times in the stored
+offset via Luxon `DateTime.fromISO(ts, { setZone: true })` — **not** the
+viewer's machine timezone. This keeps the displayed time equal to the filter
+hour for every viewer:
+
+- `formatGridTimestamp` — grid cell + detail overlay (and the best-media carousel).
+- `formatEditableTimestamp` — the editable timestamp field (includes seconds).
+- `parseEditedTimestampToISO` — parses an edited wall clock back into an ISO
+  string in the **original** timestamp's offset, so saving keeps the timestamp
+  deployment-local (round-trips through `updateMediaTimestamp`, which parses with
+  `{ setZone: true }`).
+
+## Gotchas
+
+- **String date-range comparisons.** Date-range filters compare ISO strings
+  directly. Within a single deployment the offset is consistent, so ordering is
+  correct; mixing very different offsets in one query can reorder around
+  boundaries. This predates deployment-local storage (image-directory studies
+  already carried offsets).
+- **Null / unparseable timestamps** are excluded by the hour filter (`substr`
+  of `NULL` is `NULL`); they're handled separately via the
+  `includeNullTimestamps` paths.
+- **Sequence grouping** uses `new Date(ts).getTime()` (absolute instant), which
+  is offset-aware and unaffected by the local-hour reading.

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -366,6 +366,11 @@ Each extracted timestamp is validated to reject known-bad values: QuickTime epoc
 
 **Key file:** `src/main/services/import/timestamp.js`
 
+> **Timezones:** importers store capture timestamps in **deployment-local time**
+> (preserving the source offset, never converting to UTC), so day-period
+> filtering and the gallery read the camera's local clock. See
+> [dates-and-timezones.md](dates-and-timezones.md).
+
 ### Prediction Flow
 
 ```javascript
@@ -603,17 +608,17 @@ readonly`. Returns a `PreviewPayload` (see
 
 ### Validation rules (per cell)
 
-| Rule | Effect | Tooltip |
-| --- | --- | --- |
-| `deploymentID` empty | row skipped | `deploymentID is required.` |
-| `deploymentID` not in DB | row skipped | `No deployment with this ID in the study.` |
-| `locationID` differs from DB | cell warning | `locationID is read-only. Existing value will be kept; CSV value ignored.` |
-| `latitude` non-numeric | cell warning | `'X' is not a valid number.` |
-| `latitude` ∉ [-90, 90] | cell warning | `Latitude X is outside [-90, 90].` |
-| `longitude` non-numeric | cell warning | `'X' is not a valid number.` |
-| `longitude` ∉ [-180, 180] | cell warning | `Longitude X is outside [-180, 180].` |
-| Duplicate `deploymentID` rows in CSV | earlier change cells → warning | `Overridden by row N below.` |
-| Intra-`locationID` name conflict in CSV | earlier name cells → warning | `Conflicting names for LOC_A; row N below wins.` |
+| Rule                                    | Effect                         | Tooltip                                                                    |
+| --------------------------------------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `deploymentID` empty                    | row skipped                    | `deploymentID is required.`                                                |
+| `deploymentID` not in DB                | row skipped                    | `No deployment with this ID in the study.`                                 |
+| `locationID` differs from DB            | cell warning                   | `locationID is read-only. Existing value will be kept; CSV value ignored.` |
+| `latitude` non-numeric                  | cell warning                   | `'X' is not a valid number.`                                               |
+| `latitude` ∉ [-90, 90]                  | cell warning                   | `Latitude X is outside [-90, 90].`                                         |
+| `longitude` non-numeric                 | cell warning                   | `'X' is not a valid number.`                                               |
+| `longitude` ∉ [-180, 180]               | cell warning                   | `Longitude X is outside [-180, 180].`                                      |
+| Duplicate `deploymentID` rows in CSV    | earlier change cells → warning | `Overridden by row N below.`                                               |
+| Intra-`locationID` name conflict in CSV | earlier name cells → warning   | `Conflicting names for LOC_A; row N below wins.`                           |
 
 Empty cell semantics: empty = leave existing DB value untouched. There
 is no sentinel for "clear" — clearing remains a per-row action via

--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -234,6 +234,18 @@ Returns pre-grouped sequences with cursor-based pagination for the media gallery
 }
 ```
 
+> **Time-of-day (`timeRange`) hour semantics.** Each `{ start, end }` is a
+> half-open `[start, end)` hour window in the **deployment-local clock time**
+> the day-period presets are defined in (`src/renderer/src/utils/dayPeriods.js`).
+> The hour is read literally from the stored ISO timestamp string
+> (`CAST(substr(timestamp, 12, 2) AS INTEGER)`, see `localHourExpr` in
+> `src/main/database/queries/sequences.js`) rather than via `strftime('%H', …)`,
+> which would normalize a tz-aware timestamp (e.g. `…+02:00`) to UTC and shift
+> every boundary. Importers store timestamps in deployment-local time, so the
+> filter matches the gallery display. Studies imported before that change are
+> stored as UTC (`Z`) and read as UTC until re-imported. See
+> [dates-and-timezones.md](dates-and-timezones.md) for the full model.
+
 **Response:**
 
 ```javascript

--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -231,8 +231,10 @@ export async function updateMediaTimestamp(dbPath, mediaID, newTimestamp) {
       throw new Error('A valid timestamp string is required')
     }
 
-    // Parse and validate the new timestamp
-    const newTimestampDT = DateTime.fromISO(newTimestamp)
+    // Parse and validate the new timestamp. setZone keeps the incoming offset
+    // (the deployment-local zone the editor sends) so formatToMatchOriginal
+    // re-emits it instead of rebasing onto the main process's local zone.
+    const newTimestampDT = DateTime.fromISO(newTimestamp, { setZone: true })
 
     if (!newTimestampDT.isValid) {
       throw new Error(
@@ -321,18 +323,18 @@ export async function updateMediaTimestamp(dbPath, mediaID, newTimestamp) {
     for (const obs of relatedObservations) {
       const updateData = {}
 
-      // Update eventStart with offset - preserve original format
+      // Update eventStart with offset - preserve original format and zone
       if (obs.eventStart) {
-        const oldEventStart = DateTime.fromISO(obs.eventStart)
+        const oldEventStart = DateTime.fromISO(obs.eventStart, { setZone: true })
         if (oldEventStart.isValid) {
           const newEventStart = oldEventStart.plus({ milliseconds: offsetMs })
           updateData.eventStart = formatToMatchOriginal(newEventStart, obs.eventStart)
         }
       }
 
-      // Update eventEnd with SAME offset (preserving duration) - preserve original format
+      // Update eventEnd with SAME offset (preserving duration) - preserve original format and zone
       if (obs.eventEnd) {
-        const oldEventEnd = DateTime.fromISO(obs.eventEnd)
+        const oldEventEnd = DateTime.fromISO(obs.eventEnd, { setZone: true })
         if (oldEventEnd.isValid) {
           const newEventEnd = oldEventEnd.plus({ milliseconds: offsetMs })
           updateData.eventEnd = formatToMatchOriginal(newEventEnd, obs.eventEnd)

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -45,25 +45,62 @@ export function normalizeTimeRange(timeRange) {
 }
 
 /**
+ * Extract the deployment-local hour (0–23) literally from a stored ISO
+ * timestamp string, WITHOUT any timezone conversion.
+ *
+ * Biowatch stores capture timestamps in the *deployment's* local time (the
+ * camera's wall clock), keeping the source offset — e.g. '2017-04-10T06:06+02:00'
+ * (see docs/dates-and-timezones.md). The day-period presets in
+ * src/renderer/src/utils/dayPeriods.js are defined in that same local clock, so
+ * we read the hour straight off the string. The HH characters always sit at
+ * positions 12–13 of an ISO 'YYYY-MM-DD?HH:...' string (T or space separator).
+ *
+ * We deliberately do NOT use strftime('%H', ts): with no modifier it would
+ * normalize an offset-bearing timestamp to UTC, and with 'localtime' it would
+ * convert to the *viewer's* machine timezone — both shift the boundaries away
+ * from the camera's local clock. substr() is also timezone-independent, so the
+ * filter is deterministic regardless of where it runs.
+ *
+ * Caveat: studies imported before timestamps were stored deployment-local are
+ * kept as UTC ('Z') and will read as UTC until re-imported.
+ *
+ * @param {*} tsColumn - a Drizzle column / SQL fragment for the timestamp
+ * @returns a Drizzle SQL fragment evaluating to an integer hour
+ */
+export function localHourExpr(tsColumn) {
+  return sql`CAST(substr(${tsColumn}, 12, 2) AS INTEGER)`
+}
+
+/**
+ * Raw-SQL-string form of localHourExpr, for query paths that assemble SQL text
+ * by hand (better-sqlite3 prepared statements). See localHourExpr for why this
+ * reads the literal stored hour instead of strftime('%H', ...).
+ *
+ * @param {string} tsCol - SQL expression for the timestamp column (e.g. 'm.timestamp')
+ * @returns {string} a SQL expression evaluating to an integer hour
+ */
+export function localHourExprRaw(tsCol) {
+  return `CAST(substr(${tsCol}, 12, 2) AS INTEGER)`
+}
+
+/**
  * Build a SQL condition for a single {start, end} hour range against
  * media.timestamp. Half-open [start, end). Returns null when start === end
  * (zero-width range, no rows match — caller should drop it).
  *
  * Wrap-around (start > end) is OR'd: hour >= start OR hour < end.
+ *
+ * The hour is the deployment-local hour read off the stored string (see
+ * localHourExpr), matching the capture time the gallery displays.
  */
 export function buildHourRangeCondition(range) {
   const { start, end } = range
   if (start === end) return null
+  const hour = localHourExpr(media.timestamp)
   if (start < end) {
-    return and(
-      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
-      sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
-    )
+    return and(sql`${hour} >= ${start}`, sql`${hour} < ${end}`)
   }
-  return or(
-    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) >= ${start}`,
-    sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER) < ${end}`
-  )
+  return or(sql`${hour} >= ${start}`, sql`${hour} < ${end}`)
 }
 
 /**

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -24,7 +24,7 @@ import log from 'electron-log'
 import { getStudyIdFromPath } from './utils.js'
 import { buildBboxClause } from './bbox.js'
 import { BLANK_SENTINEL } from '../../../shared/constants.js'
-import { normalizeTimeRange } from './sequences.js'
+import { normalizeTimeRange, localHourExpr, localHourExprRaw } from './sequences.js'
 
 /**
  * Get species distribution from the database using Drizzle ORM
@@ -615,10 +615,11 @@ export async function getSpeciesHeatmapDataByMedia(
       baseConditions.push(lte(media.timestamp, endDate))
     }
 
-    // Add time-of-day condition using sql template for SQLite strftime.
-    // When includeNullTimestamps=true, allow null timestamps through.
-    // Empty ranges array means no time filter.
-    const hourColumn = sql`CAST(strftime('%H', ${media.timestamp}) AS INTEGER)`
+    // Add time-of-day condition on the deployment-local hour (see
+    // localHourExpr), matching the capture time the gallery displays. When
+    // includeNullTimestamps=true, allow null timestamps through. Empty ranges
+    // array means no time filter.
+    const hourColumn = localHourExpr(media.timestamp)
     const ranges = normalizeTimeRange(timeRange)
     const rangeConditions = ranges
       .map((r) => {
@@ -760,7 +761,7 @@ export async function getSequenceAwareHeatmapSQL(
         params.push(startDate, endDate)
       }
     }
-    const hourExpr = `CAST(strftime('%H', ${tsCol}) AS INTEGER)`
+    const hourExpr = localHourExprRaw(tsCol)
     const hourClauses = hourRanges
       .map(({ start, end }) => {
         if (start === end) return null
@@ -1020,7 +1021,7 @@ export async function getSequenceAwareDailyActivitySQL(
                    m.mediaID AS mediaID,
                    m.deploymentID AS deploymentID,
                    m.timestamp AS ts,
-                   CAST(strftime('%H', m.timestamp) AS INTEGER) AS hour,
+                   ${localHourExprRaw('m.timestamp')} AS hour,
                    CASE WHEN m.fileMediatype LIKE 'video/%' THEN 1 ELSE 0 END AS is_video,
                    COUNT(*) AS media_count
               FROM observations o
@@ -1072,7 +1073,7 @@ export async function getSequenceAwareDailyActivitySQL(
           WITH media_counts AS (
             SELECT o.scientificName AS scientificName,
                    COALESCE(NULLIF(o.eventID, ''), 'solo:' || o.mediaID) AS event_key,
-                   CAST(strftime('%H', m.timestamp) AS INTEGER) AS hour,
+                   ${localHourExprRaw('m.timestamp')} AS hour,
                    COUNT(*) AS media_count
               FROM observations o
               INNER JOIN media m ON o.mediaID = m.mediaID
@@ -1100,7 +1101,7 @@ export async function getSequenceAwareDailyActivitySQL(
         .prepare(
           `
           SELECT o.scientificName AS scientificName,
-                 CAST(strftime('%H', m.timestamp) AS INTEGER) AS hour,
+                 ${localHourExprRaw('m.timestamp')} AS hour,
                  COUNT(o.observationID) AS count
             FROM observations o
             INNER JOIN media m ON o.mediaID = m.mediaID

--- a/src/main/services/import/parsers/camtrapDP.js
+++ b/src/main/services/import/parsers/camtrapDP.js
@@ -699,13 +699,18 @@ function transformObservationRow(row) {
 }
 
 /**
- * Transform date field from CSV to ISO format
+ * Transform date field from CSV to ISO format.
+ *
+ * Preserves the deployment-local wall clock and its source offset (e.g.
+ * '2020-12-16T10:28:18+01:00') instead of normalizing to UTC, so day-period
+ * filtering and the gallery read the camera's local time. Naive source values
+ * (no offset) keep their wall clock. See docs/dates-and-timezones.md.
  */
-function transformDateField(dateValue) {
+export function transformDateField(dateValue) {
   if (!dateValue) return null
 
-  const date = DateTime.fromISO(dateValue)
-  return date.isValid ? date.toUTC().toISO() : null
+  const date = DateTime.fromISO(dateValue, { setZone: true })
+  return date.isValid ? date.toISO() : null
 }
 
 /**

--- a/src/main/services/import/parsers/lila-helpers.js
+++ b/src/main/services/import/parsers/lila-helpers.js
@@ -7,21 +7,26 @@
 import { DateTime } from 'luxon'
 
 /**
- * Transform date field from COCO format to ISO
+ * Transform date field from COCO format to ISO.
+ *
+ * Preserves the deployment-local wall clock and any source offset instead of
+ * converting to UTC, so day-period filtering and the gallery read the camera's
+ * local time. Naive COCO values ("2022-12-31 09:52:50") keep their wall clock.
+ * See docs/dates-and-timezones.md.
  */
 export function transformDateField(dateValue) {
   if (!dateValue) return null
 
-  // Try ISO format first
-  let date = DateTime.fromISO(dateValue)
+  // Try ISO format first (keep the source offset if present)
+  let date = DateTime.fromISO(dateValue, { setZone: true })
   if (date.isValid) {
-    return date.toUTC().toISO()
+    return date.toISO()
   }
 
-  // Try COCO common format: "2022-12-31 09:52:50"
+  // Try COCO common format: "2022-12-31 09:52:50" (naive → local wall clock)
   date = DateTime.fromFormat(dateValue, 'yyyy-MM-dd HH:mm:ss')
   if (date.isValid) {
-    return date.toUTC().toISO()
+    return date.toISO()
   }
 
   return null

--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -53,7 +53,11 @@ import {
   getSpeciesCountsFromSequence
 } from '../utils/speciesFromBboxes'
 import { SpeciesCountLabel } from '../ui/SpeciesLabel'
-import { formatGridTimestamp } from '../utils/formatTimestamp'
+import {
+  formatGridTimestamp,
+  formatEditableTimestamp,
+  parseEditedTimestampToISO
+} from '../utils/formatTimestamp'
 import { useSequenceGap } from '../hooks/useSequenceGap'
 import { useShowThumbnailBboxes } from '../hooks/useShowThumbnailBboxes'
 import DateTimePicker from '../ui/DateTimePicker'
@@ -290,7 +294,7 @@ function ImageModal({
   // Initialize inline timestamp when media changes
   useEffect(() => {
     if (media?.timestamp) {
-      setInlineTimestamp(new Date(media.timestamp).toLocaleString())
+      setInlineTimestamp(formatEditableTimestamp(media.timestamp))
     }
     // Sync favorite state with media prop
     setIsFavorite(media?.favorite ?? false)
@@ -490,7 +494,7 @@ function ImageModal({
 
       setShowDatePicker(false)
       setIsEditingTimestamp(false)
-      setInlineTimestamp(new Date(savedTimestamp).toLocaleString())
+      setInlineTimestamp(formatEditableTimestamp(savedTimestamp))
     } catch (err) {
       // Rollback on error
       if (onTimestampUpdate) {
@@ -531,7 +535,11 @@ function ImageModal({
         return
       }
 
-      handleTimestampSave(parsedDate.toISOString())
+      // Interpret the edited wall clock in the deployment's local zone (the
+      // original timestamp's offset) so saving keeps it deployment-local rather
+      // than rebasing onto the viewer's machine zone.
+      const isoInDeploymentZone = parseEditedTimestampToISO(trimmedInput, media.timestamp)
+      handleTimestampSave(isoInDeploymentZone || parsedDate.toISOString())
     } catch {
       setError('Invalid date format. Try: "12/25/2024, 2:30:00 PM"')
     }
@@ -540,7 +548,7 @@ function ImageModal({
   const handleInlineCancel = () => {
     setIsEditingTimestamp(false)
     if (media?.timestamp) {
-      setInlineTimestamp(new Date(media.timestamp).toLocaleString())
+      setInlineTimestamp(formatEditableTimestamp(media.timestamp))
     }
     setError(null)
   }
@@ -1105,9 +1113,7 @@ function ImageModal({
                       onClick={handleInlineEdit}
                       title="Click to edit timestamp"
                     >
-                      {media.timestamp
-                        ? new Date(media.timestamp).toLocaleString()
-                        : 'No timestamp'}
+                      {media.timestamp ? formatEditableTimestamp(media.timestamp) : 'No timestamp'}
                     </span>
                     <button
                       onClick={handleInlineEdit}

--- a/src/renderer/src/ui/BestMediaCarousel.jsx
+++ b/src/renderer/src/ui/BestMediaCarousel.jsx
@@ -8,6 +8,7 @@ import DeploymentLinkPill from '../media/DeploymentLinkPill'
 import SpeciesTooltipContent from './SpeciesTooltipContent'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll'
+import { formatGridTimestamp } from '../utils/formatTimestamp'
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
@@ -188,7 +189,7 @@ function ImageViewerModal({
                 <ChevronRight size={18} />
               </button>
               <span className="truncate">
-                {media.timestamp ? new Date(media.timestamp).toLocaleString() : 'No timestamp'}
+                {media.timestamp ? formatGridTimestamp(media.timestamp) : 'No timestamp'}
               </span>
             </div>
 
@@ -460,7 +461,7 @@ function VideoViewerModal({
                 <ChevronRight size={18} />
               </button>
               <span className="truncate">
-                {media.timestamp ? new Date(media.timestamp).toLocaleString() : 'No timestamp'}
+                {media.timestamp ? formatGridTimestamp(media.timestamp) : 'No timestamp'}
               </span>
             </div>
 

--- a/src/renderer/src/utils/formatTimestamp.js
+++ b/src/renderer/src/utils/formatTimestamp.js
@@ -1,22 +1,80 @@
 /**
  * Compact "MMM D, YYYY, h:mm AM/PM" formatter used by the media-tab grid cell
- * timestamp overlay. Pure, no React, safe to unit-test.
+ * timestamp overlay (and the best-media carousel). Pure, no React, safe to
+ * unit-test.
  *
- * Uses the runtime's local timezone — camera-trap timestamps in the DB are
- * already display-time at the camera, and the rest of the app uses local
- * time elsewhere (e.g. inline editor timestamps).
+ * Renders the capture time in the *deployment's* local timezone — i.e. the
+ * offset stored in the timestamp string (e.g. "+02:00") — NOT the viewer's
+ * machine timezone. This keeps the displayed time in lock-step with the
+ * day-period filter, which reads the same stored local hour
+ * (src/main/database/queries/sequences.js → localHourExpr). See
+ * docs/dates-and-timezones.md.
  *
- * @param {string | number | Date} timestamp - Anything `new Date(x)` accepts.
+ * Timestamps imported as UTC (trailing "Z", before timestamps were stored
+ * deployment-local) render in UTC until the study is re-imported.
+ *
+ * @param {string | number | Date} timestamp - Anything Luxon can parse. ISO
+ *   strings carry their offset; Date/number inputs have no offset and fall back
+ *   to the runtime's local zone.
  * @returns {string} Formatted string, e.g. "Apr 30, 2026, 2:34 PM".
  */
-const FORMATTER = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-  hour: 'numeric',
-  minute: '2-digit'
-})
+import { DateTime } from 'luxon'
+
+const GRID_FORMAT = 'LLL d, yyyy, h:mm a'
+const EDIT_FORMAT = 'LLL d, yyyy, h:mm:ss a'
 
 export function formatGridTimestamp(timestamp) {
-  return FORMATTER.format(timestamp instanceof Date ? timestamp : new Date(timestamp))
+  const dt =
+    timestamp instanceof Date
+      ? DateTime.fromJSDate(timestamp)
+      : typeof timestamp === 'number'
+        ? DateTime.fromMillis(timestamp)
+        : DateTime.fromISO(timestamp, { setZone: true })
+  return dt.setLocale('en-US').toFormat(GRID_FORMAT)
+}
+
+/**
+ * Render a timestamp for the editable timestamp field, in the deployment's
+ * local zone (the stored offset), including seconds. Mirrors formatGridTimestamp
+ * but keeps seconds so edits don't silently truncate them.
+ *
+ * @param {string} timestamp - ISO timestamp string
+ * @returns {string} e.g. "Apr 30, 2026, 2:34:56 PM"
+ */
+export function formatEditableTimestamp(timestamp) {
+  return DateTime.fromISO(timestamp, { setZone: true }).setLocale('en-US').toFormat(EDIT_FORMAT)
+}
+
+/**
+ * Parse an edited wall-clock string back into an ISO timestamp in the SAME
+ * timezone offset as the original timestamp, so saving preserves the
+ * deployment-local zone rather than rebasing onto the viewer's machine zone.
+ *
+ * The freeform input is parsed leniently with the platform Date parser (which
+ * reads it in the machine zone); we then reinterpret those wall-clock
+ * components in the original timestamp's offset. See docs/dates-and-timezones.md.
+ *
+ * @param {string} input - User-entered date/time (e.g. "Dec 25, 2024, 2:30:00 PM")
+ * @param {string} originalTimestamp - The media's current stored timestamp
+ * @returns {string|null} ISO string with the original offset, or null if unparseable
+ */
+export function parseEditedTimestampToISO(input, originalTimestamp) {
+  const js = new Date(input)
+  if (isNaN(js.getTime())) return null
+
+  const original = DateTime.fromISO(originalTimestamp, { setZone: true })
+  const zone = original.isValid ? original.zone : 'local'
+
+  const rebuilt = DateTime.fromObject(
+    {
+      year: js.getFullYear(),
+      month: js.getMonth() + 1,
+      day: js.getDate(),
+      hour: js.getHours(),
+      minute: js.getMinutes(),
+      second: js.getSeconds()
+    },
+    { zone }
+  )
+  return rebuilt.isValid ? rebuilt.toISO() : null
 }

--- a/test/main/database/queries/sequencesTimeRange.test.js
+++ b/test/main/database/queries/sequencesTimeRange.test.js
@@ -14,6 +14,7 @@ import { normalizeTimeRange } from '../../../../src/main/database/queries/sequen
 import {
   getMediaForSequencePagination,
   hasTimestampedMedia,
+  getSpeciesHeatmapDataByMedia,
   createImageDirectoryDatabase,
   insertDeployments,
   insertMedia,
@@ -273,5 +274,112 @@ describe('hasTimestampedMedia — timeRange filter', () => {
       timeRange: { start: 8, end: 18 }
     })
     assert.equal(result, true)
+  })
+})
+
+/**
+ * Seed media whose timestamps carry an explicit +02:00 offset (deployment-local
+ * time, as stored by the fixed importers), so the literal wall-clock hour
+ * differs from the UTC hour. mediaID encodes the local wall-clock hour, e.g.
+ * local 9 → '2024-06-01T09:30:00.000+02:00' (07:30 UTC).
+ *
+ * The filter must use the local hour (9), not the UTC hour (7). These assertions
+ * are timezone-independent: substr reads the stored offset's wall clock
+ * regardless of where the test runs.
+ */
+async function seedOffsetMedia(localHours) {
+  const manager = await createImageDirectoryDatabase(testDbPath)
+  await insertDeployments(manager, {
+    d1: {
+      deploymentID: 'd1',
+      locationID: 'loc1',
+      locationName: 'Site A',
+      deploymentStart: DateTime.fromISO('2024-01-01T00:00:00Z'),
+      deploymentEnd: DateTime.fromISO('2024-12-31T23:59:59Z'),
+      latitude: 1,
+      longitude: 1,
+      cameraID: 'cam1'
+    }
+  })
+  const mediaMap = {}
+  const obsList = []
+  for (const h of localHours) {
+    const id = `m-loc-${String(h).padStart(2, '0')}`
+    const iso = `2024-06-01T${String(h).padStart(2, '0')}:30:00+02:00`
+    mediaMap[`${id}.jpg`] = {
+      mediaID: id,
+      deploymentID: 'd1',
+      timestamp: DateTime.fromISO(iso, { setZone: true }),
+      filePath: `/${id}.jpg`,
+      fileName: `${id}.jpg`
+    }
+    obsList.push({
+      observationID: `obs-${id}`,
+      mediaID: id,
+      deploymentID: 'd1',
+      eventID: `ev-${id}`,
+      observationType: 'animal',
+      scientificName: 'Sus scrofa'
+    })
+  }
+  await insertMedia(manager, mediaMap)
+  await insertObservations(manager, obsList)
+  return manager
+}
+
+describe('timeRange filters on the deployment-local hour (stored offset), not UTC', () => {
+  test('insertMedia preserves the +02:00 offset in the stored timestamp', async () => {
+    const manager = await seedOffsetMedia([9])
+    const row = manager
+      .getSqlite()
+      .prepare("SELECT timestamp FROM media WHERE mediaID='m-loc-09'")
+      .get()
+    assert.equal(row.timestamp, '2024-06-01T09:30:00.000+02:00')
+  })
+
+  test('getMediaForSequencePagination: Day [8,18) uses local hour (09:30+02 is in, its 07 UTC hour is not)', async () => {
+    await seedOffsetMedia([7, 9, 17, 23])
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 8, end: 18 }] }
+    })
+    const ids = result.media.map((m) => m.mediaID).sort()
+    // Local hours 9 and 17 are in [8,18). Filtering on the UTC hour would read
+    // 09:30+02 as 7 and wrongly drop it, leaving only m-loc-17.
+    assert.deepEqual(ids, ['m-loc-09', 'm-loc-17'])
+  })
+
+  test('getMediaForSequencePagination: Dawn [5,8) uses local hour (07:30+02 in, 09:30+02 out)', async () => {
+    await seedOffsetMedia([7, 9, 17, 23])
+    const result = await getMediaForSequencePagination(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 5, end: 8 }] }
+    })
+    const ids = result.media.map((m) => m.mediaID).sort()
+    // Only local hour 7 is in [5,8). Filtering on the UTC hour would read
+    // 09:30+02 as 7 and wrongly include it alongside m-loc-07.
+    assert.deepEqual(ids, ['m-loc-07'])
+  })
+
+  test('hasTimestampedMedia: Day [8,18) sees a 09:30+02 capture via its local hour', async () => {
+    await seedOffsetMedia([9])
+    const result = await hasTimestampedMedia(testDbPath, {
+      species: ['Sus scrofa'],
+      timeRange: { ranges: [{ start: 8, end: 18 }] }
+    })
+    assert.equal(result, true)
+  })
+
+  test('getSpeciesHeatmapDataByMedia: Day [8,18) filters on the local hour', async () => {
+    await seedOffsetMedia([7, 9, 17, 23])
+    const rows = await getSpeciesHeatmapDataByMedia(
+      testDbPath,
+      ['Sus scrofa'],
+      '2024-05-31T00:00:00Z',
+      '2024-06-02T23:59:59Z',
+      { ranges: [{ start: 8, end: 18 }] }
+    )
+    const ids = rows.map((r) => r.mediaID).sort()
+    assert.deepEqual(ids, ['m-loc-09', 'm-loc-17'])
   })
 })

--- a/test/main/services/import/parsers/transformDateField.test.js
+++ b/test/main/services/import/parsers/transformDateField.test.js
@@ -1,0 +1,44 @@
+/**
+ * The import date transformers must PRESERVE the deployment-local wall clock
+ * (and its source offset) rather than normalizing to UTC, so day-period
+ * filtering and the gallery read the camera's local time.
+ * See docs/dates-and-timezones.md.
+ */
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { transformDateField as camtrapTransform } from '../../../../../src/main/services/import/parsers/camtrapDP.js'
+import { transformDateField as lilaTransform } from '../../../../../src/main/services/import/parsers/lila-helpers.js'
+
+for (const [name, transform] of [
+  ['camtrapDP', camtrapTransform],
+  ['lila-helpers', lilaTransform]
+]) {
+  describe(`${name} transformDateField — preserves deployment-local time`, () => {
+    test('keeps a positive offset instead of converting to UTC', () => {
+      assert.equal(transform('2020-12-16T10:28:18+01:00'), '2020-12-16T10:28:18.000+01:00')
+    })
+
+    test('keeps a negative offset', () => {
+      assert.equal(transform('2021-07-04T22:15:00-05:00'), '2021-07-04T22:15:00.000-05:00')
+    })
+
+    test('leaves a UTC (Z) timestamp as UTC', () => {
+      assert.equal(transform('2022-01-01T06:36:00Z'), '2022-01-01T06:36:00.000Z')
+    })
+
+    test('returns null for empty input', () => {
+      assert.equal(transform(null), null)
+      assert.equal(transform(''), null)
+    })
+  })
+}
+
+describe('lila-helpers transformDateField — COCO naive format', () => {
+  test('keeps the naive wall clock (hour is not shifted by UTC conversion)', () => {
+    // "2022-12-31 09:52:50" → the literal hour 09 must survive (offset is the
+    // runtime zone, but the wall clock the filter reads stays 09).
+    const out = lilaTransform('2022-12-31 09:52:50')
+    assert.match(out, /^2022-12-31T09:52:50/)
+  })
+})

--- a/test/renderer/formatTimestamp.test.js
+++ b/test/renderer/formatTimestamp.test.js
@@ -1,21 +1,57 @@
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
-import { formatGridTimestamp } from '../../src/renderer/src/utils/formatTimestamp.js'
+import {
+  formatGridTimestamp,
+  formatEditableTimestamp,
+  parseEditedTimestampToISO
+} from '../../src/renderer/src/utils/formatTimestamp.js'
 
 describe('formatGridTimestamp', () => {
-  test('renders an ISO timestamp as "MMM D, YYYY, h:mm AM/PM"', () => {
-    const result = formatGridTimestamp('2026-04-30T14:34:56Z')
-    // Shape only — actual hour depends on test runner's local timezone.
-    // Examples: "Apr 30, 2026, 2:34 PM", "May 1, 2026, 12:34 AM".
-    assert.match(
-      result,
-      /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}\s(AM|PM)$/,
-      `unexpected shape: "${result}"`
+  test('renders the stored offset wall clock, independent of machine timezone', () => {
+    // 14:34 in +09:00 must render as 2:34 PM everywhere — NOT converted to the
+    // runtime zone. This is what keeps the gallery in step with the day filter.
+    assert.equal(formatGridTimestamp('2026-04-30T14:34:56+09:00'), 'Apr 30, 2026, 2:34 PM')
+  })
+
+  test('renders a UTC (Z) timestamp in UTC', () => {
+    assert.equal(formatGridTimestamp('2026-04-30T14:34:56Z'), 'Apr 30, 2026, 2:34 PM')
+  })
+
+  test('accepts a Date instance (no offset → runtime zone), matching the shape', () => {
+    const result = formatGridTimestamp(new Date('2026-04-30T14:34:56Z'))
+    assert.match(result, /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}\s(AM|PM)$/)
+  })
+})
+
+describe('formatEditableTimestamp', () => {
+  test('renders the stored offset wall clock with seconds', () => {
+    assert.equal(formatEditableTimestamp('2026-04-30T14:34:56+09:00'), 'Apr 30, 2026, 2:34:56 PM')
+  })
+})
+
+describe('parseEditedTimestampToISO', () => {
+  test('round-trips through formatEditableTimestamp, preserving the original offset', () => {
+    const original = '2026-04-30T14:34:56.000+09:00'
+    const display = formatEditableTimestamp(original)
+    assert.equal(parseEditedTimestampToISO(display, original), original)
+  })
+
+  test('applies the original offset to an edited wall clock', () => {
+    // User changes the time to 6:00:00 AM; result keeps the deployment +09:00.
+    assert.equal(
+      parseEditedTimestampToISO('Apr 30, 2026, 6:00:00 AM', '2020-01-01T00:00:00.000+09:00'),
+      '2026-04-30T06:00:00.000+09:00'
     )
   })
 
-  test('accepts a Date instance', () => {
-    const result = formatGridTimestamp(new Date('2026-04-30T14:34:56Z'))
-    assert.match(result, /^[A-Z][a-z]{2} \d{1,2}, \d{4}, \d{1,2}:\d{2}\s(AM|PM)$/)
+  test('keeps a UTC original in UTC', () => {
+    assert.equal(
+      parseEditedTimestampToISO('Apr 30, 2026, 6:00:00 AM', '2020-01-01T00:00:00.000Z'),
+      '2026-04-30T06:00:00.000Z'
+    )
+  })
+
+  test('returns null for unparseable input', () => {
+    assert.equal(parseEditedTimestampToISO('not a date', '2020-01-01T00:00:00.000Z'), null)
   })
 })


### PR DESCRIPTION
Fixes #567.

## Problem

Selecting a day-period (e.g. **Night**) returned/displayed captures whose on-screen time was clearly outside the window — a Kruger photo shown as "6:54 AM" was still included by the **Night** filter.

The root cause spanned three layers, all disagreeing about which timezone a capture's hour lives in:

- **Import** converted timestamps to UTC (`.toUTC()`) in the CamtrapDP/GBIF and LILA parsers, discarding the deployment's local offset.
- **Filter** read `strftime('%H', ts)` = the UTC hour.
- **Display** rendered `new Date(ts)` in the *viewer's machine* timezone.

So the filter (UTC), the gallery (machine-local), and the camera's actual local clock could all differ.

## Fix — everything reads the camera's local clock

- **Import** (`camtrapDP.js`, `lila-helpers.js`): preserve the deployment-local wall clock and its source offset (`DateTime.fromISO(x, { setZone: true }).toISO()`) instead of `.toUTC()`. The other parsers (deepfaune, WildlifeInsights, image-dir via `geo-tz`) already preserved it.
- **Filter + activity histogram**: read the literal stored hour via `substr(ts, 12, 2)` (`localHourExpr` / `localHourExprRaw`) at the 6 query sites. Timezone-independent → always equal to the displayed time.
- **Display** (`formatTimestamp.js`): render the stored offset via Luxon `{ setZone: true }`; `BestMediaCarousel` routed through it. The **inline timestamp editor** shows *and* parses in the deployment offset (`parseEditedTimestampToISO`), and `updateMediaTimestamp` parses with `{ setZone: true }` so saved edits stay deployment-local.
- **Docs**: new `docs/dates-and-timezones.md`; pointers added from `ipc-api.md`, `data-formats.md`, `import-export.md`.

## Verification

- `npm test` → **1474 pass, 0 fail**; lint + prettier clean.
- New tests: deployment-local filter (`sequencesTimeRange.test.js`), offset-preserving import (`transformDateField.test.js`), display + editor round-trip (`formatTimestamp.test.js`).
- Validated on real local studies: offset study `06:39+02:00` → filter hour 6 / display "6:39 AM" (agree); legacy-UTC Kruger `04:06Z` → filter 4 / display "4:06 AM" (now consistent).

## Caveat — re-import needed for existing UTC studies

Studies imported before this change are stored as UTC (`Z`) — including **GMU8 Leuven** and the **Kruger demo**. They keep filter == display, but read as UTC until **re-imported**, after which they become true camera-local (e.g. Kruger's morning shot becomes 06:06 and Night correctly excludes it). There is no in-place backfill migration.