### PR TITLE
feat(explore): enrich species hovercard with activity charts

### DIFF
--- a/src/renderer/src/explore.jsx
+++ b/src/renderer/src/explore.jsx
@@ -1555,6 +1555,7 @@ export default function Explore({ studyData, studyId }) {
       studyId={actualStudyId}
       showHeader={false}
       hidePseudoSpecies
+      showActivity
     />
   ) : null
 
@@ -1597,6 +1598,7 @@ export default function Explore({ studyData, studyId }) {
                     selectedSpecies={selectedSpecies}
                     palette={palette}
                     scientificToCommon={scientificToCommon}
+                    studyId={actualStudyId}
                     compact={!isLgUp}
                     onOpen={() => setRailVisible(true)}
                     onRemove={(name) =>

--- a/src/renderer/src/media/FilterDrawer.jsx
+++ b/src/renderer/src/media/FilterDrawer.jsx
@@ -434,6 +434,7 @@ export default function FilterDrawer({ open, studyId, filters, onChange }) {
                     onSpeciesChange={handleSpeciesChange}
                     palette={palette}
                     studyId={studyId}
+                    showActivity
                     showHeader={false}
                     // Blank is offered as a quick view, so it's not duplicated as
                     // a selectable pseudo-row in the species list.

--- a/src/renderer/src/media/MediaToolbar.jsx
+++ b/src/renderer/src/media/MediaToolbar.jsx
@@ -230,6 +230,23 @@ export default function MediaToolbar({
     enabled: !!studyId && hasSpeciesChips,
     staleTime: 60000
   })
+  // Per-species counts, so the hover card can gate its activity charts (and
+  // skeleton) the same way the rail does. Shares the drawer's cache key.
+  const { data: speciesDist } = useQuery({
+    queryKey: ['mediaFilterSpeciesDistribution', studyId],
+    queryFn: async () => {
+      const res = await window.api.getSequenceAwareSpeciesDistribution(studyId)
+      if (res?.error) throw new Error(res.error)
+      return res?.data ?? res
+    },
+    enabled: !!studyId && hasSpeciesChips,
+    staleTime: 60000
+  })
+  const speciesCountMap = useMemo(() => {
+    const m = {}
+    for (const it of speciesDist ?? []) m[it.scientificName] = it.count
+    return m
+  }, [speciesDist])
 
   const deploymentItems = useMemo(
     () =>
@@ -272,6 +289,8 @@ export default function MediaToolbar({
         <SpeciesTooltipContent
           imageData={speciesImageMap[chip.value] || { scientificName: chip.value }}
           studyId={studyId}
+          showActivity
+          detectionCount={speciesCountMap[chip.value] ?? 0}
         />
       )
     }

--- a/src/renderer/src/ui/SelectedSpeciesChips.jsx
+++ b/src/renderer/src/ui/SelectedSpeciesChips.jsx
@@ -1,8 +1,10 @@
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import * as HoverCard from '@radix-ui/react-hover-card'
 import { getMapDisplayName } from '../utils/commonNames'
 import { formatScientificName } from '../utils/scientificName'
+import SpeciesTooltipContent from './SpeciesTooltipContent'
 
 const GAP_PX = 6 // matches gap-1.5
 const OVERFLOW_RESERVE_PX = 42 // approx width of the "+N" pill, kept free
@@ -57,11 +59,34 @@ export default function SelectedSpeciesChips({
   scientificToCommon,
   onRemove,
   onOpen = () => {},
-  compact = false
+  compact = false,
+  studyId = null
 }) {
   const containerRef = useRef(null)
   const measureRef = useRef(null)
   const [visibleCount, setVisibleCount] = useState(selectedSpecies?.length ?? 0)
+
+  // Best study photo per species, for the rich hover card (mirrors the
+  // species rail). Shares react-query's cache with the rail's identical query.
+  const { data: bestImagesData } = useQuery({
+    queryKey: ['bestImagesPerSpecies', studyId],
+    queryFn: async () => {
+      const response = await window.api.getBestImagePerSpecies(studyId)
+      if (response.error) throw new Error(response.error)
+      return response.data
+    },
+    enabled: !!studyId,
+    staleTime: 60000
+  })
+  const speciesImageMap = useMemo(() => {
+    const map = {}
+    if (bestImagesData) bestImagesData.forEach((item) => (map[item.scientificName] = item))
+    return map
+  }, [bestImagesData])
+  // Image to feed the card: study photo if we have one, else a bare
+  // scientificName so SpeciesTooltipContent falls back to its own Wikipedia
+  // thumbnail (or the CameraOff placeholder).
+  const imageDataFor = (scientificName) => speciesImageMap[scientificName] || { scientificName }
 
   useLayoutEffect(() => {
     if (compact) return
@@ -173,7 +198,7 @@ export default function SelectedSpeciesChips({
           {visible.map((species, index) => {
             const label = labelFor(species)
             return (
-              <HoverCard.Root key={species.scientificName} openDelay={150} closeDelay={0}>
+              <HoverCard.Root key={species.scientificName} openDelay={250} closeDelay={150}>
                 <HoverCard.Trigger asChild>
                   <span className={chipClass}>
                     <span
@@ -198,12 +223,15 @@ export default function SelectedSpeciesChips({
                     side="bottom"
                     align="start"
                     sideOffset={6}
-                    className={CARD_CLASS}
+                    avoidCollisions
+                    collisionPadding={16}
+                    className="species-hovercard z-[10000]"
                   >
-                    <SpeciesLine
-                      species={species}
-                      color={colorFor(index)}
-                      scientificToCommon={scientificToCommon}
+                    <SpeciesTooltipContent
+                      imageData={imageDataFor(species.scientificName)}
+                      studyId={studyId}
+                      showActivity
+                      detectionCount={species.count}
                     />
                   </HoverCard.Content>
                 </HoverCard.Portal>

--- a/src/renderer/src/ui/SpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/SpeciesTooltipContent.jsx
@@ -1,10 +1,64 @@
 import { useState, useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import * as Tooltip from '@radix-ui/react-tooltip'
 import { CameraOff, Loader2 } from 'lucide-react'
 import { useCommonName } from '../utils/commonNames'
 import { formatScientificName } from '../utils/scientificName'
 import { resolveSpeciesInfo } from '../../../shared/speciesInfo/index.js'
 import IucnBadge from './IucnBadge'
 import { IUCN_ACCENT_BORDER } from './iucnPalette'
+import CircularTimeFilter, { DailyActivityRadar, DailyActivityLine } from './clock'
+import TimelineChart from './timeseries'
+import { hasEnoughActivityData, MIN_ACTIVITY_DETECTIONS } from '../utils/activitySufficiency'
+
+// Single accent for the hovercard's all-time activity charts (one species
+// per card, so no multi-series palette is needed).
+const ACTIVITY_PALETTE = ['rgb(37 99 235)']
+
+// Small uppercase heading + top divider used to group the card's content
+// (e.g. "Activity patterns", "Description"). Only render where the section
+// actually has content so we never show an empty label. `action` renders a
+// small control (e.g. the Wikipedia link) flush right on the heading row.
+function SectionHeading({ children, action }) {
+  return (
+    <div className="flex items-center justify-between gap-2 pt-1 border-t border-border">
+      <span className="text-[9px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+        {children}
+      </span>
+      {action}
+    </div>
+  )
+}
+
+// Wikipedia "W" wordmark (its favicon) as a compact clickable link. Used in
+// the Description heading instead of a full-width "Read on Wikipedia" row.
+function WikipediaLink({ url }) {
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Read more on Wikipedia"
+          onClick={(e) => e.stopPropagation()}
+          className="shrink-0 -my-0.5 px-1.5 py-0.5 rounded font-serif text-sm leading-none text-muted-foreground transition-colors hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/15 dark:hover:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
+        >
+          W
+        </a>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          side="top"
+          sideOffset={6}
+          className="z-[100000] max-w-[200px] rounded-md border border-border bg-popover px-2.5 py-1.5 text-xs text-popover-foreground shadow-md"
+        >
+          Read more on Wikipedia
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  )
+}
 
 function toTitleCase(str) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
@@ -39,11 +93,69 @@ function isRemoteUrl(filePath) {
 // Used to decide whether the "Show more" toggle is worth rendering.
 const BLURB_CLAMP_THRESHOLD = 250
 
-export default function SpeciesTooltipContent({ imageData, studyId, size = 'md' }) {
+export default function SpeciesTooltipContent({
+  imageData,
+  studyId,
+  size = 'md',
+  showActivity = false,
+  // Total detections for this species (from the distribution row). Used as a
+  // cheap upper bound on the gate's timestamped-detection count: below the
+  // threshold there can be no charts, so we skip both the fetch and the
+  // loading skeleton (no flash for sparse species). The daily-activity sum
+  // only ever counts timestamped detections, so it can't exceed this.
+  detectionCount = 0
+}) {
   const [imageError, setImageError] = useState(false)
   const [imageLoaded, setImageLoaded] = useState(false)
   const [blurbExpanded, setBlurbExpanded] = useState(false)
   const sciName = imageData?.scientificName
+
+  // Only species that could clear the gate are worth fetching / skeletoning.
+  const mightHaveActivity = showActivity && detectionCount >= MIN_ACTIVITY_DETECTIONS
+
+  // All-time, full-study activity for the hovered species. Fires only when
+  // the card is mounted (Radix mounts content on open) and showActivity is on,
+  // so the Media tab and quick hover-throughs don't trigger it. Cached per
+  // study+species; gapSeconds is left undefined so the worker reads the
+  // study's configured gap from metadata.
+  //
+  // daily-activity needs an explicit [start, end] (it returns [] otherwise),
+  // so we mirror the Explore bottom row: the all-time range is the timeseries'
+  // full extent (first..last day with data). We fetch the timeseries first,
+  // then query daily activity over that range.
+  const { data: activity, isError: activityError } = useQuery({
+    queryKey: ['speciesHovercardActivity', studyId, sciName],
+    queryFn: async () => {
+      const ts = await window.api.getSequenceAwareTimeseries(studyId, [sciName], undefined, null)
+      if (ts.error) throw new Error(ts.error)
+      const timeseries = ts.data?.timeseries ?? []
+      if (timeseries.length === 0) return { dailyActivity: [], timeseries: [] }
+
+      const start = new Date(timeseries[0].date).toISOString()
+      const end = new Date(timeseries[timeseries.length - 1].date).toISOString()
+      const daily = await window.api.getSequenceAwareDailyActivity(
+        studyId,
+        [sciName],
+        start,
+        end,
+        undefined,
+        null
+      )
+      if (daily.error) throw new Error(daily.error)
+      return { dailyActivity: daily.data ?? [], timeseries }
+    },
+    enabled: mightHaveActivity && !!studyId && !!sciName,
+    staleTime: Infinity
+  })
+
+  const activitySpecies = sciName ? [{ scientificName: sciName }] : []
+  const showCharts =
+    mightHaveActivity &&
+    !!activity &&
+    hasEnoughActivityData(activity.dailyActivity, activity.timeseries, sciName)
+  // Skeleton only while we're actually waiting on a fetch we expect to yield
+  // charts — never for sparse species (gated out above) or after an error.
+  const showActivitySkeleton = mightHaveActivity && !activity && !activityError
   const common = useCommonName(sciName)
   const info = resolveSpeciesInfo(sciName)
   const iucnUrl =
@@ -136,50 +248,100 @@ export default function SpeciesTooltipContent({ imageData, studyId, size = 'md' 
           <IucnBadge category={info?.iucn} />
         </div>
 
-        {iucnUrl && (
-          <a
-            href={iucnUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`block border-l-4 ${IUCN_ACCENT_BORDER[info.iucn] ?? 'border-border'} pl-2 -ml-0.5 py-1 hover:bg-accent rounded-r transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
-          >
-            <p className={`${blurbClass} font-semibold text-foreground`}>Why threatened?</p>
-            <p className={`${linkClass} text-blue-600 dark:text-blue-400`}>
-              View IUCN Red List assessment ↗
-            </p>
-          </a>
-        )}
-
-        {info?.blurb && (
-          <>
-            <p
-              className={`${blurbClass} leading-snug ${
-                blurbExpanded ? 'max-h-48 overflow-y-auto pr-1' : 'line-clamp-5'
-              }`}
-            >
-              {info.blurb}
-            </p>
-            {info.blurb.length > BLURB_CLAMP_THRESHOLD && (
-              <button
-                type="button"
-                onClick={() => setBlurbExpanded((v) => !v)}
-                className={`${linkClass} text-blue-600 hover:underline dark:text-blue-400`}
-              >
-                {blurbExpanded ? 'Show less' : 'Show more'}
-              </button>
+        {(showCharts || showActivitySkeleton) && (
+          <div className="space-y-1.5">
+            <SectionHeading>Activity patterns</SectionHeading>
+            {showActivitySkeleton ? (
+              <div className="space-y-1.5" aria-hidden="true">
+                <div className="flex gap-1.5 h-[132px]">
+                  <div className="flex-1 rounded-md border border-border bg-muted/40 animate-pulse" />
+                  <div className="flex-1 rounded-md border border-border bg-muted/40 animate-pulse" />
+                </div>
+                <div className="h-[112px] rounded-md border border-border bg-muted/40 animate-pulse" />
+              </div>
+            ) : (
+              <>
+                {/* Row 1 — daytime (24h) shown both ways: polar activity radar
+                    over the clock-face circle (the Explore bottom row's look,
+                    minus the filter handles) and its X–Y line twin, side by
+                    side. */}
+                <div className="flex gap-1.5 h-[132px]">
+                  <div className="relative flex-1 min-w-0 rounded-md border border-border bg-background/60">
+                    <DailyActivityRadar
+                      activityData={activity.dailyActivity}
+                      selectedSpecies={activitySpecies}
+                      palette={ACTIVITY_PALETTE}
+                    />
+                    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                      <CircularTimeFilter onChange={() => {}} mode="chips" chipSectors={[]} />
+                    </div>
+                  </div>
+                  <div className="flex-1 min-w-0 rounded-md border border-border bg-background/60 p-1.5">
+                    <DailyActivityLine
+                      activityData={activity.dailyActivity}
+                      selectedSpecies={activitySpecies}
+                      palette={ACTIVITY_PALETTE}
+                      showTrackStrip={false}
+                    />
+                  </div>
+                </div>
+                {/* Row 2 — activity over time (per-day, full study), display-only. */}
+                <div className="h-[112px] rounded-md border border-border bg-background/60 p-1.5">
+                  <TimelineChart
+                    timeseriesData={activity.timeseries}
+                    selectedSpecies={activitySpecies}
+                    dateRange={[null, null]}
+                    setDateRange={() => {}}
+                    palette={ACTIVITY_PALETTE}
+                    interactive={false}
+                  />
+                </div>
+              </>
             )}
-          </>
+          </div>
         )}
 
-        {info?.wikipediaUrl && (
-          <a
-            href={info.wikipediaUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`block ${linkClass} text-blue-600 hover:underline dark:text-blue-400`}
-          >
-            Read on Wikipedia
-          </a>
+        {(info?.blurb || iucnUrl) && (
+          <div className="space-y-1.5">
+            <SectionHeading
+              action={info?.wikipediaUrl && <WikipediaLink url={info.wikipediaUrl} />}
+            >
+              Description
+            </SectionHeading>
+            {info?.blurb && (
+              <div className="space-y-1">
+                <p
+                  className={`${blurbClass} leading-snug ${
+                    blurbExpanded ? 'max-h-48 overflow-y-auto pr-1' : 'line-clamp-5'
+                  }`}
+                >
+                  {info.blurb}
+                </p>
+                {info.blurb.length > BLURB_CLAMP_THRESHOLD && (
+                  <button
+                    type="button"
+                    onClick={() => setBlurbExpanded((v) => !v)}
+                    className={`${linkClass} text-blue-600 hover:underline dark:text-blue-400`}
+                  >
+                    {blurbExpanded ? 'Show less' : 'Show more'}
+                  </button>
+                )}
+              </div>
+            )}
+            {iucnUrl && (
+              <a
+                href={iucnUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`block border-l-4 ${IUCN_ACCENT_BORDER[info.iucn] ?? 'border-border'} pl-2 -ml-0.5 py-1 hover:bg-accent rounded-r transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300`}
+              >
+                <p className={`${blurbClass} font-semibold text-foreground`}>Why threatened?</p>
+                <p className={`${linkClass} text-blue-600 dark:text-blue-400`}>
+                  View IUCN Red List assessment ↗
+                </p>
+              </a>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -397,7 +397,11 @@ const DailyActivityLine = ({
   selectedSpecies,
   palette,
   selectedRanges = [],
-  onArcChange
+  onArcChange,
+  // The selection track strip below the axis is only useful when the chart
+  // drives a filter. Display-only uses (e.g. the species hovercard) pass false
+  // to drop the otherwise-empty grey bar.
+  showTrackStrip = true
 }) => {
   const hasSingleBand = selectedRanges.length === 1
   const isWrapBand = hasSingleBand && bandWraps(selectedRanges[0])
@@ -594,30 +598,32 @@ const DailyActivityLine = ({
 
       {/* Selection track strip below the axis. 8px insets match the chart's
           left/right margin so hour 0..24 line up with the plot. */}
-      <div className="px-2 pb-1" style={cursorStyle ? { cursor: cursorStyle } : undefined}>
-        <div
-          ref={stripRef}
-          className="relative h-1.5 rounded-full bg-muted"
-          onMouseDown={handleStripDown}
-          onMouseMove={handleStripMove}
-          onMouseLeave={handleStripLeave}
-        >
-          {segments.map(([s, e], i) => (
-            <div
-              key={i}
-              className="absolute top-0 h-full rounded-full"
-              style={{ left: pct(s), width: pct(e - s), backgroundColor: 'rgb(59 130 246)' }}
-            />
-          ))}
-          {/* start always renders; end only when it doesn't coincide with start */}
-          {dragEnabled && handleStartX !== null && (
-            <StripHandle left={pct(handleStartX)} active={hoveredEdge === 'start'} />
-          )}
-          {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
-            <StripHandle left={pct(handleEndX)} active={hoveredEdge === 'end'} />
-          )}
+      {showTrackStrip && (
+        <div className="px-2 pb-1" style={cursorStyle ? { cursor: cursorStyle } : undefined}>
+          <div
+            ref={stripRef}
+            className="relative h-1.5 rounded-full bg-muted"
+            onMouseDown={handleStripDown}
+            onMouseMove={handleStripMove}
+            onMouseLeave={handleStripLeave}
+          >
+            {segments.map(([s, e], i) => (
+              <div
+                key={i}
+                className="absolute top-0 h-full rounded-full"
+                style={{ left: pct(s), width: pct(e - s), backgroundColor: 'rgb(59 130 246)' }}
+              />
+            ))}
+            {/* start always renders; end only when it doesn't coincide with start */}
+            {dragEnabled && handleStartX !== null && (
+              <StripHandle left={pct(handleStartX)} active={hoveredEdge === 'start'} />
+            )}
+            {dragEnabled && handleEndX !== null && handleEndX !== handleStartX && (
+              <StripHandle left={pct(handleEndX)} active={hoveredEdge === 'end'} />
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/ui/speciesDistribution.jsx
+++ b/src/renderer/src/ui/speciesDistribution.jsx
@@ -44,7 +44,8 @@ function SpeciesRow({
   speciesImageMap,
   studyId,
   onToggle,
-  scrollSignal
+  scrollSignal,
+  showActivity
 }) {
   const isPseudoEntry = !!pseudoEntry
   const [hoverOpen, setHoverOpen] = useState(false)
@@ -78,7 +79,11 @@ function SpeciesRow({
   const studyImage = isPseudoEntry ? null : speciesImageMap[species.scientificName]
   const tooltipImageData =
     studyImage || (info?.imageUrl ? { scientificName: species.scientificName } : null)
-  const enableSpeciesTooltip = !isPseudoEntry && studyId && !!tooltipImageData
+  // The card opens when there's an image OR (on Explore) when activity charts
+  // may be shown — so a species with no photo still surfaces its activity.
+  // SpeciesTooltipContent always has the scientificName to query/label with.
+  const tooltipData = tooltipImageData || { scientificName: species.scientificName }
+  const enableSpeciesTooltip = !isPseudoEntry && studyId && (!!tooltipImageData || showActivity)
 
   const rowContent = (
     <div
@@ -146,7 +151,12 @@ function SpeciesRow({
             {isPseudoEntry ? (
               <PseudoSpeciesTooltipContent entry={pseudoEntry} />
             ) : (
-              <SpeciesTooltipContent imageData={tooltipImageData} studyId={studyId} />
+              <SpeciesTooltipContent
+                imageData={tooltipData}
+                studyId={studyId}
+                showActivity={showActivity}
+                detectionCount={species.count}
+              />
             )}
           </HoverCard.Content>
         </HoverCard.Portal>
@@ -170,7 +180,8 @@ function SpeciesDistribution({
   hidePseudoSpecies = false,
   allowEmpty = false,
   bordered = true,
-  sortMode = 'count'
+  sortMode = 'count',
+  showActivity = false
 }) {
   // Real-species view of the upstream data — strips out literal pseudo
   // labels like "Vehicle" or "blurred" that ride along in scientificName.
@@ -321,6 +332,7 @@ function SpeciesDistribution({
                   speciesImageMap={speciesImageMap}
                   studyId={studyId}
                   onToggle={handleSpeciesToggle}
+                  showActivity={showActivity}
                 />
               )
             })

--- a/src/renderer/src/ui/timeseries.jsx
+++ b/src/renderer/src/ui/timeseries.jsx
@@ -42,8 +42,20 @@ const formatPillDate = (d) =>
  * the chart shows the full data extent and no filter is applied.
  *
  * Gesture model — see docs/specs/2026-05-13-timeline-zoom-design.md.
+ *
+ * `interactive` (default true) gates all brush/pan/zoom gestures and the
+ * range handles/pill. Pass false for a read-only sparkline (e.g. the
+ * all-time over-time chart in the species hovercard), where only the line
+ * and axis are drawn.
  */
-const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRange, palette }) => {
+const TimelineChart = ({
+  timeseriesData,
+  selectedSpecies,
+  dateRange,
+  setDateRange,
+  palette,
+  interactive = true
+}) => {
   const containerRef = useRef(null)
   const [dragState, setDragState] = useState(null)
   const isDragging = dragState !== null
@@ -417,11 +429,11 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
       <div
         ref={containerRef}
         className="absolute inset-0 select-none [&_*]:!cursor-[inherit]"
-        style={{ cursor: cursorStyle }}
-        onMouseDown={handleNativeDown}
-        onMouseMove={handleNativeMove}
-        onMouseLeave={handleNativeLeave}
-        onWheel={handleWheel}
+        style={{ cursor: interactive ? cursorStyle : 'default' }}
+        onMouseDown={interactive ? handleNativeDown : undefined}
+        onMouseMove={interactive ? handleNativeMove : undefined}
+        onMouseLeave={interactive ? handleNativeLeave : undefined}
+        onWheel={interactive ? handleWheel : undefined}
       >
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart
@@ -459,7 +471,7 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
               />
             )}
 
-            {handleStart && (
+            {interactive && handleStart && (
               <ReferenceLine
                 x={handleStart.getTime()}
                 stroke={handleColor}
@@ -484,7 +496,7 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
                 }}
               />
             )}
-            {handleEnd && handleEnd.getTime() !== handleStart?.getTime() && (
+            {interactive && handleEnd && handleEnd.getTime() !== handleStart?.getTime() && (
               <ReferenceLine
                 x={handleEnd.getTime()}
                 stroke={handleColor}
@@ -527,7 +539,7 @@ const TimelineChart = ({ timeseriesData, selectedSpecies, dateRange, setDateRang
           </ComposedChart>
         </ResponsiveContainer>
       </div>
-      {!cleared && (
+      {interactive && !cleared && (
         <div
           className="absolute top-1 left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 pl-2 pr-1 py-0.5 rounded-full text-[10px] font-medium text-blue-700 dark:text-blue-300 bg-blue-50/90 dark:bg-blue-500/15 border border-blue-200/70 dark:border-blue-500/30 pointer-events-none"
           aria-label="Date filter range"

--- a/src/renderer/src/utils/activitySufficiency.js
+++ b/src/renderer/src/utils/activitySufficiency.js
@@ -1,0 +1,40 @@
+// Data-sufficiency gate for the Explore species hovercard's activity charts.
+//
+// The card shows two all-time charts (daytime 24h activity + activity over
+// time) for the hovered species. We gate them all-or-nothing: unless the
+// species has enough timestamped detections spanning enough distinct dates,
+// we hide the whole activity section and fall back to the plain card. This
+// single gate covers the no-temporal-data, date-only, single-day and
+// 1-3-detection cases uniformly.
+
+// Minimum timestamped detections (summed across the 24 hourly bins) before
+// the daytime clock is meaningful rather than noise.
+export const MIN_ACTIVITY_DETECTIONS = 10
+
+// Minimum distinct dates with detections before the over-time line is more
+// than a single point.
+export const MIN_ACTIVITY_DATES = 2
+
+// Total timestamped detections for `scientificName` across the hourly bins
+// returned by sequences:get-daily-activity (rows of { hour, [sci]: count }).
+export function sumDailyActivity(dailyActivity, scientificName) {
+  if (!Array.isArray(dailyActivity)) return 0
+  return dailyActivity.reduce((sum, row) => sum + (row?.[scientificName] || 0), 0)
+}
+
+// Number of distinct dates with at least one detection for `scientificName`
+// in the per-day series from sequences:get-timeseries (rows of
+// { date, [sci]: count }).
+export function countActivityDates(timeseries, scientificName) {
+  if (!Array.isArray(timeseries)) return 0
+  return timeseries.reduce((n, day) => n + ((day?.[scientificName] || 0) > 0 ? 1 : 0), 0)
+}
+
+// All-or-nothing gate: both charts show only when the species clears both
+// thresholds.
+export function hasEnoughActivityData(dailyActivity, timeseries, scientificName) {
+  return (
+    sumDailyActivity(dailyActivity, scientificName) >= MIN_ACTIVITY_DETECTIONS &&
+    countActivityDates(timeseries, scientificName) >= MIN_ACTIVITY_DATES
+  )
+}

--- a/test/renderer/activitySufficiency.test.js
+++ b/test/renderer/activitySufficiency.test.js
@@ -1,0 +1,88 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  MIN_ACTIVITY_DETECTIONS,
+  MIN_ACTIVITY_DATES,
+  sumDailyActivity,
+  countActivityDates,
+  hasEnoughActivityData
+} from '../../src/renderer/src/utils/activitySufficiency.js'
+
+const SCI = 'Vulpes vulpes'
+
+// Build a 24-row hourly histogram where `total` detections are spread so they
+// sum to exactly `total` for SCI.
+function dailyWith(total) {
+  const rows = Array.from({ length: 24 }, (_, hour) => ({ hour, [SCI]: 0 }))
+  let left = total
+  let h = 0
+  while (left > 0) {
+    rows[h % 24][SCI] += 1
+    left -= 1
+    h += 1
+  }
+  return rows
+}
+
+function seriesWithDates(datesWithDetections) {
+  return datesWithDetections.map((count, i) => ({
+    date: `2024-01-${String(i + 1).padStart(2, '0')}`,
+    [SCI]: count
+  }))
+}
+
+describe('sumDailyActivity', () => {
+  test('sums the hourly bins for the species', () => {
+    assert.equal(sumDailyActivity(dailyWith(37), SCI), 37)
+  })
+
+  test('ignores other species in the row', () => {
+    const rows = [{ hour: 0, [SCI]: 3, 'Canis lupus': 99 }]
+    assert.equal(sumDailyActivity(rows, SCI), 3)
+  })
+
+  test('returns 0 for null / non-array input', () => {
+    assert.equal(sumDailyActivity(null, SCI), 0)
+    assert.equal(sumDailyActivity(undefined, SCI), 0)
+  })
+
+  test('treats a missing species key as 0', () => {
+    assert.equal(sumDailyActivity([{ hour: 0 }], SCI), 0)
+  })
+})
+
+describe('countActivityDates', () => {
+  test('counts only days with a positive detection count', () => {
+    assert.equal(countActivityDates(seriesWithDates([0, 2, 0, 5, 1]), SCI), 3)
+  })
+
+  test('returns 0 for null / empty input', () => {
+    assert.equal(countActivityDates(null, SCI), 0)
+    assert.equal(countActivityDates([], SCI), 0)
+  })
+})
+
+describe('hasEnoughActivityData', () => {
+  test('true when both thresholds are met', () => {
+    const daily = dailyWith(MIN_ACTIVITY_DETECTIONS)
+    const series = seriesWithDates([1, 1])
+    assert.equal(hasEnoughActivityData(daily, series, SCI), true)
+  })
+
+  test('false when too few detections', () => {
+    const daily = dailyWith(MIN_ACTIVITY_DETECTIONS - 1)
+    const series = seriesWithDates([5, 5, 5])
+    assert.equal(hasEnoughActivityData(daily, series, SCI), false)
+  })
+
+  test('false when too few distinct dates (date-only / single-day study)', () => {
+    const daily = dailyWith(100)
+    const series = seriesWithDates(Array(MIN_ACTIVITY_DATES - 1).fill(50))
+    assert.equal(hasEnoughActivityData(daily, series, SCI), false)
+  })
+
+  test('false when there is no temporal data at all', () => {
+    assert.equal(hasEnoughActivityData([], [], SCI), false)
+  })
+})


### PR DESCRIPTION
## Summary

Enriches the species hover card with **all-time activity** for the hovered species and unifies it across every surface that shows species.

- **Daytime (24h):** a polar activity clock (radar over the clock-face circle, same look as the Explore bottom row minus the filter handles) **and** its x-y line twin, side by side.
- **Over time:** the per-day timeline (display-only).
- Content is grouped under **Activity patterns** and **Description** section headings; the "Read on Wikipedia" row is now a compact **W** link beside the Description title (hover pill + tooltip).

The same card now appears in:
- Explore species rail (original)
- Explore selected-species chips
- Media tab species filter list
- Media tab filter pills

## Notes

- **Sufficiency gate** (`activitySufficiency.js`): charts and their loading skeleton only render when a species has enough timestamped detections over enough distinct dates. The gate is pre-checked against the row's detection count, so sparse species never fetch data or flash a skeleton.
- **All-time range** mirrors the Explore bottom row (derived from the timeseries extent). `getSequenceAwareDailyActivitySQL` returns `[]` when its `[start, end]` is missing, so a real range is required.
- Charts are reused **display-only** via new `showTrackStrip` (DailyActivityLine) and `interactive` (TimelineChart) props; defaults preserve the existing bottom-row behaviour.
- Wikipedia tooltip uses a high z-index so it sits above the Media hovercards.

## Test plan

- `npm run lint` — 0 errors
- `npm test` — 1494 passing (incl. 10 new tests for the sufficiency gate)
- Verified live in the running app on all four surfaces: each opens the card with the daytime + over-time charts; sparse species show the plain card with no skeleton; the Wikipedia tooltip renders above the Media hovercards.