### PR TITLE
fix(explore): raise composition hovercard above other map overlays

### DIFF
--- a/src/renderer/src/explore.jsx
+++ b/src/renderer/src/explore.jsx
@@ -222,7 +222,7 @@ function HoverCardOverlay({ hover, selectedSpecies, palette, scientificToCommon 
         position: 'absolute',
         left: pos ? pos.left : -9999,
         top: pos ? pos.top : 0,
-        zIndex: 700,
+        zIndex: 1200,
         pointerEvents: 'none'
       }}
     >


### PR DESCRIPTION
## Summary

The species composition hover card on the explore map was being drawn *underneath* other map overlays. Its portal container sat at `z-index: 700`, below:

- the species & density legends (`z-1000`)
- the species rail (`z-1100`)

So when a card opened near those elements, it appeared partly or fully hidden behind them.

## Fix

Raise the hover card container to `z-index: 1200` so it renders above all other map components. The container keeps `pointerEvents: 'none'`, so this is a purely visual stacking change and does not intercept any clicks beneath it.

`src/renderer/src/explore.jsx:225`

## Testing

- `npm run format` — clean
- `npm run lint` — 0 errors
- `npm test` — 1484 passed, 0 failed