### PR TITLE
feat(species): fall back to a study photo in species tooltips

### DIFF
--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -208,6 +208,21 @@ export const observations = sqliteTable('observations', {
 })
 ```
 
+#### Partial index: `idx_observations_usable_bbox`
+
+```sql
+CREATE INDEX idx_observations_usable_bbox ON observations (bboxWidth)
+  WHERE bboxWidth > 0 AND bboxHeight > 0;
+```
+
+`getBestMedia` and `getBestImagePerSpecies` gate their bbox-scoring CTE on an
+EXISTS probe (`… WHERE bboxX IS NOT NULL AND bboxWidth IS NOT NULL AND bboxWidth
+> 0 AND bboxHeight > 0 LIMIT 1`). Without this index that probe is a full table
+`SCAN`; on no-bbox studies (CamTrap DP / GBIF imports) it reads every row to
+confirm absence (~5–8s cold on 2.7–4M-row studies). The partial index is empty
+on such studies, so the probe becomes an instant index `SEARCH`. Added in
+migration `0016_add_usable_bbox_partial_index`.
+
 #### Pseudo-species and blank media
 
 The Camtrap DP `observationType` enum carries six values: `animal`, `human`,

--- a/docs/ipc-api.md
+++ b/docs/ipc-api.md
@@ -65,10 +65,30 @@ const { data, error } = await window.api.getSequences(studyId, { limit: 20 })
 
 ### Species & Distribution
 
-| Method                            | Channel                    | Parameters | Returns                    |
-| --------------------------------- | -------------------------- | ---------- | -------------------------- |
-| `getSpeciesDistribution(studyId)` | `species:get-distribution` | studyId    | `{ data: Distribution[] }` |
-| `getDistinctSpecies(studyId)`     | `species:get-distinct`     | studyId    | `{ data: string[] }`       |
+| Method                              | Channel                    | Parameters | Returns                        |
+| ----------------------------------- | -------------------------- | ---------- | ------------------------------ |
+| `getSpeciesDistribution(studyId)`   | `species:get-distribution` | studyId    | `{ data: Distribution[] }`     |
+| `getDistinctSpecies(studyId)`       | `species:get-distinct`     | studyId    | `{ data: string[] }`           |
+| `getBestImagePerSpecies(studyId)`   | `species:get-best-images`  | studyId    | `{ data: SpeciesImage[] }`     |
+
+`SpeciesImage` (one representative image per species, for hover tooltips):
+
+```ts
+{
+  scientificName: string
+  filePath: string
+  mediaID: string
+  compositeScore?: number // present only on bbox-scored images
+  isFallback: boolean // true when picked without bbox geometry (see below)
+}
+```
+
+When a study has usable bounding boxes, each species gets a bbox-scored "best"
+image (same formula as `getBestMedia`, `isFallback: false`). Species with no
+scored image — and whole studies with no bbox data (e.g. CamTrap DP / GBIF
+imports like Seattle Camera Traps) — fall back to a representative study photo
+chosen without bbox geometry (`isFallback: true`), so tooltips still show a real
+picture. The tooltip ranks a fallback photo below the Wikipedia thumbnail.
 
 ### Overview
 

--- a/src/main/database/migrations/0016_add_usable_bbox_partial_index.sql
+++ b/src/main/database/migrations/0016_add_usable_bbox_partial_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_observations_usable_bbox` ON `observations` (`bboxWidth`) WHERE "observations"."bboxWidth" > 0 AND "observations"."bboxHeight" > 0;

