### PR TITLE
feat(media): zoom media thumbnails on hover in gallery

### DIFF
--- a/src/renderer/src/media/Gallery.jsx
+++ b/src/renderer/src/media/Gallery.jsx
@@ -1613,7 +1613,7 @@ function ThumbnailBboxOverlay({ bboxes, imageRef, containerRef }) {
   const { offsetX, offsetY, renderedWidth, renderedHeight } = imageBounds
 
   return (
-    <svg className="absolute inset-0 w-full h-full pointer-events-none z-10">
+    <svg className="absolute inset-0 w-full h-full pointer-events-none z-10 transition-transform duration-300 ease-out group-hover:scale-110">
       {drawableBboxes.map((bbox, index) => {
         const isValidated = bbox.classificationMethod === 'human'
         return (
@@ -1699,7 +1699,7 @@ function ThumbnailCard({
 
   return (
     <div
-      className="border border-border rounded-lg overflow-hidden flex flex-col transition-all"
+      className="group border border-border rounded-lg overflow-hidden flex flex-col transition-all"
       style={{ width: itemWidth ? `${itemWidth}px` : undefined }}
     >
       <div
@@ -1729,7 +1729,7 @@ function ThumbnailCard({
                 ref={imageRef}
                 src={thumbnailUrl}
                 alt={media.fileName || `Video ${media.mediaID}`}
-                className="relative z-10 w-full h-full object-contain"
+                className="relative z-10 w-full h-full object-contain transition-transform duration-300 ease-out group-hover:scale-110"
                 loading="lazy"
               />
             ) : (
@@ -1737,7 +1737,7 @@ function ThumbnailCard({
               <video
                 ref={imageRef}
                 src={constructImageUrl(media.filePath)}
-                className={`relative z-10 w-full h-full object-contain ${imageErrors[media.mediaID] ? 'hidden' : ''}`}
+                className={`relative z-10 w-full h-full object-contain transition-transform duration-300 ease-out group-hover:scale-110 ${imageErrors[media.mediaID] ? 'hidden' : ''}`}
                 onError={() => setImageErrors((prev) => ({ ...prev, [media.mediaID]: true }))}
                 muted
                 preload="metadata"
@@ -1761,7 +1761,7 @@ function ThumbnailCard({
               src={constructImageUrl(media.filePath)}
               alt={media.fileName || `Media ${media.mediaID}`}
               data-image={media.filePath}
-              className={`w-full h-full object-contain ${imageErrors[media.mediaID] ? 'hidden' : ''} ${isImageLoading ? 'opacity-0' : 'opacity-100'} transition-opacity duration-200`}
+              className={`w-full h-full object-contain ${imageErrors[media.mediaID] ? 'hidden' : ''} ${isImageLoading ? 'opacity-0' : 'opacity-100'} transition duration-300 ease-out group-hover:scale-110`}
               onLoad={() => setIsImageLoading(false)}
               onError={() => {
                 setImageErrors((prev) => ({ ...prev, [media.mediaID]: true }))
@@ -1965,7 +1965,7 @@ function SequenceCard({
                 ref={imageRef}
                 src={currentThumbnailUrl}
                 alt={currentMedia.fileName || `Video ${currentMedia.mediaID}`}
-                className="relative z-10 w-full h-full object-contain transition-opacity duration-300"
+                className="relative z-10 w-full h-full object-contain transition duration-300 ease-out group-hover:scale-110"
                 loading="lazy"
               />
             ) : (
@@ -1973,7 +1973,7 @@ function SequenceCard({
               <video
                 ref={imageRef}
                 src={constructImageUrl(currentMedia.filePath)}
-                className={`relative z-10 w-full h-full object-contain transition-opacity duration-300 ${imageErrors[currentMedia.mediaID] ? 'hidden' : ''}`}
+                className={`relative z-10 w-full h-full object-contain transition duration-300 ease-out group-hover:scale-110 ${imageErrors[currentMedia.mediaID] ? 'hidden' : ''}`}
                 onError={() =>
                   setImageErrors((prev) => ({ ...prev, [currentMedia.mediaID]: true }))
                 }
@@ -1998,7 +1998,7 @@ function SequenceCard({
               ref={imageRef}
               src={constructImageUrl(currentMedia.filePath)}
               alt={currentMedia.fileName || `Media ${currentMedia.mediaID}`}
-              className={`w-full h-full object-contain transition-opacity duration-300 ${imageErrors[currentMedia.mediaID] ? 'hidden' : ''} ${!loadedImages[currentMedia.mediaID] ? 'opacity-0' : 'opacity-100'}`}
+              className={`w-full h-full object-contain transition duration-300 ease-out group-hover:scale-110 ${imageErrors[currentMedia.mediaID] ? 'hidden' : ''} ${!loadedImages[currentMedia.mediaID] ? 'opacity-0' : 'opacity-100'}`}
               onLoad={() => setLoadedImages((prev) => ({ ...prev, [currentMedia.mediaID]: true }))}
               onError={() => {
                 setImageErrors((prev) => ({ ...prev, [currentMedia.mediaID]: true }))


### PR DESCRIPTION
## What

Brings the zoom-on-hover effect used by the **Featured species** and **Best captures** cards to the **Media tab** gallery grid.

Previously, gallery cards only darkened their background on hover (`hover:bg-gray-900`). Now the media image scales to 110% with a smooth 300ms `ease-out` transition — matching the existing card pattern (`group-hover:scale-110`).

## Scope

- **`ThumbnailCard`** — single-image cards (added `group` to the card root).
- **`SequenceCard`** — multi-image/burst cards (already had `group`).
- Applies to images, video thumbnails, and inline video elements.
- Keeps `object-contain` (black letterbox preserved — no change to how images are cropped).

## Notable detail

The bounding-box overlay is a separate SVG sibling positioned from the image bounds, so scaling only the image would make the boxes drift on hover. The overlay SVG now receives the **same** transform, so image and boxes scale about the same center and stay aligned.

Images that had a load-fade (`transition-opacity`) were switched to the bare `transition` utility (covers both opacity and transform) so the fade-in and the zoom don't conflict over `transition-property`. Fade timing shifts 200ms→300ms — visually negligible.

Badges, timestamps, sequence counters, progress dots, spinners, and error fallbacks stay fixed during the zoom.

## Verification

- `npm run format` — clean
- `npm run lint` — 0 errors (only pre-existing warnings, none in `Gallery.jsx`)
- `npm test` — 1458 passing