### PR TITLE
fix(settings): render inline markdown in recent-release notes

### DIFF
--- a/src/renderer/src/SettingsInfo/RecentReleases.jsx
+++ b/src/renderer/src/SettingsInfo/RecentReleases.jsx
@@ -10,6 +10,53 @@ const SECTION_LABELS = {
 
 const COLLAPSED_MAX_HEIGHT = 180
 
+const REPO_URL = 'https://github.com/earthtoolsmaker/biowatch'
+
+// Splits on **bold**, `code`, and #123 issue/PR refs, rendering each as inline markup.
+function renderInline(text) {
+  return text.split(/(\*\*[^*]+\*\*|`[^`]+`|#\d+)/g).map((part, i) => {
+    if (!part) return null
+
+    const bold = part.match(/^\*\*([^*]+)\*\*$/)
+    if (bold) {
+      return (
+        <strong key={i} className="font-semibold">
+          {bold[1]}
+        </strong>
+      )
+    }
+
+    const code = part.match(/^`([^`]+)`$/)
+    if (code) {
+      return (
+        <code
+          key={i}
+          className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em] text-muted-foreground"
+        >
+          {code[1]}
+        </code>
+      )
+    }
+
+    const issue = part.match(/^#(\d+)$/)
+    if (issue) {
+      return (
+        <a
+          key={i}
+          href={`${REPO_URL}/pull/${issue[1]}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline dark:text-blue-400"
+        >
+          {part}
+        </a>
+      )
+    }
+
+    return part
+  })
+}
+
 function ReleaseBlock({ release }) {
   const sections = ['added', 'changed', 'fixed'].filter(
     (key) => release[key] && release[key].length > 0
@@ -29,7 +76,7 @@ function ReleaseBlock({ release }) {
             </div>
             <ul className="text-sm text-foreground space-y-0.5 list-disc list-inside marker:text-muted-foreground">
               {release[key].map((item, i) => (
-                <li key={i}>{item}</li>
+                <li key={i}>{renderInline(item)}</li>
               ))}
             </ul>
           </div>


### PR DESCRIPTION
## Summary

The **Settings > Info → Recent releases** list rendered changelog items as raw text, so inline markdown showed its literal markers (e.g. `**Merge a study as a source**`, `` `services/logger.js` ``, `(#519)`).

This adds a small inline parser in `RecentReleases.jsx` that renders:

- `**bold**` → `<strong>`
- `` `code` `` → styled `<code>` chip (`bg-muted` + monospace, matching the existing chip style used elsewhere)
- `#NNN` → link to the GitHub PR/issue (`/pull/<n>`; GitHub auto-redirects PR↔issue)

The parser is ordered so a backtick code span is matched before the `#NNN` rule, keeping a `#` inside code literal. Surrounding parens/commas in `(#524, #532)` stay as plain text and each number links independently.

No markdown dependency was added — the changelog parser (`src/main/services/changelog.js`) already stores item text verbatim, so no backend change is needed.

## Testing

- `npm run format` — clean
- `npm run lint` — 0 errors (pre-existing warnings only, none in the touched file)
- `npm test` — 1458 passing
- Manual: Settings > Info > Recent releases renders bold, code chips, and clickable issue links with no stray markers.