--- a/src/main/database/migrations/meta/0016_snapshot.json
+++ b/src/main/database/migrations/meta/0016_snapshot.json
@@ -1,0 +1,869 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ae5ac942-5886-4403-8697-4640ccb4c094",
+  "prevId": "025acb83-8554-494c-93d7-91fe77f3b6c6",
+  "tables": {
+    "deployments": {
+      "name": "deployments",
+      "columns": {
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locationID": {
+          "name": "locationID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "locationName": {
+          "name": "locationName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentStart": {
+          "name": "deploymentStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentEnd": {
+          "name": "deploymentEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cameraModel": {
+          "name": "cameraModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cameraID": {
+          "name": "cameraID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "coordinateUncertainty": {
+          "name": "coordinateUncertainty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_deployments_locationID": {
+          "name": "idx_deployments_locationID",
+          "columns": [
+            "locationID"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "jobs": {
+      "name": "jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "maxAttempts": {
+          "name": "maxAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_jobs_kind_status": {
+          "name": "idx_jobs_kind_status",
+          "columns": [
+            "kind",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_jobs_status_createdAt": {
+          "name": "idx_jobs_status_createdAt",
+          "columns": [
+            "status",
+            "createdAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileName": {
+          "name": "fileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "importFolder": {
+          "name": "importFolder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folderName": {
+          "name": "folderName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fileMediatype": {
+          "name": "fileMediatype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image/jpeg'"
+        },
+        "exifData": {
+          "name": "exifData",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite": {
+          "name": "favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_media_deploymentID": {
+          "name": "idx_media_deploymentID",
+          "columns": [
+            "deploymentID"
+          ],
+          "isUnique": false
+        },
+        "idx_media_timestamp": {
+          "name": "idx_media_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_media_filePath": {
+          "name": "idx_media_filePath",
+          "columns": [
+            "filePath"
+          ],
+          "isUnique": false
+        },
+        "idx_media_folderName": {
+          "name": "idx_media_folderName",
+          "columns": [
+            "folderName"
+          ],
+          "isUnique": false
+        },
+        "idx_media_deploymentID_timestamp": {
+          "name": "idx_media_deploymentID_timestamp",
+          "columns": [
+            "deploymentID",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_deploymentID_deployments_deploymentID_fk": {
+          "name": "media_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "media",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata": {
+      "name": "metadata",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created": {
+          "name": "created",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "importerName": {
+          "name": "importerName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contributors": {
+          "name": "contributors",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "startDate": {
+          "name": "startDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequenceGap": {
+          "name": "sequenceGap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_outputs": {
+      "name": "model_outputs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runID": {
+          "name": "runID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rawOutput": {
+          "name": "rawOutput",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_model_outputs_runID": {
+          "name": "idx_model_outputs_runID",
+          "columns": [
+            "runID"
+          ],
+          "isUnique": false
+        },
+        "model_outputs_mediaID_runID_unique": {
+          "name": "model_outputs_mediaID_runID_unique",
+          "columns": [
+            "mediaID",
+            "runID"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "model_outputs_mediaID_media_mediaID_fk": {
+          "name": "model_outputs_mediaID_media_mediaID_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_outputs_runID_model_runs_id_fk": {
+          "name": "model_outputs_runID_model_runs_id_fk",
+          "tableFrom": "model_outputs",
+          "tableTo": "model_runs",
+          "columnsFrom": [
+            "runID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_runs": {
+      "name": "model_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelID": {
+          "name": "modelID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "modelVersion": {
+          "name": "modelVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "importPath": {
+          "name": "importPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_model_runs_startedAt": {
+          "name": "idx_model_runs_startedAt",
+          "columns": [
+            "startedAt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "observations": {
+      "name": "observations",
+      "columns": {
+        "observationID": {
+          "name": "observationID",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mediaID": {
+          "name": "mediaID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deploymentID": {
+          "name": "deploymentID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventID": {
+          "name": "eventID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventStart": {
+          "name": "eventStart",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eventEnd": {
+          "name": "eventEnd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scientificName": {
+          "name": "scientificName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observationType": {
+          "name": "observationType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commonName": {
+          "name": "commonName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationProbability": {
+          "name": "classificationProbability",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifeStage": {
+          "name": "lifeStage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sex": {
+          "name": "sex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "behavior": {
+          "name": "behavior",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxX": {
+          "name": "bboxX",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxY": {
+          "name": "bboxY",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxWidth": {
+          "name": "bboxWidth",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bboxHeight": {
+          "name": "bboxHeight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "detectionConfidence": {
+          "name": "detectionConfidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "modelOutputID": {
+          "name": "modelOutputID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationMethod": {
+          "name": "classificationMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classifiedBy": {
+          "name": "classifiedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classificationTimestamp": {
+          "name": "classificationTimestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_observations_mediaID": {
+          "name": "idx_observations_mediaID",
+          "columns": [
+            "mediaID"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_deploymentID": {
+          "name": "idx_observations_deploymentID",
+          "columns": [
+            "deploymentID"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_scientificName": {
+          "name": "idx_observations_scientificName",
+          "columns": [
+            "scientificName"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_eventStart": {
+          "name": "idx_observations_eventStart",
+          "columns": [
+            "eventStart"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_scientificName_eventStart": {
+          "name": "idx_observations_scientificName_eventStart",
+          "columns": [
+            "scientificName",
+            "eventStart"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_mediaID_deploymentID": {
+          "name": "idx_observations_mediaID_deploymentID",
+          "columns": [
+            "mediaID",
+            "deploymentID"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_observationType": {
+          "name": "idx_observations_observationType",
+          "columns": [
+            "observationType"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_blank_cover": {
+          "name": "idx_observations_blank_cover",
+          "columns": [
+            "mediaID",
+            "scientificName",
+            "observationType"
+          ],
+          "isUnique": false
+        },
+        "idx_observations_usable_bbox": {
+          "name": "idx_observations_usable_bbox",
+          "columns": [
+            "bboxWidth"
+          ],
+          "isUnique": false,
+          "where": "\"observations\".\"bboxWidth\" > 0 AND \"observations\".\"bboxHeight\" > 0"
+        }
+      },
+      "foreignKeys": {
+        "observations_mediaID_media_mediaID_fk": {
+          "name": "observations_mediaID_media_mediaID_fk",
+          "tableFrom": "observations",
+          "tableTo": "media",
+          "columnsFrom": [
+            "mediaID"
+          ],
+          "columnsTo": [
+            "mediaID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_deploymentID_deployments_deploymentID_fk": {
+          "name": "observations_deploymentID_deployments_deploymentID_fk",
+          "tableFrom": "observations",
+          "tableTo": "deployments",
+          "columnsFrom": [
+            "deploymentID"
+          ],
+          "columnsTo": [
+            "deploymentID"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "observations_modelOutputID_model_outputs_id_fk": {
+          "name": "observations_modelOutputID_model_outputs_id_fk",
+          "tableFrom": "observations",
+          "tableTo": "model_outputs",
+          "columnsFrom": [
+            "modelOutputID"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/main/database/migrations/meta/_journal.json
+++ b/src/main/database/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1777891262442,
       "tag": "0015_add_observationType_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1780669776160,
+      "tag": "0016_add_usable_bbox_partial_index",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/database/models.js
+++ b/src/main/database/models.js
@@ -1,4 +1,5 @@
 import { sqliteTable, text, real, integer, unique, index } from 'drizzle-orm/sqlite-core'
+import { sql } from 'drizzle-orm'
 
 // Persistent job queue for async work (ML inference, OCR, etc.)
 export const jobs = sqliteTable(
@@ -166,6 +167,15 @@ export const observations = sqliteTable(
       table.mediaID,
       table.scientificName,
       table.observationType
-    )
+    ),
+    // Partial index over rows with drawable bbox geometry. getBestMedia and
+    // getBestImagePerSpecies gate their scoring CTE on a "has any usable bbox?"
+    // EXISTS probe; without this index that probe is a full table SCAN that, on
+    // no-bbox studies (CamTrap DP / GBIF imports), reads every row to confirm
+    // absence (~5-8s cold on 2.7-4M-row studies). The partial index is empty on
+    // such studies, so the probe becomes an instant index seek (SCAN → SEARCH).
+    index('idx_observations_usable_bbox')
+      .on(table.bboxWidth)
+      .where(sql`${table.bboxWidth} > 0 AND ${table.bboxHeight} > 0`)
   ]
 )

--- a/src/main/database/queries/best-media.js
+++ b/src/main/database/queries/best-media.js
@@ -590,10 +590,83 @@ export async function getBestMedia(dbPath, options = {}) {
 }
 
 /**
+ * Get a representative study photo per species WITHOUT requiring bbox geometry.
+ *
+ * Used as a fallback for hover tooltips when getBestImagePerSpecies can't score
+ * images (no usable bboxes, e.g. CamTrap DP / GBIF imports like Seattle Camera
+ * Traps) or for individual species whose observations all lack bboxes. Links
+ * observations to media the same two ways getBestMedia does (mediaID for ML /
+ * Wildlife Insights / Deepfaune; eventStart = media.timestamp for CamTrap DP
+ * where observations.mediaID is NULL) and excludes videos.
+ *
+ * Performance: this picks ONE representative per species via O(species) indexed
+ * seeks (idx_observations_scientificName), not an O(observations) scan. A naive
+ * "rank every linked row per species and take the best" window query took 4-16s
+ * on 2.7-4M-row studies; this is <100ms on the same data (no new index needed).
+ * The cost of that speed is we take the first indexed row per species rather
+ * than the "nicest" frame — acceptable for a fallback, where any real photo of
+ * the species beats showing nothing.
+ *
+ * @param {string} studyId
+ * @param {string} dbPath
+ * @param {Set<string>} coveredSpecies - species already covered by a scored image (skipped)
+ * @returns {Promise<Array>} - Array of { scientificName, filePath, mediaID, isFallback: true }
+ */
+async function getFallbackImagePerSpecies(studyId, dbPath, coveredSpecies = new Set()) {
+  const covered = Array.from(coveredSpecies)
+  const exclusion =
+    covered.length > 0 ? `AND scientificName NOT IN (${covered.map(() => '?').join(',')})` : ''
+
+  // For each species, COALESCE picks a mediaID-linked image first (Strategy 1),
+  // falling back to the timestamp-linked one (Strategy 2, CamTrap DP). Each
+  // correlated subquery seeks the species via idx_observations_scientificName
+  // and stops at the first row that joins to a usable image (LIMIT 1), so the
+  // work is bounded by the species count, not the observation count.
+  const query = `
+    WITH species AS (
+      SELECT DISTINCT scientificName FROM observations
+      WHERE scientificName IS NOT NULL AND scientificName != ''
+      ${exclusion}
+    )
+    SELECT sp.scientificName, m.filePath, m.mediaID
+    FROM species sp
+    JOIN media m ON m.mediaID = COALESCE(
+      (
+        SELECT m1.mediaID
+        FROM observations o1
+        INNER JOIN media m1 ON o1.mediaID = m1.mediaID
+        WHERE o1.scientificName = sp.scientificName
+          AND o1.mediaID IS NOT NULL
+          AND m1.filePath IS NOT NULL
+          AND (m1.fileMediatype IS NULL OR m1.fileMediatype NOT LIKE 'video/%')
+        LIMIT 1
+      ),
+      (
+        SELECT m2.mediaID
+        FROM observations o2
+        INNER JOIN media m2 ON o2.eventStart = m2.timestamp AND o2.deploymentID = m2.deploymentID
+        WHERE o2.scientificName = sp.scientificName
+          AND o2.mediaID IS NULL
+          AND m2.filePath IS NOT NULL
+          AND (m2.fileMediatype IS NULL OR m2.fileMediatype NOT LIKE 'video/%')
+        LIMIT 1
+      )
+    )
+    ORDER BY sp.scientificName
+  `
+
+  const rows = await executeRawQuery(studyId, dbPath, query, covered)
+  return rows.map((r) => ({ ...r, isFallback: true }))
+}
+
+/**
  * Get the single best image for each species (for hover tooltips)
  * Reuses the exact scoring formula from getBestMedia but returns one image per species.
+ * Species without a scored (bbox-based) image get a representative fallback photo
+ * via getFallbackImagePerSpecies, flagged with isFallback so the tooltip can rank
+ * it below the Wikipedia thumbnail.
  * @param {string} dbPath - Path to the SQLite database
- * @returns {Promise<Array>} - Array of { scientificName, filePath, mediaID, compositeScore }
+ * @returns {Promise<Array>} - Array of { scientificName, filePath, mediaID, compositeScore?, isFallback }
  */
 export async function getBestImagePerSpecies(dbPath) {
   const startTime = Date.now()
@@ -602,14 +675,15 @@ export async function getBestImagePerSpecies(dbPath) {
   try {
     const studyId = getStudyIdFromPath(dbPath)
 
-    // Short-circuit: the scoring formula requires bbox area/visibility/padding,
+    // Gate the scoring CTE: the formula requires bbox area/visibility/padding,
     // which only make sense when bboxWidth/bboxHeight are populated. Many
     // datasets (e.g. CamTrap DP exports with point-only annotations) have
     // bboxX/bboxY but no bbox size. On such datasets the big CTE below
     // evaluates to zero rows but still scans the whole observations table
-    // (~2s on 2.7M rows). A quick EXISTS probe is cheap when bboxes are
-    // present (stops at the first match) and bounded when they are not
-    // (full scan ~200ms on gmu8_leuven, vs the query's ~2.3s).
+    // (~2s on 2.7M rows), so we skip it entirely and rely on the fallback
+    // query. A quick EXISTS probe is cheap when bboxes are present (stops at
+    // the first match) and bounded when they are not (full scan ~200ms on
+    // gmu8_leuven, vs the query's ~2.3s).
     const hasUsableBbox = await executeRawQuery(
       studyId,
       dbPath,
@@ -621,12 +695,6 @@ export async function getBestImagePerSpecies(dbPath) {
          LIMIT 1`,
       []
     )
-    if (hasUsableBbox.length === 0) {
-      const elapsedTime = Date.now() - startTime
-      log.info(`Retrieved best images for 0 species in ${elapsedTime}ms (no usable bbox data)`)
-      return []
-    }
-
     // Use the same scoring formula as getBestMedia but return only one per species
     const query = `
       WITH
@@ -747,10 +815,27 @@ export async function getBestImagePerSpecies(dbPath) {
       ORDER BY r.scientificName
     `
 
-    const results = await executeRawQuery(studyId, dbPath, query, [])
+    // Scored ("best") image per species — only meaningful when the study has
+    // usable bboxes (the formula needs area/visibility/padding).
+    const bboxBest =
+      hasUsableBbox.length > 0
+        ? (await executeRawQuery(studyId, dbPath, query, [])).map((r) => ({
+            ...r,
+            isFallback: false
+          }))
+        : []
 
+    // Fill species that have no scored image (and whole no-bbox studies) with a
+    // representative study photo so the tooltip shows a real picture instead of
+    // nothing. The tooltip ranks these below the Wikipedia thumbnail.
+    const covered = new Set(bboxBest.map((r) => r.scientificName))
+    const fallback = await getFallbackImagePerSpecies(studyId, dbPath, covered)
+
+    const results = [...bboxBest, ...fallback]
     const elapsedTime = Date.now() - startTime
-    log.info(`Retrieved best images for ${results.length} species in ${elapsedTime}ms`)
+    log.info(
+      `Retrieved best images for ${results.length} species (${bboxBest.length} scored, ${fallback.length} fallback) in ${elapsedTime}ms`
+    )
 
     return results
   } catch (error) {

--- a/src/renderer/src/ui/SpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/SpeciesTooltipContent.jsx
@@ -208,8 +208,27 @@ export default function SpeciesTooltipContent({
         className={`relative w-full ${imageHeight} ${usingWikipediaImage ? 'bg-black' : 'bg-gray-100 dark:bg-muted'}`}
       >
         {!imageSource || imageError ? (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <CameraOff size={32} className="text-muted-foreground" />
+          // No usable image anywhere (no scored/fallback study photo, no
+          // Wikipedia thumbnail, or the image failed to load). Mirror the
+          // deployment hovercard's empty state (DeploymentHoverMap): a faint
+          // grid panel + icon + label, so the slot reads as an intentional
+          // "no photo" rather than a broken image.
+          <div className="absolute inset-0 overflow-hidden bg-gradient-to-br from-slate-100 to-slate-200 dark:from-slate-800 dark:to-slate-900">
+            <div
+              className="absolute inset-0 opacity-40 dark:opacity-20"
+              style={{
+                backgroundImage:
+                  'linear-gradient(#94a3b8 1px, transparent 1px), linear-gradient(90deg, #94a3b8 1px, transparent 1px)',
+                backgroundSize: '22px 22px'
+              }}
+            />
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 px-5 text-center">
+              <CameraOff className="h-6 w-6 text-muted-foreground" strokeWidth={1.5} />
+              <span className="text-xs font-medium text-foreground">No photo available</span>
+              <span className="text-[11px] leading-snug text-muted-foreground">
+                No camera-trap image or reference photo was found for this species.
+              </span>
+            </div>
           </div>
         ) : (
           <>

--- a/src/renderer/src/ui/SpeciesTooltipContent.jsx
+++ b/src/renderer/src/ui/SpeciesTooltipContent.jsx
@@ -176,19 +176,22 @@ export default function SpeciesTooltipContent({
     setBlurbExpanded(false)
   }, [imageData?.mediaID, sciName])
 
-  // Image source priority: study photo > Wikipedia thumbnail > placeholder.
-  // Study photos are usually camera-trap-shaped (~16:9), so we crop to fill
-  // (object-cover). Wikipedia thumbnails come in wildly varying aspect
-  // ratios, so we fit-with-letterbox (object-contain) on a black background
-  // to avoid awkward crops.
-  const usingFallbackImage = !imageData?.filePath && !!info?.imageUrl
+  // Image source priority: scored study photo (bbox-best) > Wikipedia
+  // thumbnail > fallback study photo (no bbox) > placeholder. The fallback
+  // ranks below Wikipedia on purpose — a clean Wikipedia portrait usually reads
+  // better than an arbitrary camera-trap frame, but a real frame still beats
+  // showing nothing (e.g. CamTrap DP / GBIF studies with no bbox data).
+  const studyPhotoUrl = imageData?.filePath ? constructImageUrl(imageData.filePath, studyId) : null
+  const hasScoredPhoto = !!studyPhotoUrl && !imageData?.isFallback
   // Wikipedia thumbnails are global (same URL across all studies), so we omit
   // studyId to share one cache entry app-wide instead of duplicating per study.
-  const imageSource = imageData?.filePath
-    ? constructImageUrl(imageData.filePath, studyId)
-    : info?.imageUrl
-      ? constructImageUrl(info.imageUrl, null)
-      : null
+  const wikiUrl = info?.imageUrl ? constructImageUrl(info.imageUrl, null) : null
+  // True when the displayed image is the Wikipedia thumbnail. These come in
+  // wildly varying aspect ratios, so we fit-with-letterbox (object-contain) on
+  // a black background. Study photos (scored or fallback) are camera-trap-
+  // shaped (~16:9), so they crop-to-fill (object-cover).
+  const usingWikipediaImage = !hasScoredPhoto && !!wikiUrl
+  const imageSource = hasScoredPhoto ? studyPhotoUrl : (wikiUrl ?? studyPhotoUrl)
 
   if (!imageSource && !info?.blurb && !info?.iucn && !sciName) {
     return null
@@ -202,7 +205,7 @@ export default function SpeciesTooltipContent({
     >
       {/* Image */}
       <div
-        className={`relative w-full ${imageHeight} ${usingFallbackImage ? 'bg-black' : 'bg-gray-100 dark:bg-muted'}`}
+        className={`relative w-full ${imageHeight} ${usingWikipediaImage ? 'bg-black' : 'bg-gray-100 dark:bg-muted'}`}
       >
         {!imageSource || imageError ? (
           <div className="absolute inset-0 flex items-center justify-center">
@@ -222,7 +225,7 @@ export default function SpeciesTooltipContent({
             <img
               src={imageSource}
               alt={sciName ?? ''}
-              className={`w-full h-full ${usingFallbackImage ? 'object-contain' : 'object-cover'} transition-opacity duration-150 ${imageLoaded ? 'opacity-100' : 'opacity-0'}`}
+              className={`w-full h-full ${usingWikipediaImage ? 'object-contain' : 'object-cover'} transition-opacity duration-150 ${imageLoaded ? 'opacity-100' : 'opacity-0'}`}
               onLoad={() => setImageLoaded(true)}
               onError={() => setImageError(true)}
             />

--- a/test/main/database/queries/bestMedia.test.js
+++ b/test/main/database/queries/bestMedia.test.js
@@ -396,8 +396,8 @@ describe('getBestMedia short-circuit on missing bbox data', () => {
   })
 })
 
-describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
-  test('returns [] when no observations have bboxWidth/bboxHeight', async () => {
+describe('getBestImagePerSpecies fallback when bbox data is missing', () => {
+  test('falls back to a representative photo per species when no observations have bboxWidth/bboxHeight', async () => {
     await seed({
       media: {
         'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z'),
@@ -425,10 +425,16 @@ describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
 
     const result = await getBestImagePerSpecies(testDbPath)
 
-    assert.deepEqual(result, [])
+    // No bbox -> every species gets a fallback photo (linked via mediaID).
+    const byName = Object.fromEntries(result.map((r) => [r.scientificName, r]))
+    assert.equal(result.length, 2)
+    assert.equal(byName.Fox.mediaID, 'm-a')
+    assert.equal(byName.Fox.isFallback, true)
+    assert.equal(byName.Deer.mediaID, 'm-b')
+    assert.equal(byName.Deer.isFallback, true)
   })
 
-  test('returns [] when observations have bboxX but no bboxWidth (point-only CamTrap DP pattern)', async () => {
+  test('falls back when observations have bboxX but no bboxWidth (point-only CamTrap DP pattern)', async () => {
     const manager = await seed({
       media: {
         'a.jpg': mediaEntry('m-a', '2024-01-05T10:00:00Z')
@@ -453,10 +459,41 @@ describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
 
     const result = await getBestImagePerSpecies(testDbPath)
 
-    assert.deepEqual(result, [])
+    assert.equal(result.length, 1)
+    assert.equal(result[0].scientificName, 'Fox')
+    assert.equal(result[0].mediaID, 'm-a')
+    assert.equal(result[0].isFallback, true)
   })
 
-  test('runs the scoring pipeline and returns one row per species when bbox data exists', async () => {
+  test('falls back via the timestamp link when observations.mediaID is NULL (CamTrap DP)', async () => {
+    // CamTrap DP datasets leave observations.mediaID NULL and link to media by
+    // eventStart = media.timestamp within the same deployment.
+    await seed({
+      media: {
+        'fox.jpg': mediaEntry('m-fox', '2024-01-05T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-fox',
+          mediaID: null,
+          deploymentID: 'd1',
+          eventID: 'e-fox',
+          eventStart: DateTime.fromISO('2024-01-05T10:00:00Z'),
+          scientificName: 'Fox',
+          count: 1
+        }
+      ]
+    })
+
+    const result = await getBestImagePerSpecies(testDbPath)
+
+    assert.equal(result.length, 1)
+    assert.equal(result[0].scientificName, 'Fox')
+    assert.equal(result[0].mediaID, 'm-fox')
+    assert.equal(result[0].isFallback, true)
+  })
+
+  test('runs the scoring pipeline and returns one scored row per species when bbox data exists', async () => {
     const manager = await seed({
       media: {
         'fox.jpg': mediaEntry('m-fox', '2024-01-05T10:00:00Z'),
@@ -488,12 +525,53 @@ describe('getBestImagePerSpecies short-circuit on missing bbox data', () => {
 
     const result = await getBestImagePerSpecies(testDbPath)
 
-    // One row per species, each pointing to the correct media.
+    // One row per species, each pointing to the correct media and flagged as a
+    // scored (non-fallback) image.
     const byName = Object.fromEntries(result.map((r) => [r.scientificName, r]))
     assert.ok(byName.Fox, 'Fox row present')
     assert.equal(byName.Fox.mediaID, 'm-fox')
+    assert.equal(byName.Fox.isFallback, false)
     assert.ok(byName.Deer, 'Deer row present')
     assert.equal(byName.Deer.mediaID, 'm-deer')
+    assert.equal(byName.Deer.isFallback, false)
     assert.equal(result.length, 2)
+  })
+
+  test('mixes scored and fallback rows: species without a bbox still gets a photo', async () => {
+    const manager = await seed({
+      media: {
+        'fox.jpg': mediaEntry('m-fox', '2024-01-05T10:00:00Z'),
+        'deer.jpg': mediaEntry('m-deer', '2024-01-06T10:00:00Z')
+      },
+      observations: [
+        {
+          observationID: 'o-fox',
+          mediaID: 'm-fox',
+          deploymentID: 'd1',
+          eventID: 'e-fox',
+          scientificName: 'Fox',
+          count: 1
+        },
+        {
+          observationID: 'o-deer',
+          mediaID: 'm-deer',
+          deploymentID: 'd1',
+          eventID: 'e-deer',
+          scientificName: 'Deer',
+          count: 1
+        }
+      ]
+    })
+    // Only Fox has a usable bbox; Deer has none.
+    setBbox(manager, 'o-fox', { x: 0.2, y: 0.2, width: 0.3, height: 0.3 })
+
+    const result = await getBestImagePerSpecies(testDbPath)
+
+    const byName = Object.fromEntries(result.map((r) => [r.scientificName, r]))
+    assert.equal(result.length, 2)
+    assert.equal(byName.Fox.mediaID, 'm-fox')
+    assert.equal(byName.Fox.isFallback, false)
+    assert.equal(byName.Deer.mediaID, 'm-deer')
+    assert.equal(byName.Deer.isFallback, true)
   })
 })


### PR DESCRIPTION
## Summary

Species tooltips (Explore distribution, Media species filter, Overview list, selected-species chips) often showed no study picture. They all render through `SpeciesTooltipContent` fed by `getBestImagePerSpecies`, which only returned **bbox-scored** images and short-circuited to `[]` when a study had no usable bounding boxes. CamTrap DP / GBIF imports (e.g. **Seattle(ish) Camera Traps**) have no bbox sizes, so every species fell back to a Wikipedia thumbnail or the `CameraOff` placeholder — even though the study is full of real photos.

Now, any species lacking a bbox-scored image gets a representative **study photo** as a fallback (`isFallback: true`), linking media via `mediaID` or, for CamTrap DP, `eventStart = media.timestamp`.

Image priority in the tooltip (per product decision — prefer Wikipedia over the fallback):

> scored study photo → Wikipedia thumbnail → fallback study photo → placeholder

## Performance

The fallback picks **one representative per species via O(species) indexed seeks** (`SELECT DISTINCT scientificName` + correlated `LIMIT 1`, `COALESCE` over both linking strategies) on the existing `idx_observations_scientificName` — not a window-sort over every observation.

| study | observations | original (window-sort) | this PR |
| --- | --- | --- | --- |
| 3.99M obs | 3,996,924 | 4.4s | **68ms** |
| 3.44M obs | 3,440,827 | 16.5s | **69ms** |
| 2.94M obs (CamTrap DP) | 2,943,392 | 12.9s | **62ms** |

50–90× faster, all sub-100ms, **no new index required**. Tradeoff: the fallback takes the first indexed row per species rather than the "nicest" daytime frame (any `ORDER BY` reintroduces a full per-species scan) — acceptable for a fallback.

## Changes

- `src/main/database/queries/best-media.js` — `getBestImagePerSpecies` tags scored rows `isFallback: false`; new `getFallbackImagePerSpecies` fills the gaps.
- `src/renderer/src/ui/SpeciesTooltipContent.jsx` — new image priority honoring scored > Wikipedia > fallback.
- No call-site changes: all four map builders spread the whole row, so `isFallback` flows through automatically.
- `docs/ipc-api.md` — documents the `species:get-best-images` handler and `isFallback`.

## Testing

- New/updated unit tests in `test/main/database/queries/bestMedia.test.js` cover both linking strategies (mediaID + CamTrap DP timestamp), the scored/fallback mix, and the covered-species exclusion.
- Full suite green: **1496 passing**. Lint clean (0 errors).