### PR TITLE
fix(website): use Biowatch logo as favicon

### DIFF
--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -7,6 +7,7 @@ repo_name: earthtoolsmaker/biowatch
 theme:
   name: material
   logo: assets/images/biowatch-logo.png
+  favicon: assets/images/biowatch-logo.png
   palette:
     - scheme: default
       primary: blue


### PR DESCRIPTION
## Summary
- The manual website was using the default MkDocs Material favicon; set `theme.favicon` in `website/mkdocs.yml` to the existing Biowatch logo (256×256 PNG, already used as the site logo)

## Test plan
- [x] `mkdocs build` succeeds and pages emit `<link rel="icon" href="assets/images/biowatch-logo.png">`
- [x] Verified locally with `mkdocs serve` — browser tab shows the Biowatch logo