### PR TITLE
fix(tooltip): swap cleanly between adjacent triggers

### DIFF
--- a/src/renderer/src/base.jsx
+++ b/src/renderer/src/base.jsx
@@ -531,7 +531,7 @@ function ThemedToaster() {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <Tooltip.Provider delayDuration={200} skipDelayDuration={0}>
+      <Tooltip.Provider delayDuration={200} skipDelayDuration={0} disableHoverableContent>
         <ThemedToaster />
         <HashRouter>
           <ErrorBoundary FallbackComponent={ErrorFallback}>


### PR DESCRIPTION
## Problem

Across the app, segmented controls show a Radix Tooltip card on hover, but moving the pointer from one option to the adjacent one left the **first card stuck open** — the new one never took over. Reported on:

- Explore map composition toggle (Composition / Abundance / Density / Hex grid)
- Daytime activity shape toggle (Polar / X–Y line)
- Deployments sparkline toggle (bars / lines / heatmap)
- …and most other toggle groups (day-period chips, view-mode, species-rail, thumbnail-bbox).

## Root cause

All these tooltips share one `Tooltip.Provider` that didn't set `disableHoverableContent`. With hoverable content enabled (the Radix default), leaving a trigger keeps the tooltip alive via a "grace area" in case the pointer is heading toward the content. Sliding sideways to the neighbouring button therefore left the previous tooltip open instead of closing it — the "shown but not replaced" symptom, global because it lives on the shared Provider.

## Fix

Add `disableHoverableContent` to the shared `Tooltip.Provider` so each tooltip closes immediately on pointer-leave of its trigger.

This is safe to disable globally: every `@radix-ui/react-tooltip` usage here is plain non-interactive text. Interactive cards that genuinely need the grace area (filter charts "Reset filters", study/species hover cards) use `@radix-ui/react-hover-card`, a separate primitive unaffected by this prop.

## Verification

- Manually confirmed in the running app: cards now swap cleanly across the map composition, daytime activity, and deployment toggles; no stale card lingers. Hover-out still dismisses.
- `npm run format` — clean
- `npm run lint` — 0 errors
- `npm test` — 1458 passing, 0 failures