### PR TITLE
feat(explore): animate map encoding toggle with sliding pill

### DIFF
--- a/src/renderer/src/ui/MapEncodingToggle.jsx
+++ b/src/renderer/src/ui/MapEncodingToggle.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 import { PieChart, Circle, Flame, Hexagon } from 'lucide-react'
 import * as Tooltip from '@radix-ui/react-tooltip'
@@ -46,6 +46,11 @@ const ENCODINGS = [
  * Explore view toggle. Click/scroll propagation is disabled so interacting with
  * the control doesn't pan or zoom the map underneath.
  *
+ * A single blue pill is absolutely positioned behind the buttons and slides
+ * (transitioning left/width) to the active segment, mirroring ViewModeToggle.
+ * Positions are measured from the button elements and re-measured on resize,
+ * when collapsing to icon-only, and when the available encodings change.
+ *
  * On a single species, Composition is hidden (a one-species pie is just the
  * Abundance disc). On narrow maps the control collapses to icon-only so it
  * doesn't collide with the legend on the opposite corner — the hover cards
@@ -58,7 +63,9 @@ const ENCODINGS = [
  */
 export default function MapEncodingToggle({ value, onChange, singleSpecies }) {
   const ref = useRef(null)
+  const btnRefs = useRef({})
   const [compact, setCompact] = useState(false)
+  const [pill, setPill] = useState(null)
 
   useEffect(() => {
     const el = ref.current
@@ -79,24 +86,43 @@ export default function MapEncodingToggle({ value, onChange, singleSpecies }) {
 
   const encodings = singleSpecies ? ENCODINGS.filter((e) => e.key !== 'pies') : ENCODINGS
 
+  // Slide the blue pill to the active segment. Re-measure when the selection,
+  // the icon-only collapse, or the available encodings change, since each
+  // alters button widths/offsets.
+  useLayoutEffect(() => {
+    const btn = btnRefs.current[value]
+    if (!btn) return
+    setPill({ left: btn.offsetLeft, width: btn.offsetWidth })
+  }, [value, compact, singleSpecies])
+
   return (
     <div
       ref={ref}
       className="absolute bottom-5 left-5 z-[1000] flex items-center gap-0.5 bg-card p-1 rounded-md shadow-md cursor-default"
     >
+      {pill && (
+        <span
+          aria-hidden="true"
+          className="absolute top-1 h-7 rounded bg-blue-50 dark:bg-blue-950 transition-[left,width] duration-200 ease-out"
+          style={{ left: pill.left, width: pill.width }}
+        />
+      )}
       {encodings.map(({ key, label, icon: Icon, description }) => {
         const active = value === key
         return (
           <Tooltip.Root key={key}>
             <Tooltip.Trigger asChild>
               <button
+                ref={(el) => {
+                  btnRefs.current[key] = el
+                }}
                 type="button"
                 onClick={() => onChange(key)}
                 aria-pressed={active}
-                className={`flex items-center gap-1.5 px-2 h-7 rounded text-xs cursor-pointer transition-colors ${
+                className={`relative z-10 flex items-center gap-1.5 px-2 h-7 rounded text-xs cursor-pointer transition-colors ${
                   active
-                    ? 'bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300'
-                    : 'text-muted-foreground hover:text-foreground'
+                    ? 'text-blue-700 dark:text-blue-300'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                 }`}
               >
                 <Icon size={14} />


### PR DESCRIPTION
## What

Animate the Explore tab's map visualization toggle (Composition / Abundance / Density / Hex grid) and emphasize the inactive-segment hover.

## Changes (`MapEncodingToggle.jsx` only)

**Sliding pill** — ported the `ViewModeToggle` pattern: a single blue pill (`bg-blue-50 dark:bg-blue-950`) is absolutely positioned behind the buttons and transitions `left`/`width` to the active segment (`duration-200 ease-out`), instead of hard-swapping a per-button background. A `useLayoutEffect` measures the active button's `offsetLeft`/`offsetWidth`, re-running on selection change, the icon-only collapse, and when the available encodings change (the dropped Composition segment on single-species). The pill color is identical to the old active background, so the look is preserved — it just animates now.

**Stronger hover** — inactive segments went from a bare `hover:text-foreground` text-color shift to `hover:bg-muted hover:text-foreground`, giving a clear idle → gray (hover) → blue (active) progression that stays visually distinct from the selected state.

No new dependencies (pure Tailwind + CSS transition, matching the existing `ViewModeToggle` pattern). `ViewModeToggle.jsx` is untouched.

## Verification
- `npm run format` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in this file)
- `npm test` — 1458 passing