### PR TITLE
fix(tabs): remove native title tooltip on study tab hover

### DIFF
--- a/src/renderer/src/ui/Tab.jsx
+++ b/src/renderer/src/ui/Tab.jsx
@@ -11,7 +11,6 @@ export function Tab({ to, icon: Icon, children, end = false, indicator = null, c
     <NavLink
       to={to}
       end={end}
-      title={typeof children === 'string' ? children : undefined}
       className={({ isActive }) =>
         classNames(
           isActive


### PR DESCRIPTION
## What

Hovering over the study tab buttons (Overview, Explore, Media, Deployments, Sources, Settings) showed a delayed native browser tooltip duplicating the tab name. This removes it.

## Why

The shared `Tab` component (`src/renderer/src/ui/Tab.jsx`) set the HTML `title` attribute on the `NavLink`, which the browser renders as a hover tooltip. The label is already visible next to the icon at wide viewports, so the tooltip was redundant and unwanted.

## Change

Removed the single `title` line. Accessibility is preserved — the `sr-only` `<span>{children}</span>` still supplies the tab's accessible name for screen readers.

## Test

- `npm run format`, `npm run lint` (0 errors), `npm test` (1458 pass)
- Manually: hover each tab — no tooltip appears.