### PR TITLE
feat(overview): navigate to Explore when clicking a threatened species

### DIFF
--- a/src/renderer/src/overview/KpiBand.jsx
+++ b/src/renderer/src/overview/KpiBand.jsx
@@ -317,7 +317,7 @@ function ThreatenedSpeciesPopover({ studyId, species, onClose, ignoreOutsideClic
   }, [onClose, ignoreOutsideClickRef])
 
   const handleClick = (scientificName) => {
-    navigate(`/study/${studyId}/media?species=${encodeURIComponent(scientificName)}`)
+    navigate(`/study/${studyId}/explore?species=${encodeURIComponent(scientificName)}&view=both`)
   }
 
   // Sort by display name (common name from the bundled dictionary, falling


### PR DESCRIPTION
## Summary
- The "Species (threatened)" KPI tile's popover navigated to the Media tab when a species row was clicked. It now navigates to the Explore tab with the species pre-selected and the map+gallery (`view=both`) view, matching the species distribution list's behavior on the same overview page.

## Test plan
- [x] `npm run dev`, open a study with threatened species (IUCN VU/EN/CR/EW/EX)
- [x] Click the "Species (threatened)" tile, then click a species row in the popover
- [x] Confirm it lands on the Explore tab with that species pre-selected and the map+gallery view — identical to clicking the same species in the species distribution list