### PR TITLE
refactor(database): break circular barrel imports in queries

### DIFF
--- a/src/main/database/index.js
+++ b/src/main/database/index.js
@@ -4,7 +4,14 @@
  */
 
 import { eq, desc } from 'drizzle-orm'
-import { getStudyDatabase, closeStudyDatabase, closeAllDatabases } from './manager.js'
+import {
+  getStudyDatabase,
+  closeStudyDatabase,
+  closeAllDatabases,
+  getDrizzleDb,
+  getReadonlyDrizzleDb,
+  executeRawQuery
+} from './manager.js'
 import {
   deployments,
   media,
@@ -24,7 +31,14 @@ import log from '../services/logger.js'
 
 // Re-export schema and manager functions
 export { deployments, media, observations, modelRuns, modelOutputs, metadata, jobs }
-export { getStudyDatabase, closeStudyDatabase, closeAllDatabases }
+export {
+  getStudyDatabase,
+  closeStudyDatabase,
+  closeAllDatabases,
+  getDrizzleDb,
+  getReadonlyDrizzleDb,
+  executeRawQuery
+}
 
 // Re-export Zod validation schemas
 export {
@@ -42,50 +56,6 @@ export {
   manasRawOutputSchema,
   rawOutputSchema
 } from './validators.js'
-
-/**
- * Helper function to get Drizzle database instance for a study
- * @param {string} studyId - Study identifier
- * @param {string} dbPath - Path to database file
- * @param {Object} options - Database options (e.g., {readonly: true})
- * @returns {Promise<Object>} Drizzle database instance
- */
-export async function getDrizzleDb(studyId, dbPath, options = {}) {
-  const manager = await getStudyDatabase(studyId, dbPath, options)
-  return manager.getDb()
-}
-
-/**
- * Helper function to get a readonly Drizzle database instance for a study
- * @param {string} studyId - Study identifier
- * @param {string} dbPath - Path to database file
- * @returns {Promise<Object>} Readonly Drizzle database instance
- */
-export async function getReadonlyDrizzleDb(studyId, dbPath) {
-  const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
-  return manager.getDb()
-}
-
-/**
- * Helper function to execute raw SQL queries when needed
- * @param {string} studyId - Study identifier
- * @param {string} dbPath - Path to database file
- * @param {string} query - SQL query
- * @param {Array} params - Query parameters
- * @returns {Promise<Array>} Query results
- */
-export async function executeRawQuery(studyId, dbPath, query, params = []) {
-  const manager = await getStudyDatabase(studyId, dbPath)
-  const sqlite = manager.getSqlite()
-
-  try {
-    const statement = sqlite.prepare(query)
-    return statement.all(params)
-  } catch (error) {
-    log.error(`[DB] Raw query failed for study ${studyId}:`, error)
-    throw error
-  }
-}
 
 // ============================================================================
 // Metadata CRUD operations

--- a/src/main/database/manager.js
+++ b/src/main/database/manager.js
@@ -328,3 +328,47 @@ export async function closeAllDatabases() {
   dbConnections.clear()
   log.info('[DB] All database connections closed')
 }
+
+/**
+ * Helper function to get Drizzle database instance for a study
+ * @param {string} studyId - Study identifier
+ * @param {string} dbPath - Path to database file
+ * @param {Object} options - Database options (e.g., {readonly: true})
+ * @returns {Promise<Object>} Drizzle database instance
+ */
+export async function getDrizzleDb(studyId, dbPath, options = {}) {
+  const manager = await getStudyDatabase(studyId, dbPath, options)
+  return manager.getDb()
+}
+
+/**
+ * Helper function to get a readonly Drizzle database instance for a study
+ * @param {string} studyId - Study identifier
+ * @param {string} dbPath - Path to database file
+ * @returns {Promise<Object>} Readonly Drizzle database instance
+ */
+export async function getReadonlyDrizzleDb(studyId, dbPath) {
+  const manager = await getStudyDatabase(studyId, dbPath, { readonly: true })
+  return manager.getDb()
+}
+
+/**
+ * Helper function to execute raw SQL queries when needed
+ * @param {string} studyId - Study identifier
+ * @param {string} dbPath - Path to database file
+ * @param {string} query - SQL query
+ * @param {Array} params - Query parameters
+ * @returns {Promise<Array>} Query results
+ */
+export async function executeRawQuery(studyId, dbPath, query, params = []) {
+  const manager = await getStudyDatabase(studyId, dbPath)
+  const sqlite = manager.getSqlite()
+
+  try {
+    const statement = sqlite.prepare(query)
+    return statement.all(params)
+  } catch (error) {
+    log.error(`[DB] Raw query failed for study ${studyId}:`, error)
+    throw error
+  }
+}

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -3,7 +3,7 @@
  * Complex scoring and diversity selection logic for hero images
  */
 
-import { executeRawQuery } from '../index.js'
+import { executeRawQuery } from '../manager.js'
 import log from '../../services/logger.js'
 import { getStudyIdFromPath } from './utils.js'
 

--- a/src/main/database/queries/deployments.js
+++ b/src/main/database/queries/deployments.js
@@ -2,7 +2,8 @@
  * Deployment-related database queries
  */
 
-import { getDrizzleDb, deployments, media, observations } from '../index.js'
+import { getDrizzleDb } from '../manager.js'
+import { deployments, media, observations } from '../models.js'
 import { and, count, countDistinct, desc, eq, isNotNull, ne, notExists, or, sql } from 'drizzle-orm'
 import log from '../../services/logger.js'
 import { getStudyIdFromPath } from './utils.js'

--- a/src/main/database/queries/media.js
+++ b/src/main/database/queries/media.js
@@ -2,14 +2,8 @@
  * Media-related database queries
  */
 
-import {
-  getDrizzleDb,
-  media,
-  observations,
-  modelRuns,
-  modelOutputs,
-  deployments
-} from '../index.js'
+import { getDrizzleDb } from '../manager.js'
+import { media, observations, modelRuns, modelOutputs, deployments } from '../models.js'
 import { eq, and, desc, count, sql, isNotNull, inArray, isNull } from 'drizzle-orm'
 import { DateTime } from 'luxon'
 import log from '../../services/logger.js'

--- a/src/main/database/queries/observations.js
+++ b/src/main/database/queries/observations.js
@@ -2,7 +2,8 @@
  * Observation-related database queries
  */
 
-import { getDrizzleDb, observations } from '../index.js'
+import { getDrizzleDb } from '../manager.js'
+import { observations } from '../models.js'
 import { eq } from 'drizzle-orm'
 import log from '../../services/logger.js'
 import { getStudyIdFromPath } from './utils.js'

--- a/src/main/database/queries/overview.js
+++ b/src/main/database/queries/overview.js
@@ -9,7 +9,7 @@
  * against the bundled speciesInfo dictionary for the threatened tally).
  */
 
-import { getStudyDatabase } from '../index.js'
+import { getStudyDatabase } from '../manager.js'
 import log from '../../services/logger.js'
 import { getStudyIdFromPath } from './utils.js'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/resolver.js'

--- a/src/main/database/queries/sequences.js
+++ b/src/main/database/queries/sequences.js
@@ -4,7 +4,8 @@
  * Provides cursor-based pagination for sequence grouping in the main process.
  */
 
-import { getDrizzleDb, deployments, media, observations } from '../index.js'
+import { getDrizzleDb } from '../manager.js'
+import { deployments, media, observations } from '../models.js'
 import {
   eq,
   and,

--- a/src/main/database/queries/species.js
+++ b/src/main/database/queries/species.js
@@ -2,7 +2,8 @@
  * Species-related database queries
  */
 
-import { getDrizzleDb, getStudyDatabase, deployments, media, observations } from '../index.js'
+import { getDrizzleDb, getStudyDatabase } from '../manager.js'
+import { deployments, media, observations } from '../models.js'
 import {
   eq,
   and,

--- a/src/main/database/queries/utils.js
+++ b/src/main/database/queries/utils.js
@@ -3,7 +3,8 @@
  * Helper functions used across multiple query modules
  */
 
-import { getDrizzleDb, getStudyDatabase, observations } from '../index.js'
+import { getDrizzleDb, getStudyDatabase } from '../manager.js'
+import { observations } from '../models.js'
 import { sql } from 'drizzle-orm'
 // Note: observations import kept for checkStudyHasEventIDs
 import log from '../../services/logger.js'


### PR DESCRIPTION
## Summary
- Fixes #547. The `database/queries/*.js` files imported schema (`deployments`, `media`, `observations`, …) and db helpers (`getDrizzleDb`, `getStudyDatabase`, `executeRawQuery`) back from the `database/index.js` barrel that re-exports them, forming an `index.js ↔ queries/*.js` cycle. After #509 shifted Rollup's chunk boundaries, this surfaced as 30 "was reexported through module" warnings with undefined cross-chunk load order.
- Moved `getDrizzleDb` / `getReadonlyDrizzleDb` / `executeRawQuery` into `manager.js` (next to `getStudyDatabase`, which they wrap), and pointed the query files at `../models.js` for schema and `../manager.js` for helpers instead of the barrel.
- `database/index.js` continues to re-export everything, so IPC/service callers are unchanged. Fixed all 9 query files with the pattern (the issue listed 4).

## Test plan
- [x] `npm run build` — 0 "was reexported through module" warnings (was 30)
- [x] `npm test` — 1458 passed, 0 failed
- [x] `npm run lint` — 0 errors (pre-existing renderer warnings unchanged)
- [x] `npm run format` — no changes
- [x] Smoke test: import a GBIF dataset, browse a study