### PR TITLE
feat(ui): animate study sidebar hover card with spring pop

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -377,11 +377,24 @@ input::-webkit-inner-spin-button {
   }
 }
 
+/* Study sidebar hover card — same spring pop, but it always flies out to the
+   right of the sidebar, so grow it from its left edge (the anchor) rather than
+   its center. */
+.study-hovercard[data-state='open'] {
+  transform-origin: left center;
+  animation: hovercard-pop 260ms cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.study-hovercard[data-state='closed'] {
+  animation: tooltip-fade-out 100ms ease-in;
+}
+
 /* Respect reduced-motion: drop the pop/slide entrances for the hover cards
    and tooltips, leaving them to appear instantly. */
 @media (prefers-reduced-motion: reduce) {
   .species-hovercard[data-state='open'],
   .species-hovercard[data-state='closed'],
+  .study-hovercard[data-state='open'],
+  .study-hovercard[data-state='closed'],
   [data-radix-tooltip-content] {
     animation: none;
   }

--- a/src/renderer/src/ui/StudyHoverCard.jsx
+++ b/src/renderer/src/ui/StudyHoverCard.jsx
@@ -51,7 +51,7 @@ export default function StudyHoverCard({ study, scrollSignal, children }) {
           align="start"
           avoidCollisions
           collisionPadding={16}
-          className="z-[10001] w-80 bg-card rounded-lg shadow-xl border border-border p-4"
+          className="study-hovercard z-[10001] w-80 bg-card rounded-lg shadow-xl border border-border p-4"
         >
           <Body study={study} stats={stats} isLoading={isLoading} />
         </HoverCard.Content>


### PR DESCRIPTION
## Summary

Adds an entrance animation to the **study hover card** (sidebar / left pane) so it no longer appears instantly — mirroring the existing **species hover card** spring-pop.

Both cards use Radix `HoverCard`, which exposes a `data-state` attribute; the species card hooks CSS keyframes onto that via a `.species-hovercard` class. This applies the same pattern to the study card with a new `.study-hovercard` class.

## Changes

- **`StudyHoverCard.jsx`** — add `study-hovercard` class to the `HoverCard.Content`.
- **`main.css`** — reuse the existing `hovercard-pop` (260ms, `cubic-bezier(0.34, 1.56, 0.64, 1)`) on open and `tooltip-fade-out` on close; add the class to the `prefers-reduced-motion` opt-out.

## Difference from the species card

`transform-origin: left center` — the study card always flies out to the right of the sidebar (`side="right"`), so it grows from its left edge (the hovered row) instead of ballooning from its center. The species card is direction-independent, so it keeps a center origin.

## Testing

- `npm run format` — clean
- `npm run lint` — 0 errors
- `npm test` — 1458 passing