### PR TITLE
fix(hovercard): keep Radix species cards visible after pop animation

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -473,13 +473,20 @@ input::-webkit-inner-spin-button {
     0 8px 24px -8px rgba(0, 0, 0, 0.22),
     0 2px 6px -2px rgba(0, 0, 0, 0.12);
   overflow: hidden;
+}
+/* The explore overlay drives its own enter/exit through the --visible toggle and
+   has no Radix data-state, so the hidden default + transition live only here.
+   Radix species cards (KpiBand) animate via .species-hovercard[data-state] and
+   must keep their natural opacity:1 once the keyframe finishes — otherwise they
+   pop in and immediately vanish (the keyframe has no animation-fill-mode). */
+.species-hovercard:not([data-state]) {
   opacity: 0;
   transform: scale(0.86);
   transition:
     opacity 0.16s ease,
     transform 0.26s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.species-hovercard--visible {
+.species-hovercard:not([data-state]).species-hovercard--visible {
   opacity: 1;
   transform: scale(1);
 }


### PR DESCRIPTION
## Problem

The species detail hover cards in the Overview tab ("Best captures" / "Featured species" in `KpiBand.jsx`) popped in via their spring animation and then **disappeared immediately**, even while the cursor stayed on the trigger.

## Root cause

The `.species-hovercard` class is shared by two unrelated animation systems:

- **Radix cards** (`KpiBand.jsx`) — `HoverCard.Content` driven by `data-state`, animating in via the `hovercard-pop` keyframe.
- **Explore map overlay** (`explore.jsx` `HoverCardOverlay`) — a plain `<div>` revealed by toggling `.species-hovercard--visible`.

Commit `5e7c7f4` ("animate map composition hover card") rewrote the base `.species-hovercard` rule to default `opacity: 0` (correct for the overlay). But the `hovercard-pop` keyframe has **no `animation-fill-mode`**, so when the 260ms animation finished, the Radix cards reverted to the cascade value `opacity: 0` and vanished while `data-state` was still `open`. (`.study-hovercard` was unaffected — it never got an `opacity: 0` base — which confirmed the diagnosis.)

## Fix

Keep shared appearance on the unscoped `.species-hovercard`; scope the hidden-default + transition + `--visible` reveal to `.species-hovercard:not([data-state])`. Radix cards always carry a `data-state` and now keep their natural `opacity: 1` after the keyframe. Also fixes the reduced-motion case, where those cards were doubly broken (`animation: none` + `opacity: 0` = permanently invisible).

CSS-only, one file.

## Verification

- Overview tab → hover a "Best captures" / "Featured species" row → card pops in and **stays** while hovering, fades out on leave. ✅
- Regression: Explore tab → hover a pie/cluster marker → composition card still pops in and fades. ✅
- `npm run format` / `npm run lint` clean; `npm test` → 1458 pass.