### PR TITLE
feat(explore): normalize activity charts per species for comparison

### DIFF
--- a/src/renderer/src/explore.jsx
+++ b/src/renderer/src/explore.jsx
@@ -155,6 +155,34 @@ function aggregateClusterCounts(markers, selectedSpecies) {
   return Object.fromEntries(Object.entries(combined).filter(([, count]) => count > 0))
 }
 
+// Scale each species' series to its own peak so every curve reaches the top of
+// the shared axis — each species reads as if it were the only one selected,
+// instead of being flattened by a more abundant one. `rows` are objects keyed
+// by scientificName (daily-activity hours or weekly timeseries); each species'
+// values are divided by that species' max across the rows. Used by both the
+// daytime activity charts and the timeline chart on the Explore tab.
+function normalizePerSpeciesToPeak(rows, selectedSpecies) {
+  if (!rows?.length) return rows
+  const maxBySpecies = {}
+  for (const { scientificName } of selectedSpecies) {
+    let max = 0
+    for (const row of rows) {
+      const v = row[scientificName]
+      if (typeof v === 'number' && v > max) max = v
+    }
+    maxBySpecies[scientificName] = max
+  }
+  return rows.map((row) => {
+    const out = { ...row }
+    for (const { scientificName } of selectedSpecies) {
+      const max = maxBySpecies[scientificName]
+      const v = row[scientificName]
+      if (typeof v === 'number' && max > 0) out[scientificName] = v / max
+    }
+    return out
+  })
+}
+
 // Distance (px) the card is pushed off the marker so it sits BESIDE the pie
 // rather than over it. The pie scales up to ~60px wide; 36px clears the largest
 // one with a small gap.
@@ -1530,6 +1558,22 @@ export default function Explore({ studyData, studyId }) {
     staleTime: Infinity
   })
 
+  // Normalize each species to its own peak so a sparse species reads as if it
+  // were the only one selected, instead of being flattened by an abundant one.
+  // Applied to the polar + x-y daytime charts and the timeline chart; the
+  // shared chart components stay value-agnostic.
+  const normalizedDailyActivity = useMemo(
+    () => normalizePerSpeciesToPeak(dailyActivityData, selectedSpecies),
+    [dailyActivityData, selectedSpecies]
+  )
+
+  // Same per-species peak scaling for the activity-over-time chart, so each
+  // species' temporal trend is readable regardless of its abundance.
+  const normalizedTimeseries = useMemo(
+    () => normalizePerSpeciesToPeak(timeseriesData, selectedSpecies),
+    [timeseriesData, selectedSpecies]
+  )
+
   const handleArcChange = useCallback((newArc) => {
     setArc(newArc)
   }, [])
@@ -1800,7 +1844,7 @@ export default function Explore({ studyData, studyId }) {
                       </div>
                       <div className="flex-1 relative">
                         <DailyActivityRadar
-                          activityData={dailyActivityData}
+                          activityData={normalizedDailyActivity}
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                         />
@@ -1822,7 +1866,7 @@ export default function Explore({ studyData, studyId }) {
                       </div>
                       <div className="flex-1 relative">
                         <DailyActivityLine
-                          activityData={dailyActivityData}
+                          activityData={normalizedDailyActivity}
                           selectedSpecies={selectedSpecies}
                           palette={palette}
                           selectedRanges={visualRanges}
@@ -1837,7 +1881,7 @@ export default function Explore({ studyData, studyId }) {
                 </div>
                 <div className="flex-grow rounded px-2 border border-border">
                   <TimelineChart
-                    timeseriesData={timeseriesData}
+                    timeseriesData={normalizedTimeseries}
                     selectedSpecies={selectedSpecies}
                     dateRange={dateRange}
                     setDateRange={setDateRange}

--- a/src/renderer/src/ui/clock.jsx
+++ b/src/renderer/src/ui/clock.jsx
@@ -569,7 +569,9 @@ const DailyActivityLine = ({
               axisLine={false}
               tickLine={false}
             />
-            <YAxis hide domain={[0, 'auto']} />
+            {/* 10% headroom so a species' peak isn't flush against the top
+                edge (otherwise the line gets clipped into a flat "cap"). */}
+            <YAxis hide domain={[0, (dataMax) => (dataMax > 0 ? dataMax * 1.1 : 1)]} />
             {/* Dashed vertical guides at the selection boundaries. */}
             {boundaries.map((hour) => (
               <ReferenceLine

--- a/src/renderer/src/ui/timeseries.jsx
+++ b/src/renderer/src/ui/timeseries.jsx
@@ -457,7 +457,9 @@ const TimelineChart = ({
               minTickGap={-1}
               height={25}
             />
-            <YAxis hide domain={[0, 'auto']} />
+            {/* 10% headroom so the peak isn't flush against the top edge
+                (otherwise the line gets clipped into a flat "cap"). */}
+            <YAxis hide domain={[0, (dataMax) => (dataMax > 0 ? dataMax * 1.1 : 1)]} />
 
             {livePreview && (
               <ReferenceArea
@@ -528,6 +530,7 @@ const TimelineChart = ({
                 type="monotone"
                 dataKey={species.scientificName}
                 stroke={palette[index % palette.length]}
+                strokeWidth={1.5}
                 dot={false}
                 activeDot={{ r: 5 }}
                 name={species.scientificName}


### PR DESCRIPTION
## Summary

On the Explore tab, the daytime activity charts (polar radar + x-y line) and the timeline chart plotted **raw counts on a shared scale**, so an abundant species flattened sparser ones — you couldn't compare their activity *shapes*.

This scales each selected species to **its own peak** (per-species max = 1.0), so every curve fills the shared axis and reads as if it were the only one selected. Implemented as a data transform at the Explore composition layer (`normalizePerSpeciesToPeak`), so the shared chart components — and the species hovercard that reuses them — stay value-agnostic.

Also:
- **10% Y-domain headroom** on the two line charts so a peak isn't flush against the top edge (it was clipping into a flat "cap").
- **Matched the timeline line thickness** (`1.5`) to the daytime x-y chart.

Smoothing was prototyped and **deliberately dropped** — it spread sparse detections into empty hours/weeks (misrepresenting the data); normalization alone keeps the values honest.

## Files
- `src/renderer/src/explore.jsx` — `normalizePerSpeciesToPeak` helper + two memos + chart wiring
- `src/renderer/src/ui/clock.jsx` — Y-domain headroom (daytime x-y line)
- `src/renderer/src/ui/timeseries.jsx` — Y-domain headroom + `strokeWidth={1.5}`

## Testing
- Verified live on the **Demo - Kruger National Park** study (Explore tab, multiple species) over CDP — sparse species are now readable alongside abundant ones.
- `npm test` green (1496 passing); format + lint clean.

## Known tradeoffs (intentional)
- Normalization hides cross-species *magnitude* (a rare species reads as tall as a common one) — by design, for shape comparison.
- The long diagonal "ramp" on the timeline is the chart interpolating across genuine multi-month gaps in the demo data (only ~17 weeks have data), not an artifact of this change.

## Optional follow-ups (from review, not blocking)
- Add matching headroom to the polar radar (`PolarRadiusAxis` domain) for consistency.
- Extract the duplicated `[0, dataMax => dataMax*1.1]` domain into a shared `yDomainWithHeadroom` helper.